### PR TITLE
build(runtime): enable position-independent code for runtime library

### DIFF
--- a/library/runtime/CMakeLists.txt
+++ b/library/runtime/CMakeLists.txt
@@ -34,6 +34,8 @@ find_package(Threads REQUIRED)
 target_link_libraries(kaede_runtime PRIVATE Threads::Threads)
 target_compile_definitions(kaede_runtime PRIVATE GC_THREADS GC_ALLOW_REGISTER_THREADS)
 
+set_target_properties(kaede_runtime PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 # Set compiler flags for x86_64 assembly
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(kaede_runtime PRIVATE -Wall -Wextra)


### PR DESCRIPTION
Set POSITION_INDEPENDENT_CODE ON on kaede_runtime so the library can be built/used as a shared library or with dynamic loading.