### PR TITLE
feat: make closure return type optional

### DIFF
--- a/compiler/ast/src/top.rs
+++ b/compiler/ast/src/top.rs
@@ -108,7 +108,7 @@ pub struct FnDecl {
     pub name: Ident,
     pub generic_params: Option<GenericParams>,
     pub params: Params,
-    pub return_ty: Option<Rc<Ty>>,
+    pub return_ty: Rc<Ty>,
     pub span: Span,
     // For generic functions
     pub link_once: bool,

--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -122,7 +122,7 @@ pub struct CodeGenerator<'ctx> {
     spawn_counter: usize,
     literal_counter: usize,
 
-    fn_return_ty_stack: Vec<Option<Rc<Ty>>>,
+    fn_return_ty_stack: Vec<Rc<Ty>>,
 }
 
 impl<'ctx> CodeGenerator<'ctx> {
@@ -199,14 +199,13 @@ impl<'ctx> CodeGenerator<'ctx> {
 
     fn gc_init(&mut self) -> anyhow::Result<()> {
         // Declare GC_malloc in boehm-gc
-        let return_ty = Ty {
+        let return_ty = Rc::new(Ty {
             kind: TyKind::Reference(ReferenceType {
                 refee_ty: make_fundamental_type(FundamentalTypeKind::I8, Mutability::Mut).into(),
             })
             .into(),
             mutability: Mutability::Mut,
-        }
-        .into();
+        });
 
         let params = vec![Param {
             name: Symbol::from("size".to_owned()),
@@ -220,7 +219,7 @@ impl<'ctx> CodeGenerator<'ctx> {
                 link_once: false,
                 name: QualifiedSymbol::new(ModulePath::new(vec![]), self.cgcx.malloc_symbol),
                 is_c_variadic: false,
-                return_ty: Some(return_ty),
+                return_ty,
                 params,
             },
         )?;

--- a/compiler/ir/src/top.rs
+++ b/compiler/ir/src/top.rs
@@ -32,7 +32,7 @@ pub struct FnDecl {
     pub name: QualifiedSymbol,
     pub params: Vec<Param>,
     pub is_c_variadic: bool,
-    pub return_ty: Option<Rc<Ty>>,
+    pub return_ty: Rc<Ty>,
 }
 
 #[derive(Debug)]

--- a/compiler/parse/src/top.rs
+++ b/compiler/parse/src/top.rs
@@ -5,7 +5,7 @@ use kaede_ast::top::{
     Path, PathSegment, Struct, StructField, TopLevel, TopLevelKind, TypeAlias, Use, VariadicKind,
     Visibility,
 };
-use kaede_ast_type::Mutability;
+use kaede_ast_type::{Mutability, Ty};
 use kaede_common::LangLinkage;
 use kaede_lex::token::{Token, TokenKind};
 use kaede_span::Location;
@@ -308,9 +308,10 @@ impl Parser {
         };
 
         let (return_ty, finish) = if let Ok(span) = self.consume(&TokenKind::Colon) {
-            (Some(Rc::new(self.ty()?)), span.finish)
+            (Rc::new(self.ty()?), span.finish)
         } else {
-            (None, params.span.finish)
+            let unit_span = self.new_span(params.span.finish, params.span.finish);
+            (Rc::new(Ty::new_unit(unit_span)), params.span.finish)
         };
 
         // Pop generic param names.

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -85,18 +85,11 @@ impl SemanticAnalyzer {
             }
         };
 
-        let returns_unit = match callee.return_ty.as_ref() {
-            None => true,
-            Some(ty) => matches!(ty.kind.as_ref(), ir_type::TyKind::Unit),
-        };
+        let returns_unit = matches!(callee.return_ty.kind.as_ref(), ir_type::TyKind::Unit);
 
         if !returns_unit {
             return Err(SemanticError::SpawnReturnTypeNotUnit {
-                ty: callee
-                    .return_ty
-                    .as_ref()
-                    .map(|ty| ty.kind.to_string())
-                    .unwrap_or_else(|| "()".to_string()),
+                ty: callee.return_ty.kind.to_string(),
                 span: node.span,
             }
             .into());
@@ -1061,10 +1054,7 @@ impl SemanticAnalyzer {
                 args: ir::expr::Args(args, node.span),
                 span: node.span,
             }),
-            ty: match callee_decl.return_ty.as_ref() {
-                Some(ty) => ty.clone(),
-                None => Rc::new(ir_type::Ty::new_unit()),
-            },
+            ty: callee_decl.return_ty.clone(),
             span: node.span,
         })
     }
