### PR TITLE
fix: use := in website websocket sample

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -13,7 +13,7 @@ app.get("/", |req, res| {
 
 app.ws("/ws/echo", |req, ws| {
     loop {
-        let msg = ws.receive().unwrap()
+        msg := ws.receive().unwrap()
         match msg.kind {
             std.http.WebSocketMessageKind::Close => return
             _ => ws.send(msg)


### PR DESCRIPTION
Closes #198.

Updates the website home page sample to use := for the WebSocket message binding.

Testing: not run (documentation-only change).