### PR TITLE
feat: add byte literal support (b'a' syntax)

### DIFF
--- a/compiler/ast/src/expr.rs
+++ b/compiler/ast/src/expr.rs
@@ -28,6 +28,12 @@ pub struct CharLiteral {
 }
 
 #[derive(Debug)]
+pub struct ByteLiteral {
+    pub byte: u8,
+    pub span: Span,
+}
+
+#[derive(Debug)]
 pub struct StructLiteral {
     pub struct_ty: UserDefinedType,
     pub values: Vec<(Ident, Expr)>,
@@ -265,6 +271,7 @@ pub enum ExprKind {
     Int(Int),
     StringLiteral(StringLiteral),
     ByteStringLiteral(ByteStringLiteral),
+    ByteLiteral(ByteLiteral),
     CharLiteral(CharLiteral),
     Binary(Binary),
     Ident(Ident),

--- a/compiler/codegen/src/expr.rs
+++ b/compiler/codegen/src/expr.rs
@@ -17,9 +17,9 @@ use kaede_common::rust_function_prefix;
 use kaede_ir::{
     expr::{
         ArrayLiteral, ArrayRepeat, Binary, BinaryKind, BuiltinFnCall, BuiltinFnCallKind,
-        ByteStringLiteral, Cast, CharLiteral, Closure, Else, EnumUnpack, EnumVariant, Expr,
-        ExprKind, FieldAccess, FnCall, FnPointer, If, Indexing, Int, LogicalNot, Loop, Slicing,
-        StringLiteral, StructLiteral, TupleIndexing, TupleLiteral, Variable,
+        ByteLiteral, ByteStringLiteral, Cast, CharLiteral, Closure, Else, EnumUnpack, EnumVariant,
+        Expr, ExprKind, FieldAccess, FnCall, FnPointer, If, Indexing, Int, LogicalNot, Loop,
+        Slicing, StringLiteral, StructLiteral, TupleIndexing, TupleLiteral, Variable,
     },
     stmt::Block,
     ty::{
@@ -134,6 +134,7 @@ impl<'ctx> CodeGenerator<'ctx> {
 
             ExprKind::StringLiteral(node) => self.build_string_literal(node)?,
             ExprKind::ByteStringLiteral(node) => self.build_byte_string_literal(node)?,
+            ExprKind::ByteLiteral(node) => self.build_byte_literal(node)?,
 
             ExprKind::CharLiteral(node) => self.build_char_literal(node)?,
 
@@ -677,6 +678,11 @@ impl<'ctx> CodeGenerator<'ctx> {
     fn build_char_literal(&mut self, node: &CharLiteral) -> anyhow::Result<Value<'ctx>> {
         let char_val = self.context().i8_type().const_int(node.ch as u64, false);
         Ok(Some(char_val.into()))
+    }
+
+    fn build_byte_literal(&mut self, node: &ByteLiteral) -> anyhow::Result<Value<'ctx>> {
+        let byte_val = self.context().i8_type().const_int(node.byte as u64, false);
+        Ok(Some(byte_val.into()))
     }
 
     fn build_logical_not(&mut self, node: &LogicalNot) -> anyhow::Result<Value<'ctx>> {

--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -426,6 +426,43 @@ fn byte_string_literal_with_escapes() -> anyhow::Result<()> {
 }
 
 #[test]
+fn byte_literal() -> anyhow::Result<()> {
+    let program = r#"fn main(): i32 {
+        let b = b'A'
+        return b as i32
+    }"#;
+
+    assert_eq!(exec(program)?, 65); // 'A' is 65
+    Ok(())
+}
+
+#[test]
+fn byte_literal_escape_sequences() -> anyhow::Result<()> {
+    let program = r#"fn main(): i32 {
+        let newline = b'\n'
+        let tab = b'\t'
+        let backslash = b'\\'
+        let quote = b'\''
+        return (newline as i32) + (tab as i32) + (backslash as i32) + (quote as i32)
+    }"#;
+
+    assert_eq!(exec(program)?, 10 + 9 + 92 + 39); // '\n' (10) + '\t' (9) + '\\' (92) + '\'' (39)
+    Ok(())
+}
+
+#[test]
+fn byte_literal_arithmetic() -> anyhow::Result<()> {
+    let program = r#"fn main(): i32 {
+        let a = b'a'
+        let z = b'z'
+        return (z - a) as i32
+    }"#;
+
+    assert_eq!(exec(program)?, 25); // 'z' (122) - 'a' (97) = 25
+    Ok(())
+}
+
+#[test]
 fn string_type() -> anyhow::Result<()> {
     let program = r#"fn f(s: str): str {
         return s

--- a/compiler/ir/src/expr.rs
+++ b/compiler/ir/src/expr.rs
@@ -28,6 +28,12 @@ pub struct CharLiteral {
 }
 
 #[derive(Debug, Clone)]
+pub struct ByteLiteral {
+    pub byte: u8,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
 pub struct StructLiteral {
     pub struct_info: Rc<Struct>,
     pub values: Vec<(Symbol, Expr)>,
@@ -264,6 +270,7 @@ pub enum ExprKind {
     Int(Int),
     StringLiteral(StringLiteral),
     ByteStringLiteral(ByteStringLiteral),
+    ByteLiteral(ByteLiteral),
     CharLiteral(CharLiteral),
     StructLiteral(StructLiteral),
     ArrayLiteral(ArrayLiteral),

--- a/compiler/lex/src/semi.rs
+++ b/compiler/lex/src/semi.rs
@@ -49,6 +49,7 @@ fn is_semi_insertable(token: &TokenKind) -> bool {
             | Self_
             | StringLiteral(_)
             | ByteStringLiteral(_)
+            | ByteLiteral(_)
             | CharLiteral(_)
             | CloseParen
             | CloseBrace

--- a/compiler/lex/src/tests.rs
+++ b/compiler/lex/src/tests.rs
@@ -165,3 +165,19 @@ fn byte_string_literal_escape_sequences() {
         ],
     );
 }
+
+#[test]
+fn byte_literal() {
+    lex_test(r#"b'a'"#, vec![ByteLiteral(b'a'), Semi, Eoi]);
+    lex_test(r#"b'Z'"#, vec![ByteLiteral(b'Z'), Semi, Eoi]);
+    lex_test(r#"b'0'"#, vec![ByteLiteral(b'0'), Semi, Eoi]);
+}
+
+#[test]
+fn byte_literal_escape_sequences() {
+    lex_test(r#"b'\n'"#, vec![ByteLiteral(b'\n'), Semi, Eoi]);
+    lex_test(r#"b'\r'"#, vec![ByteLiteral(b'\r'), Semi, Eoi]);
+    lex_test(r#"b'\t'"#, vec![ByteLiteral(b'\t'), Semi, Eoi]);
+    lex_test(r#"b'\\'"#, vec![ByteLiteral(b'\\'), Semi, Eoi]);
+    lex_test(r#"b'\''"#, vec![ByteLiteral(b'\''), Semi, Eoi]);
+}

--- a/compiler/lex/src/token.rs
+++ b/compiler/lex/src/token.rs
@@ -12,6 +12,7 @@ pub enum TokenKind {
     Ident(String),
     StringLiteral(String),
     ByteStringLiteral(Vec<u8>),
+    ByteLiteral(u8),
     CharLiteral(char),
 
     // Punctuators
@@ -154,6 +155,7 @@ impl std::fmt::Display for TokenKind {
                 Ident(_) => "identifier",
                 StringLiteral(_) => "string literal",
                 ByteStringLiteral(_) => "byte string literal",
+                ByteLiteral(_) => "byte literal",
                 CharLiteral(_) => "character literal",
 
                 OpenParen => "'('",

--- a/compiler/parse/src/expr.rs
+++ b/compiler/parse/src/expr.rs
@@ -1,9 +1,9 @@
 use std::{collections::VecDeque, rc::Rc};
 
 use kaede_ast::expr::{
-    Args, ArrayLiteral, ArrayRepeat, Binary, BinaryKind, Break, ByteStringLiteral, CharLiteral,
-    Closure, Else, Expr, ExprKind, FnCall, If, Indexing, Int, IntKind, LogicalNot, Loop, Match,
-    MatchArm, Return, Slicing, StringLiteral, StructLiteral, TupleLiteral,
+    Args, ArrayLiteral, ArrayRepeat, Binary, BinaryKind, Break, ByteLiteral, ByteStringLiteral,
+    CharLiteral, Closure, Else, Expr, ExprKind, FnCall, If, Indexing, Int, IntKind, LogicalNot,
+    Loop, Match, MatchArm, Return, Slicing, StringLiteral, StructLiteral, TupleLiteral,
 };
 use kaede_ast_type::{GenericArgs, Ty, TyKind};
 use kaede_lex::token::TokenKind;
@@ -406,6 +406,10 @@ impl Parser {
             return Ok(lit);
         }
 
+        if let Some(lit) = self.byte_literal() {
+            return Ok(lit);
+        }
+
         if let Some(lit) = self.char_literal() {
             return Ok(lit);
         }
@@ -797,6 +801,24 @@ impl Parser {
                     span: token.span,
                     kind: ExprKind::CharLiteral(CharLiteral {
                         ch,
+                        span: token.span,
+                    }),
+                });
+            }
+        }
+
+        None
+    }
+
+    fn byte_literal(&mut self) -> Option<Expr> {
+        if matches!(self.first().kind, TokenKind::ByteLiteral(_)) {
+            let token = self.bump().unwrap();
+
+            if let TokenKind::ByteLiteral(byte) = token.kind {
+                return Some(Expr {
+                    span: token.span,
+                    kind: ExprKind::ByteLiteral(ByteLiteral {
+                        byte,
                         span: token.span,
                     }),
                 });

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -44,6 +44,7 @@ impl SemanticAnalyzer {
             ExprKind::Block(node) => self.analyze_block_expr(node),
             ExprKind::StringLiteral(node) => self.analyze_string_literal(node),
             ExprKind::ByteStringLiteral(node) => self.analyze_byte_string_literal(node),
+            ExprKind::ByteLiteral(node) => self.analyze_byte_literal(node),
             ExprKind::CharLiteral(node) => self.analyze_char_literal(node),
             ExprKind::Binary(node) => self.analyze_binary(node),
             ExprKind::Ident(node) => self.analyze_ident(node),
@@ -1738,6 +1739,23 @@ impl SemanticAnalyzer {
             }),
             ty: Rc::new(ir_type::make_fundamental_type(
                 ir_type::FundamentalTypeKind::Char,
+                ir_type::Mutability::Not,
+            )),
+            span: node.span,
+        })
+    }
+
+    fn analyze_byte_literal(
+        &self,
+        node: &ast::expr::ByteLiteral,
+    ) -> anyhow::Result<ir::expr::Expr> {
+        Ok(ir::expr::Expr {
+            kind: ir::expr::ExprKind::ByteLiteral(ir::expr::ByteLiteral {
+                byte: node.byte,
+                span: node.span,
+            }),
+            ty: Rc::new(ir_type::make_fundamental_type(
+                ir_type::FundamentalTypeKind::U8,
                 ir_type::Mutability::Not,
             )),
             span: node.span,

--- a/compiler/type_infer/src/lib.rs
+++ b/compiler/type_infer/src/lib.rs
@@ -93,6 +93,10 @@ impl TypeInferrer {
                     mutability: Mutability::Not,
                 }))
             }
+            ByteLiteral(_) => Ok(Rc::new(make_fundamental_type(
+                FundamentalTypeKind::U8,
+                Mutability::Not,
+            ))),
             CharLiteral(_) => Ok(Rc::new(make_fundamental_type(
                 FundamentalTypeKind::Char,
                 Mutability::Not,
@@ -1195,8 +1199,8 @@ impl TypeInferrer {
             }
 
             // Other literals have no child expressions
-            StringLiteral(_) | ByteStringLiteral(_) | CharLiteral(_) | BooleanLiteral(_)
-            | Break | FnPointer(_) => {}
+            StringLiteral(_) | ByteStringLiteral(_) | ByteLiteral(_) | CharLiteral(_)
+            | BooleanLiteral(_) | Break | FnPointer(_) => {}
 
             // Structured literals with child expressions
             ArrayLiteral(arr_lit) => {


### PR DESCRIPTION
Implement Rust-style byte literals that represent single u8 values. This complements the existing byte string literals (b"hello").

Changes:
- Lexer: Add TokenKind::ByteLiteral and b'x' pattern recognition with escape sequence support (\n, \r, \t, \\, \')
- Lexer: Refactor escape sequence parsing into shared helper functions (parse_char_escape and parse_byte_escape)
- AST/Parse: Add ByteLiteral struct and parsing logic