@@ -1093,10 +1083,7 @@ impl SemanticAnalyzer {
         Rc::new(ir_type::Ty {
             kind: ir_type::TyKind::Closure(ir_type::ClosureType {
                 param_tys: decl.params.iter().map(|p| p.ty.clone()).collect(),
-                ret_ty: decl
-                    .return_ty
-                    .clone()
-                    .unwrap_or_else(|| Rc::new(ir_type::Ty::new_unit())),
+                ret_ty: decl.return_ty.clone(),
                 captures: Vec::new(),
             })
             .into(),
@@ -1125,7 +1112,7 @@ impl SemanticAnalyzer {
             name: QualifiedSymbol::new(self.current_module_path().clone(), name),
             params,
             is_c_variadic: false,
-            return_ty: Some(closure_ty.ret_ty.clone()),
+            return_ty: closure_ty.ret_ty.clone(),
         }
         .into()
     }
@@ -1277,10 +1264,7 @@ impl SemanticAnalyzer {
                 args: ir::expr::Args(args, node.span),
                 span: node.span,
             }),
-            ty: callee_decl
-                .return_ty
-                .clone()
-                .unwrap_or_else(|| Rc::new(ir_type::Ty::new_unit())),
+            ty: callee_decl.return_ty.clone(),
             span: node.span,
         };
 
@@ -1347,10 +1331,7 @@ impl SemanticAnalyzer {
                         args: ir::expr::Args(args, node.span),
                         span,
                     }),
-                    ty: match callee_decl.return_ty.as_ref() {
-                        Some(ty) => ty.clone(),
-                        None => Rc::new(ir_type::Ty::new_unit()),
-                    },
+                    ty: callee_decl.return_ty.clone(),
                     span,
                 })
             }
@@ -2151,10 +2132,7 @@ impl SemanticAnalyzer {
                 args: ir::expr::Args(args, call_node.span),
                 span: call_node.span,
             }),
-            ty: match method_decl.return_ty.as_ref() {
-                Some(ty) => ty.clone(),
-                None => Rc::new(ir_type::Ty::new_unit()),
-            },
+            ty: method_decl.return_ty.clone(),
             span: call_node.span,
         })
     }
@@ -2667,10 +2645,7 @@ impl SemanticAnalyzer {
         // For simplicity, we treat the method call as a function call.
         Ok(ir::expr::Expr {
             kind: ir::expr::ExprKind::FnCall(call_node),
-            ty: callee
-                .return_ty
-                .clone()
-                .unwrap_or_else(|| Rc::new(ir_type::Ty::new_unit())),
+            ty: callee.return_ty.clone(),
             span,
         })
     }

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -539,10 +539,7 @@ impl SemanticAnalyzer {
                 args: ir::expr::Args(vec![argc_expr, argv_expr], Span::dummy()),
                 span: Span::dummy(),
             }),
-            ty: prepare_command_line_arguments_decl
-                .return_ty
-                .clone()
-                .unwrap(),
+            ty: prepare_command_line_arguments_decl.return_ty.clone(),
             span: Span::dummy(),
         };
 
@@ -584,10 +581,10 @@ impl SemanticAnalyzer {
             name: QualifiedSymbol::new(ModulePath::new(vec![]), "main".to_owned().into()),
             params,
             is_c_variadic: false,
-            return_ty: Some(Rc::new(ir::ty::make_fundamental_type(
+            return_ty: Rc::new(ir::ty::make_fundamental_type(
                 ir::ty::FundamentalTypeKind::I32,
                 ir::ty::Mutability::Not,
-            ))),
+            )),
         };
 
         let runtime_init_decl = ir::top::FnDecl {
@@ -599,7 +596,7 @@ impl SemanticAnalyzer {
             ),
             params: vec![],
             is_c_variadic: false,
-            return_ty: None,
+            return_ty: Rc::new(ir::ty::Ty::new_unit()),
         };
 
         let runtime_run_decl = ir::top::FnDecl {
@@ -611,10 +608,10 @@ impl SemanticAnalyzer {
             ),
             params: vec![],
             is_c_variadic: false,
-            return_ty: Some(Rc::new(ir::ty::make_fundamental_type(
+            return_ty: Rc::new(ir::ty::make_fundamental_type(
                 ir::ty::FundamentalTypeKind::I32,
                 ir::ty::Mutability::Not,
-            ))),
+            )),
         };
 
         let runtime_shutdown_decl = ir::top::FnDecl {
@@ -626,7 +623,7 @@ impl SemanticAnalyzer {
             ),
             params: vec![],
             is_c_variadic: false,
-            return_ty: None,
+            return_ty: Rc::new(ir::ty::Ty::new_unit()),
         };
 
         top_level_irs.push(ir::top::TopLevel::Fn(Rc::new(ir::top::Fn {
@@ -717,14 +714,14 @@ impl SemanticAnalyzer {
                 args: ir::expr::Args(vec![], Span::dummy()),
                 span: Span::dummy(),
             }),
-            ty: runtime_run_decl.return_ty.clone().unwrap(),
+            ty: runtime_run_decl.return_ty.clone(),
             span: Span::dummy(),
         };
 
         body.push(ir::stmt::Stmt::Let(ir::stmt::Let {
             name: exit_code_symbol,
             init: Some(exit_code_expr),
-            ty: runtime_run_decl.return_ty.clone().unwrap(),
+            ty: runtime_run_decl.return_ty.clone(),
             span: Span::dummy(),
         }));
 
@@ -734,7 +731,7 @@ impl SemanticAnalyzer {
                 args: ir::expr::Args(vec![], Span::dummy()),
                 span: Span::dummy(),
             }),
-            ty: Rc::new(ir::ty::Ty::new_unit()),
+            ty: runtime_shutdown_decl.return_ty.clone(),
             span: Span::dummy(),
         };
         body.push(ir::stmt::Stmt::Expr(Rc::new(runtime_shutdown_expr)));
