### PR TITLE
fix: move built-in slice methods to autoload from prelude

### DIFF
--- a/library/src/autoload/slice.kd
+++ b/library/src/autoload/slice.kd
@@ -1,0 +1,9 @@
+impl<T> [T] {
+    pub fn as_ptr(self): *T {
+        return self.0
+    }
+
+    pub fn len(self): u64 {
+        return self.1
+    }
+}

--- a/library/src/prelude.kd
+++ b/library/src/prelude.kd
@@ -12,13 +12,3 @@ pub use std.any.Any
 pub use std.option.Option
 pub use std.string.String
 pub use std.runtime.__prepare_command_line_arguments
-
-impl<T> [T] {
-    pub fn as_ptr(self): *T {
-        return self.0
-    }
-
-    pub fn len(self): u64 {
-        return self.1
-    }
-}


### PR DESCRIPTION
preludeにスライス型の組み込みメソッドを定義していると標準ライブラリのビルド時にスライス型メソッドが使用できない問題が発生していた。（--no-preludeを付与して標準ライブラリはビルドされるため）