### PR TITLE
fix: link docs sidebar categories to first page

### DIFF
--- a/website/docs/getting-started/_category_.json
+++ b/website/docs/getting-started/_category_.json
@@ -1,5 +1,9 @@
 {
   "label": "Getting Started",
   "position": 2,
-  "collapsible": false
+  "collapsible": false,
+  "link": {
+    "type": "doc",
+    "id": "getting-started/installation"
+  }
 }

--- a/website/docs/language/_category_.json
+++ b/website/docs/language/_category_.json
@@ -1,5 +1,9 @@
 {
   "label": "Language",
   "position": 3,
-  "collapsible": false
+  "collapsible": false,
+  "link": {
+    "type": "doc",
+    "id": "language/overview"
+  }
 }


### PR DESCRIPTION
## Summary
- make the Getting Started category link to the installation page
- make the Language category link to the overview page
- keep the existing sidebar structure while making category clicks navigate somewhere useful

## Verification
- npm run build