@@ -742,10 +739,10 @@ impl SemanticAnalyzer {
         let exit_code_var = ir::expr::Expr {
             kind: ir::expr::ExprKind::Variable(ir::expr::Variable {
                 name: exit_code_symbol,
-                ty: runtime_run_decl.return_ty.clone().unwrap(),
+                ty: runtime_run_decl.return_ty.clone(),
                 span: Span::dummy(),
             }),
-            ty: runtime_run_decl.return_ty.clone().unwrap(),
+            ty: runtime_run_decl.return_ty.clone(),
             span: Span::dummy(),
         };
 
@@ -791,12 +788,7 @@ impl SemanticAnalyzer {
         let symbol_table_view = ScopedSymbolTable::merge_for_inference(module.get_symbol_tables());
 
         // Create a type inferrer with the merged symbol table
-        let expected_return_ty = decl
-            .return_ty
-            .clone()
-            .unwrap_or_else(|| Rc::new(ir_type::Ty::new_unit()));
-
-        let mut inferrer = TypeInferrer::new(symbol_table_view, expected_return_ty);
+        let mut inferrer = TypeInferrer::new(symbol_table_view, decl.return_ty.clone());
 
         // Infer types for all statements in the block
         for stmt in &body.body {

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -620,10 +620,7 @@ impl SemanticAnalyzer {
             name: qualified_name,
             is_c_variadic: matches!(node.params.variadic, ast::top::VariadicKind::C),
             params,
-            return_ty: match &node.return_ty {
-                None => None,
-                Some(ty) => Some(self.analyze_type(ty)?),
-            },
+            return_ty: self.analyze_type(&node.return_ty)?,
         };
 
         let symbol_table_value = SymbolTableValue::new(

--- a/compiler/type_infer/src/lib.rs
+++ b/compiler/type_infer/src/lib.rs
@@ -861,10 +861,7 @@ impl TypeInferrer {
         }
 
         // Return the function's return type
-        Ok(decl
-            .return_ty
-            .clone()
-            .unwrap_or_else(|| Rc::new(Ty::new_unit())))
+        Ok(decl.return_ty.clone())
     }
 
     fn infer_spawn(&mut self, spawn: &Spawn) -> Result<Rc<Ty>, TypeInferError> {
@@ -1368,9 +1365,7 @@ impl TypeInferrer {
                 for param in applied_callee.params.iter_mut() {
                     param.ty = self.context.apply(&param.ty);
                 }
-                if let Some(ret) = applied_callee.return_ty.clone() {
-                    applied_callee.return_ty = Some(self.context.apply(&ret));
-                }
+                applied_callee.return_ty = self.context.apply(&applied_callee.return_ty);
                 fn_call.callee = applied_callee.into();
             }
             Spawn(spawn) => {
@@ -1382,9 +1377,7 @@ impl TypeInferrer {
                 for param in applied_callee.params.iter_mut() {
                     param.ty = self.context.apply(&param.ty);
                 }
-                if let Some(ret) = applied_callee.return_ty.clone() {
-                    applied_callee.return_ty = Some(self.context.apply(&ret));
-                }
+                applied_callee.return_ty = self.context.apply(&applied_callee.return_ty);
                 spawn.callee = applied_callee.into();
 
                 spawn.arg_types = spawn


### PR DESCRIPTION
- Allow omitting return type in closure type syntax (e.g., `fn(i32)` instead of `fn(i32) -> ()`)
- Change `FnDecl.return_ty` from `Option<Rc<Ty>>` to `Rc<Ty>` across AST and IR
- Use `TyKind::Unit` to represent void/no return value instead of `None`
- Simplify codegen by checking for Unit type directly instead of Option pattern matching