### PR TITLE
feat(std): add print/println/eprint/eprintln and kaede_io_write FFI

### DIFF
--- a/compiler/semantic/src/context.rs
+++ b/compiler/semantic/src/context.rs
@@ -18,9 +18,9 @@ pub enum AnalyzeCommand {
 
 #[derive(Debug, Clone)]
 pub struct AnalysisContext {
-    // std.io.puts(s) in test.kd -> [std, io]
+    // std.io.print(s) in test.kd -> [std, io]
     current_module_path: ModulePath,
-    // std.io.puts(s) in test.kd -> [test]
+    // std.io.print(s) in test.kd -> [test]
     module_path: ModulePath,
     fallback_lookup_module_path: Option<ModulePath>,
 

--- a/example/calculator/src/main.kd
+++ b/example/calculator/src/main.kd
@@ -1,7 +1,6 @@
 import tokenize
 import eval
 import parse
-import std.io
 
 use tokenize.Tokenizer
 use parse.Parser
@@ -12,7 +11,7 @@ fn main(args: Vector<str>): i32 {
         Option::Some(expr) => expr,
 
         Option::None => {
-            std.io.puts("Please provide an expression as an command line argument!\n")
+            println("Please provide an expression as an command line argument!")
             return 1
         }
     })

--- a/example/calculator/src/parse.kd
+++ b/example/calculator/src/parse.kd
@@ -1,6 +1,5 @@
 import ast
 import tokenize
-import std.io
 
 use ast.*
 use tokenize.Token
@@ -59,7 +58,7 @@ impl Parser {
             _ => {}
         }
 
-        std.io.eputs("expect number")
+        eprintln("expect number")
         __unreachable()
     }
 

--- a/library/ffi/io/io.c
+++ b/library/ffi/io/io.c
@@ -1,5 +1,6 @@
 #include "io.h"
 #include <stdio.h>
+#include <unistd.h>
 
 /*
  * These simply forward libc's standard streams.
@@ -12,3 +13,7 @@ FILE *kaede_rt_stdin(void) { return stdin; }
 FILE *kaede_rt_stdout(void) { return stdout; }
 
 FILE *kaede_rt_stderr(void) { return stderr; }
+
+int32_t kaede_io_write(int32_t fd, const void *buf, size_t len) {
+    return (int32_t)write((int)fd, buf, len);
+}

--- a/library/ffi/io/io.h
+++ b/library/ffi/io/io.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #ifdef __cplusplus
@@ -23,6 +25,9 @@ FILE *kaede_rt_stdout(void);
 
 /* Standard error */
 FILE *kaede_rt_stderr(void);
+
+/* fd / buffer / length — thin wrapper around POSIX write(2) */
+int32_t kaede_io_write(int32_t fd, const void *buf, size_t len);
 
 #ifdef __cplusplus
 }

--- a/library/src/prelude.kd
+++ b/library/src/prelude.kd
@@ -2,6 +2,7 @@
 // And this is not included in the standard library and will not be compiled
 
 import std.collections
+import std.io
 import std.option
 import std.string
 import std.sync
@@ -13,3 +14,7 @@ pub use std.option.Option
 pub use std.string.String
 pub use std.sync.Channel
 pub use std.ffi.args.__prepare_command_line_arguments
+pub use std.io.print
+pub use std.io.println
+pub use std.io.eprint
+pub use std.io.eprintln

--- a/library/src/std/ffi/io.kd
+++ b/library/src/std/ffi/io.kd
@@ -2,6 +2,12 @@ pub extern "C" fn kaede_rt_stdin(): *i8
 pub extern "C" fn kaede_rt_stdout(): *i8
 pub extern "C" fn kaede_rt_stderr(): *i8
 
+pub extern "C" fn kaede_io_write(fd: i32, buf: *i8, byte: u64): i32
+
+pub fn write(fd: i32, msg: str): i32 {
+    return kaede_io_write(fd, msg.as_ptr(), msg.len())
+}
+
 pub fn __stdin(): *i8 {
     return kaede_rt_stdin()
 }

--- a/library/src/std/io.kd
+++ b/library/src/std/io.kd
@@ -1,13 +1,21 @@
-pub extern "C" fn write(fd: i32, buf: *i8, byte: u64): i32
+import std.ffi.io
 
-fn c_write(fd: i32, msg: str): i32 {
-    return write(fd, msg.as_ptr(), msg.len())
+use std.ffi.io.write
+
+pub fn print(msg: str): i32 {
+    return write(1, msg)
 }
 
-pub fn puts(msg: str): i32 {
-    return c_write(1, msg)
+pub fn println(msg: str): i32 {
+    print(msg)
+    return write(1, "\n")
 }
 
-pub fn eputs(msg: str): i32 {
-    return c_write(2, msg)
+pub fn eprint(msg: str): i32 {
+    return write(2, msg)
+}
+
+pub fn eprintln(msg: str): i32 {
+    eprint(msg)
+    return write(2, "\n")
 }


### PR DESCRIPTION
- Rename puts/eputs to print/eprint; add println/eprintln
- Re-export from prelude
- Move str write helper to std.ffi.io.write via kaede_io_write in ffi/io
- Update calculator example and context.rs comment