### PR TITLE
docs(website): Kaede Programming Language in site title for SEO

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -5,7 +5,7 @@ const autumnFavicon =
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'Kaede',
+  title: 'Kaede Programming Language',
   tagline: 'A statically typed compiled language for concise servers.',
   url: 'https://itto-hiramoto.github.io',
   baseUrl: '/kaede/',

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -81,7 +81,7 @@ const examples = [
 export default function Home() {
   return (
     <Layout
-      title="Kaede"
+      title="Kaede Programming Language"
       description="Kaede is a language for concise servers without giving up performance."
     >
       <main className="kaede-home">


### PR DESCRIPTION
## Summary
- Set Docusaurus `title` to **Kaede Programming Language** so default `<head>` titles and doc page suffixes are clearer for search (e.g. `Page | Kaede Programming Language`).
- Match the home page `Layout` `title` so the landing page tab is consistent.

## Verification
- `cd website && npm run build` (optional)

Closes #211