### PR TITLE
fix(parse): fix checkpoint leak in ty() causing while condition parse…

### DIFF
--- a/compiler/parse/src/lib.rs
+++ b/compiler/parse/src/lib.rs
@@ -136,6 +136,14 @@ impl Parser {
         }
     }
 
+    // Discard the most recent checkpoint without backtracking.
+    // Call this when a speculative parse succeeded.
+    fn discard_checkpoint(&mut self) {
+        self.checkpoint_stack
+            .pop()
+            .expect("Attempted to discard checkpoint without a checkpoint");
+    }
+
     /// Check without consuming tokens
     fn check(&mut self, tok: &TokenKind) -> bool {
         &self.first().kind == tok

--- a/compiler/parse/src/ty.rs
+++ b/compiler/parse/src/ty.rs
@@ -87,6 +87,9 @@ impl Parser {
                 // Last segment was the type name, everything before is the access chain
                 let access_chain = segments;
 
+                // Discard checkpoint - we successfully parsed an access chain
+                self.discard_checkpoint();
+
                 Ok(Ty {
                     span: base_ty.span,
                     kind: TyKind::External(base_ty, access_chain).into(),

--- a/library/src/std/ffi/args.kd
+++ b/library/src/std/ffi/args.kd
@@ -7,10 +7,7 @@ pub extern "C" fn strlen(s: *char): u64
 pub fn __prepare_command_line_arguments(argc: i32, argv: **char): Vector<str> {
     let mut i = 0
     let mut args = Vector<str>::new()
-    loop {
-        if i >= argc {
-            break
-        }
+    while i < argc {
         args.push(__str(argv[i], strlen(argv[i])))
         i += 1
     }

--- a/library/src/std/string.kd
+++ b/library/src/std/string.kd
@@ -17,13 +17,8 @@ impl String {
         let mut chars = Vector<char>::new()
 
         let mut i = 0
-        loop {
-            if i == s.len() {
-                break
-            }
-
+        while i < s.len() {
             chars.push(s[i])
-
             i += 1
         }
 
@@ -34,13 +29,8 @@ impl String {
         let mut chars = Vector<char>::new()
 
         let mut i = 0
-        loop {
-            if i == bytes.len() {
-                break
-            }
-
+        while i < bytes.len() {
             chars.push(bytes[i] as char)
-
             i += 1
         }
 

--- a/library/src/std/sys.kd
+++ b/library/src/std/sys.kd
@@ -82,11 +82,7 @@ fn write_all(fd: Fd, buf: [u8]): u64 {
     let mut off = 0
     let total = buf.len()
 
-    loop {
-        if off >= total {
-            break
-        }
-
+    while off < total {
         let ptr = __ptr_add(buf.as_ptr(), off)
         let rem = total - off
 
@@ -142,19 +138,11 @@ pub fn find_subslice(haystack: [u8], needle: [u8]): i32 {
 
     let mut i = 0
 
-    loop {
-        if i > hlen - nlen {
-            return -1
-        }
-
+    while i <= hlen - nlen {
         let mut j = 0
         let mut ok = true
 
-        loop {
-            if j >= nlen {
-                break
-            }
-
+        while j < nlen {
             if haystack[i + j] != needle[j] {
                 ok = false
                 break
@@ -208,11 +196,7 @@ fn split3_spaces(line: [u8]): (String, String, String) {
 
 fn find_byte(buf: [u8], b: u8): i32 {
     let mut i = 0
-    loop {
-        if i == buf.len() {
-            break
-        }
-
+    while i < buf.len() {
         if buf[i] == b {
             return i as i32
         }


### PR DESCRIPTION
… failure

The parser failed to parse `while i < s.len() { ... }` because `<` was misinterpreted as the start of generic arguments.

Root cause: ty() did not discard its checkpoint when successfully parsing an access chain (e.g., `s.len`). This caused generic_args() to backtrack to the wrong position when it determined `<` was not a generic argument.

Changes:
- Add discard_checkpoint() method to properly clean up checkpoints on success
- Call discard_checkpoint() in ty() when access chain parsing succeeds
- Simplify standard library code using the new while statement:
  - std/string.kd: String::from(), String::from_bytes()
  - std/ffi/args.kd: __prepare_command_line_arguments()
  - std/sys.kd: write_all(), find_subslice(), find_byte()