### PR TITLE
fix(http): preserve UTF-8 in percent-decoded query params

### DIFF
--- a/compiler/driver/tests/http_runtime.rs
+++ b/compiler/driver/tests/http_runtime.rs
@@ -27,6 +27,14 @@ app.get("/hello", |req, res| {{
     res.send_text("hello")
 }})
 
+app.get("/query", |req, res| {{
+    author := match req.query("author") {{
+        std.option.Option::Some(value) => value,
+        std.option.Option::None => std.string.String::from("missing"),
+    }}
+    res.send_text(author.as_str())
+}})
+
 app.post("/echo", |req, res| {{
     res.send_bytes(req.body)
 }})
@@ -139,6 +147,19 @@ fn std_http_honors_close_semantics_and_rejects_bad_content_length() -> anyhow::R
         assert!(response.body.is_empty());
         assert_stream_closed(&mut stream)?;
     }
+
+    let _ = fs::remove_file(binary_path);
+    Ok(())
+}
+
+#[test]
+fn std_http_query_percent_decoding_preserves_utf8() -> anyhow::Result<()> {
+    let (_tempdir, _server, port, binary_path) = spawn_http_server()?;
+
+    let response =
+        http_test_support::http_get(port, "/query?author=%E3%83%9E%E3%82%A4%E3%82%B1%E3%83%AB")?;
+    assert_eq!(response.status_code, 200);
+    assert_eq!(std::str::from_utf8(&response.body)?, "マイケル");
 
     let _ = fs::remove_file(binary_path);
     Ok(())

--- a/library/src/std/http.kd
+++ b/library/src/std/http.kd
@@ -613,33 +613,34 @@ fn find_query_param_value(query: String, name: str): Option<String> {
 }
 
 fn decode_query_component(component: String): String {
-    let mut out = String::new()
+    let bytes = component.as_str().to_bytes()
+    let mut out = Vector<u8>::new()
     let mut i = 0
 
-    while i < component.len() {
-        let ch = component.as_str()[i]
+    while i < bytes.len() {
+        let b = bytes.at(i).unwrap()
 
-        if ch == '+' {
-            out.push(' ')
+        if b == b'+' {
+            out.push(b' ')
             i += 1
-        } else if ch == '%' && i + 2 < component.len() {
-            let hi = hex_nibble(component.as_str()[i + 1])
-            let lo = hex_nibble(component.as_str()[i + 2])
+        } else if b == b'%' && i + 2 < bytes.len() {
+            let hi = hex_nibble(bytes.at(i + 1).unwrap() as char)
+            let lo = hex_nibble(bytes.at(i + 2).unwrap() as char)
 
             if hi >= 0 && lo >= 0 {
-                out.push(((hi << 4) | lo) as char)
+                out.push(((hi << 4) | lo) as u8)
                 i += 3
             } else {
-                out.push(ch)
+                out.push(b)
                 i += 1
             }
         } else {
-            out.push(ch)
+            out.push(b)
             i += 1
         }
     }
 
-    return out
+    return String::from_bytes(out.as_slice())
 }
 
 fn hex_nibble(ch: char): i32 {


### PR DESCRIPTION
## Summary
- preserve percent-decoded query parameter bytes as UTF-8 instead of re-encoding each byte as a Unicode scalar value
- add an HTTP integration test that verifies `%E3%83%9E%E3%82%A4%E3%82%B1%E3%83%AB` decodes to `マイケル`
- fixes the mojibake seen in `example/comment_app` author names while leaving request bodies unchanged

## Cause
`decode_query_component()` decoded each `%xx` byte and appended it via `String.push(char)`. After the Unicode scalar value change, that path re-encoded each decoded byte as UTF-8, which corrupted non-ASCII query parameters.

## Verification
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test --release --no-fail-fast`

Closes #206
