### PR TITLE
fix(std): stop storing null terminator inside String

### DIFF
--- a/library/src/std/string.kd
+++ b/library/src/std/string.kd
@@ -34,9 +34,6 @@ impl String {
             i += 1
         }
 
-        // Add null terminator
-        chars.push('\0')
-
         return String { chars: chars }
     }
 
@@ -45,14 +42,7 @@ impl String {
     }
 
     pub fn len(self): u32 {
-        let len = self.chars.len()
-
-        if len == 0 {
-            return 0
-        }
-
-        // Exclude the trailing null terminator
-        return len - 1
+        return self.chars.len()
     }
 
     pub fn as_str(self): str {


### PR DESCRIPTION
- String::from_bytes(s) no longer pushes '\0' into chars
- len() returns self.chars.len() directly (was len-1 to exclude terminator)