### PR TITLE
feat: migrate function syntax to export/fun/->

### DIFF
--- a/compiler/ast_type/src/lib.rs
+++ b/compiler/ast_type/src/lib.rs
@@ -249,7 +249,7 @@ impl std::fmt::Display for TyKind {
                     .map(|t| t.kind.to_string())
                     .collect::<Vec<_>>()
                     .join(", ");
-                write!(f, "fn({params}) -> {}", closure.ret_ty.kind)
+                write!(f, "fun({params}) -> {}", closure.ret_ty.kind)
             }
 
             Self::Reference(refee) => write!(f, "&{}", refee.refee_ty.kind),

--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -261,7 +261,7 @@ fn top_level_statements_can_call_later_functions() -> anyhow::Result<()> {
             r#"
             return add(40, 2)
 
-            fn add(a: i32, b: i32): i32 {
+            fun add(a: i32, b: i32) -> i32 {
                 return a + b
             }
             "#,
@@ -281,66 +281,69 @@ fn top_level_fallthrough_returns_zero() -> anyhow::Result<()> {
 
 #[test]
 fn add() -> anyhow::Result<()> {
-    assert_eq!(exec("fn main(): i32 { return 48 + 10 }")?, 58);
+    assert_eq!(exec("fun main() -> i32 { return 48 + 10 }")?, 58);
 
     Ok(())
 }
 
 #[test]
 fn sub() -> anyhow::Result<()> {
-    assert_eq!(exec("fn main(): i32 { return 68 - 10 }")?, 58);
+    assert_eq!(exec("fun main() -> i32 { return 68 - 10 }")?, 58);
 
     Ok(())
 }
 
 #[test]
 fn mul() -> anyhow::Result<()> {
-    assert_eq!(exec("fn main(): i32 { return 48 * 10 }")?, 480);
+    assert_eq!(exec("fun main() -> i32 { return 48 * 10 }")?, 480);
 
     Ok(())
 }
 
 #[test]
 fn div() -> anyhow::Result<()> {
-    assert_eq!(exec("fn main(): i32 { return 580 / 10 }")?, 58);
+    assert_eq!(exec("fun main() -> i32 { return 580 / 10 }")?, 58);
 
     Ok(())
 }
 
 #[test]
 fn mul_precedence() -> anyhow::Result<()> {
-    assert_eq!(exec("fn main(): i32 { return 48 + 10 * 2 }")?, 68);
+    assert_eq!(exec("fun main() -> i32 { return 48 + 10 * 2 }")?, 68);
 
     Ok(())
 }
 
 #[test]
 fn div_precedence() -> anyhow::Result<()> {
-    assert_eq!(exec("fn main(): i32 { return 48 + 20 / 2 }")?, 58);
+    assert_eq!(exec("fun main() -> i32 { return 48 + 20 / 2 }")?, 58);
 
     Ok(())
 }
 
 #[test]
 fn four_arithmetic_precedence() -> anyhow::Result<()> {
-    assert_eq!(exec("fn main(): i32 { return (48 -10/ 2) + 58 * 2 }")?, 159);
+    assert_eq!(
+        exec("fun main() -> i32 { return (48 -10/ 2) + 58 * 2 }")?,
+        159
+    );
 
     Ok(())
 }
 
 #[test]
 fn unary_plus_and_minus() -> anyhow::Result<()> {
-    assert_eq!(exec("fn main(): i32 { return +(-(-58)) }")?, 58);
+    assert_eq!(exec("fun main() -> i32 { return +(-(-58)) }")?, 58);
 
     Ok(())
 }
 
 #[test]
 fn empty_function() -> anyhow::Result<()> {
-    let program = r"fn f() {
+    let program = r"fun f() {
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         f()
         return 58
     }";
@@ -352,18 +355,18 @@ fn empty_function() -> anyhow::Result<()> {
 
 #[test]
 fn return_() -> anyhow::Result<()> {
-    assert_eq!(exec("fn main(): i32 { return (48*2 +10 * 2) / 2}")?, 58);
+    assert_eq!(exec("fun main() -> i32 { return (48*2 +10 * 2) / 2}")?, 58);
 
     Ok(())
 }
 
 #[test]
 fn empty_return() -> anyhow::Result<()> {
-    let program = r"fn f() {
+    let program = r"fun f() {
         return
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         f()
         return 58
     }";
@@ -376,7 +379,7 @@ fn empty_return() -> anyhow::Result<()> {
 #[test]
 fn let_statement() -> anyhow::Result<()> {
     // Type inference
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let x = 48
         let y = 10
         return x + y
@@ -385,7 +388,7 @@ fn let_statement() -> anyhow::Result<()> {
     assert_eq!(exec(program)?, 58);
 
     // Mutable, Type inference
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let mut x = 58
         return x
     }";
@@ -393,7 +396,7 @@ fn let_statement() -> anyhow::Result<()> {
     assert_eq!(exec(program)?, 58);
 
     // Specified type
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let x: i32 = 58
         return x
     }";
@@ -401,7 +404,7 @@ fn let_statement() -> anyhow::Result<()> {
     assert_eq!(exec(program)?, 58);
 
     // Mutable, Specified type
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let mut x: i32 = 58
         return x
     }";
@@ -413,7 +416,7 @@ fn let_statement() -> anyhow::Result<()> {
 
 #[test]
 fn short_decl_colon_eq() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         x := 48
         y := 10
         return x + y
@@ -421,14 +424,14 @@ fn short_decl_colon_eq() -> anyhow::Result<()> {
 
     assert_eq!(exec(program)?, 58);
 
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         mut x := 58
         return x
     }";
 
     assert_eq!(exec(program)?, 58);
 
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         mut x := 0
         x = 58
         return x
@@ -441,15 +444,15 @@ fn short_decl_colon_eq() -> anyhow::Result<()> {
 
 #[test]
 fn call_function() -> anyhow::Result<()> {
-    let program = r"fn f1(): i32 {
+    let program = r"fun f1() -> i32 {
         return 48
     }
 
-    fn f2(): i32 {
+    fun f2() -> i32 {
         return 10
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         return f1() + f2()
     }";
 
@@ -460,11 +463,11 @@ fn call_function() -> anyhow::Result<()> {
 
 #[test]
 fn function_parameters() -> anyhow::Result<()> {
-    let program = r"fn f(n: i32): i32 {
+    let program = r"fun f(n: i32) -> i32 {
         return n
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         return 58
     }";
 
@@ -475,11 +478,11 @@ fn function_parameters() -> anyhow::Result<()> {
 
 #[test]
 fn function_call_with_one_argument() -> anyhow::Result<()> {
-    let program = r"fn f(n: i32): i32 {
+    let program = r"fun f(n: i32) -> i32 {
         return n
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         return f(58)
     }";
 
@@ -490,11 +493,11 @@ fn function_call_with_one_argument() -> anyhow::Result<()> {
 
 #[test]
 fn function_call_with_multi_args() -> anyhow::Result<()> {
-    let program = r"fn f(x: i32, y: i32): i32 {
+    let program = r"fun f(x: i32, y: i32) -> i32 {
         return x + y
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         return f(48, 10)
     }";
 
@@ -505,11 +508,11 @@ fn function_call_with_multi_args() -> anyhow::Result<()> {
 
 #[test]
 fn function_call_with_keyword_args() -> anyhow::Result<()> {
-    let program = r"fn f(x: i32, y: i32, z: i32): i32 {
+    let program = r"fun f(x: i32, y: i32, z: i32) -> i32 {
         return x * y + z
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         // Reordered keyword arguments should map correctly.
         return f(z=8, x=50, y=0)
     }";
@@ -521,7 +524,7 @@ fn function_call_with_keyword_args() -> anyhow::Result<()> {
 
 #[test]
 fn simple_if() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         if 58 == 58 {
             return 58
         }
@@ -536,7 +539,7 @@ fn simple_if() -> anyhow::Result<()> {
 
 #[test]
 fn if_else() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         if 48 == 10 {
             return 48
         } else if
@@ -557,7 +560,7 @@ fn if_else() -> anyhow::Result<()> {
 
 #[test]
 fn equality_operation() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         if 4810 == 4810 {
             return 58
         }
@@ -572,7 +575,7 @@ fn equality_operation() -> anyhow::Result<()> {
 
 #[test]
 fn loop_() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let mut n = 0
 
         loop {
@@ -593,7 +596,7 @@ fn loop_() -> anyhow::Result<()> {
 
 #[test]
 fn while_() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let mut n = 0
 
         while n < 10 {
@@ -610,7 +613,7 @@ fn while_() -> anyhow::Result<()> {
 
 #[test]
 fn break_() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         loop {
             break
         }
@@ -625,7 +628,7 @@ fn break_() -> anyhow::Result<()> {
 
 #[test]
 fn break_outside_of_loop() {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         break
     }";
 
@@ -637,7 +640,7 @@ fn break_outside_of_loop() {
 
 #[test]
 fn simple_assignment() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let mut n = 0
 
         n = 58
@@ -652,7 +655,7 @@ fn simple_assignment() -> anyhow::Result<()> {
 
 #[test]
 fn assign_to_immutable() {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let n = 58
         n = 4810
         return n
@@ -666,7 +669,7 @@ fn assign_to_immutable() {
 
 #[test]
 fn string_literal() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let s1 = "hello, world"
         let s2 = "こんにちは"
 
@@ -680,7 +683,7 @@ fn string_literal() -> anyhow::Result<()> {
 
 #[test]
 fn builtin_format() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let s = __format("a{}b{}", "x", "yz")
         return s.len() as i32
     }"#;
@@ -691,7 +694,7 @@ fn builtin_format() -> anyhow::Result<()> {
 
 #[test]
 fn builtin_format_requires_literal_template() {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let t = "{}"
         let _ = __format(t, "x")
         return 0
@@ -705,7 +708,7 @@ fn builtin_format_requires_literal_template() {
 
 #[test]
 fn builtin_format_requires_matching_placeholder_count() {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let _ = __format("{} {}", "x")
         return 0
     }"#;
@@ -718,7 +721,7 @@ fn builtin_format_requires_matching_placeholder_count() {
 
 #[test]
 fn format_is_undeclared() {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let _ = format("{}", "x")
         return 0
     }"#;
@@ -731,7 +734,7 @@ fn format_is_undeclared() {
 
 #[test]
 fn interpolated_string() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let name = "xy"
         let s = $"a{name}b"
         return s.len() as i32
@@ -743,7 +746,7 @@ fn interpolated_string() -> anyhow::Result<()> {
 
 #[test]
 fn byte_string_literal() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let bs = b"hi"
         return (bs[0] as i32) + (bs[1] as i32)
     }"#;
@@ -755,7 +758,7 @@ fn byte_string_literal() -> anyhow::Result<()> {
 
 #[test]
 fn byte_string_literal_with_escapes() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let bs = b"a\n\\\""
         return (bs[0] as i32) + (bs[1] as i32) + (bs[2] as i32) + (bs[3] as i32)
     }"#;
@@ -766,7 +769,7 @@ fn byte_string_literal_with_escapes() -> anyhow::Result<()> {
 
 #[test]
 fn byte_literal() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let b = b'A'
         return b as i32
     }"#;
@@ -777,7 +780,7 @@ fn byte_literal() -> anyhow::Result<()> {
 
 #[test]
 fn byte_literal_escape_sequences() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let newline = b'\n'
         let tab = b'\t'
         let backslash = b'\\'
@@ -791,7 +794,7 @@ fn byte_literal_escape_sequences() -> anyhow::Result<()> {
 
 #[test]
 fn byte_literal_arithmetic() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let a = b'a'
         let z = b'z'
         return (z - a) as i32
@@ -803,11 +806,11 @@ fn byte_literal_arithmetic() -> anyhow::Result<()> {
 
 #[test]
 fn string_type() -> anyhow::Result<()> {
-    let program = r#"fn f(s: str): str {
+    let program = r#"fun f(s: str) -> str {
         return s
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let s: str = f("Yohaio")
         return 58
     }"#;
@@ -826,7 +829,7 @@ fn define_struct() -> anyhow::Result<()> {
 
     struct B { a: i32, b: bool }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         return 58
     }";
 
@@ -844,7 +847,7 @@ fn struct_field_access() -> anyhow::Result<()> {
         is_female: bool,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let person = Person { is_male: false, stature: 48, age: 10, is_female: true }
         return person.age + person.stature
     }";
@@ -856,7 +859,7 @@ fn struct_field_access() -> anyhow::Result<()> {
 
 #[test]
 fn true_() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let b = true
 
         if b {
@@ -873,7 +876,7 @@ fn true_() -> anyhow::Result<()> {
 
 #[test]
 fn false_() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let b = false
 
         if b {
@@ -890,7 +893,7 @@ fn false_() -> anyhow::Result<()> {
 
 #[test]
 fn has_no_fields() {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         4810.shino
     }";
 
@@ -899,7 +902,7 @@ fn has_no_fields() {
 
 #[test]
 fn less_than() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         if 48 < 48 {
             return 123
         } else if 48 < 10 {
@@ -918,7 +921,7 @@ fn less_than() -> anyhow::Result<()> {
 
 #[test]
 fn greater_than() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         if 10 > 10 {
             return 123
         } else if 10 > 48 {
@@ -937,7 +940,7 @@ fn greater_than() -> anyhow::Result<()> {
 
 #[test]
 fn less_than_or_equal() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         if 48 <= 48 {
             return 58
         } else {
@@ -954,7 +957,7 @@ fn less_than_or_equal() -> anyhow::Result<()> {
 
 #[test]
 fn greater_than_or_equal() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         if 10 >= 10 {
             return 58
         } else {
@@ -971,7 +974,7 @@ fn greater_than_or_equal() -> anyhow::Result<()> {
 
 #[test]
 fn not_equal_to() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         if 48 != 48 {
             return 123
         } else if 48 != 10 {
@@ -988,11 +991,11 @@ fn not_equal_to() -> anyhow::Result<()> {
 
 #[test]
 fn logical_not() -> anyhow::Result<()> {
-    let program = r"fn f(fl: bool): bool {
+    let program = r"fun f(fl: bool) -> bool {
         return !fl
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         if !(48 != 10) {
             return 123
         }
@@ -1013,7 +1016,7 @@ fn logical_not() -> anyhow::Result<()> {
 
 #[test]
 fn remainder() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         return 123 % 7
     }";
 
@@ -1025,7 +1028,7 @@ fn remainder() -> anyhow::Result<()> {
 #[test]
 fn bit_and_or_xor() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let a = 5 & 3
             let b = 5 | 2
             let c = 5 ^ 1
@@ -1040,7 +1043,7 @@ fn bit_and_or_xor() -> anyhow::Result<()> {
 #[test]
 fn bit_shift() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let a = 3 << 2
             let b = 16 >> 2
             return a + b
@@ -1054,7 +1057,7 @@ fn bit_shift() -> anyhow::Result<()> {
 #[test]
 fn bit_not() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             return ~0
         }
     "#;
@@ -1066,7 +1069,7 @@ fn bit_not() -> anyhow::Result<()> {
 #[test]
 fn bit_operator_precedence() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let a = 1 + 2 << 3
             let b = 8 >> 1 & 3
             let c = 1 | 2 ^ 3 & 4
@@ -1080,7 +1083,7 @@ fn bit_operator_precedence() -> anyhow::Result<()> {
 
 #[test]
 fn logical_or() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         if false || false {
             return 123
         }
@@ -1103,7 +1106,7 @@ fn logical_or() -> anyhow::Result<()> {
 
 #[test]
 fn logical_and() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         if false && true {
             return 123
         }
@@ -1128,7 +1131,7 @@ fn logical_and() -> anyhow::Result<()> {
 
 #[test]
 fn array_literal() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let a = [48, 10]
         return 58
     }";
@@ -1140,7 +1143,7 @@ fn array_literal() -> anyhow::Result<()> {
 
 #[test]
 fn array_repeat() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let a = [42; 3]
         return a[0] + a[1] + a[2]
     }";
@@ -1152,7 +1155,7 @@ fn array_repeat() -> anyhow::Result<()> {
 
 #[test]
 fn array_repeat_value_evaluated_once() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let mut x = 0
         let arr = [{ x = x + 1; x }; 4]
         return x * 10 + arr[3]
@@ -1165,7 +1168,7 @@ fn array_repeat_value_evaluated_once() -> anyhow::Result<()> {
 
 #[test]
 fn array_repeat_with_type_annotation() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let arr: [i32; 2] = [0; 2]
         return arr[0] + arr[1]
     }";
@@ -1177,7 +1180,7 @@ fn array_repeat_with_type_annotation() -> anyhow::Result<()> {
 
 #[test]
 fn array_indexing() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let a = [48, 10]
         return a[0] + [4][0] + a[1]
     }";
@@ -1189,7 +1192,7 @@ fn array_indexing() -> anyhow::Result<()> {
 
 #[test]
 fn array_type() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let a: [i32; 2] = [48, 10]
         let n: [i32; 1] = [4]
         return a[0] + a[1] + n[0]
@@ -1202,11 +1205,11 @@ fn array_type() -> anyhow::Result<()> {
 
 #[test]
 fn array_as_argument() -> anyhow::Result<()> {
-    let program = r"fn add(a: [i32; 2]): i32 {
+    let program = r"fun add(a: [i32; 2]) -> i32 {
         return a[0] + a[1]
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = [48, 10]
 
         return add(a)
@@ -1219,16 +1222,16 @@ fn array_as_argument() -> anyhow::Result<()> {
 
 #[test]
 fn array_as_mutable_argument() -> anyhow::Result<()> {
-    let program = r"fn modify(a: mut [i32; 2]) {
+    let program = r"fun modify(a: mut [i32; 2]) {
         a[0] = 48
         a[1] = 10
     }
 
-    fn add(a: [i32; 2]): i32 {
+    fun add(a: [i32; 2]) -> i32 {
         return a[0] + a[1]
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let mut a = [12, 34]
 
         modify(a)
@@ -1243,16 +1246,16 @@ fn array_as_mutable_argument() -> anyhow::Result<()> {
 
 #[test]
 fn immutable_array_as_mutable_argument() {
-    let program = r"fn modify(a: mut [i32; 2]) {
+    let program = r"fun modify(a: mut [i32; 2]) {
         a[0] = 48
         a[1] = 10
     }
 
-    fn add(a: [i32; 2]): i32 {
+    fun add(a: [i32; 2]) -> i32 {
         return a[0] + a[1]
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = [123, 124]
 
         // ERROR!
@@ -1269,7 +1272,7 @@ fn immutable_array_as_mutable_argument() {
 
 #[test]
 fn assign_to_array_elements() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let mut a = [123]
 
         a[0] = 58
@@ -1284,7 +1287,7 @@ fn assign_to_array_elements() -> anyhow::Result<()> {
 
 #[test]
 fn tuple_indexing() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let tup = (58, true, "hello")
 
         if tup.1 {
@@ -1301,7 +1304,7 @@ fn tuple_indexing() -> anyhow::Result<()> {
 
 #[test]
 fn tuple_unpacking() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let tup = (48, true, "hello", 10)
 
         let (n1, f, _, n2) = tup
@@ -1315,7 +1318,7 @@ fn tuple_unpacking() -> anyhow::Result<()> {
 
     assert_eq!(exec(program)?, 58);
 
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let (n1, f, _, n2) = (48, true, "hello", 10)
 
         if f {
@@ -1332,7 +1335,7 @@ fn tuple_unpacking() -> anyhow::Result<()> {
 
 #[test]
 fn tuple_as_argument() -> anyhow::Result<()> {
-    let program = r"fn tup1(a: (i32, bool)): i32 {
+    let program = r"fun tup1(a: (i32, bool)) -> i32 {
         if a.1 {
             return a.0
         }
@@ -1340,7 +1343,7 @@ fn tuple_as_argument() -> anyhow::Result<()> {
         return 123
     }
 
-    fn tup2(a: (i32, bool)): i32 {
+    fun tup2(a: (i32, bool)) -> i32 {
         let (n, f) = a
 
         if f {
@@ -1350,7 +1353,7 @@ fn tuple_as_argument() -> anyhow::Result<()> {
         return 124
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let tup = (58, true)
 
         return tup1(tup) + tup2(tup)
@@ -1363,12 +1366,12 @@ fn tuple_as_argument() -> anyhow::Result<()> {
 
 #[test]
 fn tuple_as_mutable_argument() -> anyhow::Result<()> {
-    let program = r"fn modify(tup: mut (i32, bool)) {
+    let program = r"fun modify(tup: mut (i32, bool)) {
         tup.0 = 58
         tup.1 = true
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let mut tup = (123, false)
 
         modify(tup)
@@ -1387,7 +1390,7 @@ fn tuple_as_mutable_argument() -> anyhow::Result<()> {
 
 #[test]
 fn tuples_require_access_by_index() {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let tup = (58, true)
         tup.llvm
     }";
@@ -1400,7 +1403,7 @@ fn tuples_require_access_by_index() {
 
 #[test]
 fn tuple_in_tuple() -> anyhow::Result<()> {
-    let program = r"fn main(): i32 {
+    let program = r"fun main() -> i32 {
         let mut tuptup = ((48, true), (0, true))
 
         let mut io = tuptup.1
@@ -1423,7 +1426,7 @@ fn assign_to_struct_field() -> anyhow::Result<()> {
         is_female: bool,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let mut person = Person { is_male: false, stature: 48, age: 0, is_female: true }
         person.age = 10
         return person.age + person.stature
@@ -1443,7 +1446,7 @@ fn assign_to_immutable_struct_field() {
         is_female: bool,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let person = Person { is_male: false, stature: 48, age: 0, is_female: true }
         person.age = 10
         return person.age + person.stature
@@ -1457,7 +1460,7 @@ fn assign_to_immutable_struct_field() {
 
 #[test]
 fn assign_to_tuple_field() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let mut t = (58, false)
         t.1 = true
 
@@ -1475,7 +1478,7 @@ fn assign_to_tuple_field() -> anyhow::Result<()> {
 
 #[test]
 fn assign_to_immutable_tuple_field() {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let t = (58, false)
         t.1 = true
 
@@ -1500,7 +1503,7 @@ fn comments() -> anyhow::Result<()> {
     hello, world
     world, hello
      */
-    fn main(): i32 {
+    fun main() -> i32 {
         // hello, world
         /* hello, world */
         /*
@@ -1522,7 +1525,7 @@ fn comments() -> anyhow::Result<()> {
 
 #[test]
 fn if_expr_to_initializers_1() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let x = if true {
             58
         } else {
@@ -1539,7 +1542,7 @@ fn if_expr_to_initializers_1() -> anyhow::Result<()> {
 
 #[test]
 fn if_expr_to_initializers_2() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let x = if true {
             58
         } else {
@@ -1556,7 +1559,7 @@ fn if_expr_to_initializers_2() -> anyhow::Result<()> {
 
 #[test]
 fn if_expr_to_initializers_3() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let x = if false {
             123
         } else {
@@ -1573,7 +1576,7 @@ fn if_expr_to_initializers_3() -> anyhow::Result<()> {
 
 #[test]
 fn if_expr_to_initializers_4() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let n = 4810
 
         let x = if false {
@@ -1594,7 +1597,7 @@ fn if_expr_to_initializers_4() -> anyhow::Result<()> {
 
 #[test]
 fn if_expr_in_return_1() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         return if true {
             58
         } else {
@@ -1609,7 +1612,7 @@ fn if_expr_in_return_1() -> anyhow::Result<()> {
 
 #[test]
 fn if_expr_in_return_2() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         return if false {
             123
         } else {
@@ -1624,7 +1627,7 @@ fn if_expr_in_return_2() -> anyhow::Result<()> {
 
 #[test]
 fn if_expr_in_return_3() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         return 122 + if true {
             return 58
         } else {
@@ -1639,7 +1642,7 @@ fn if_expr_in_return_3() -> anyhow::Result<()> {
 
 #[test]
 fn nested_if_expr_1() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let n = 4810
 
         let x = if n == 4810 {
@@ -1666,7 +1669,7 @@ fn nested_if_expr_1() -> anyhow::Result<()> {
 
 #[test]
 fn nested_if_expr_2() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let n = 4810
 
         let x = if false {
@@ -1700,7 +1703,7 @@ fn copy_struct() -> anyhow::Result<()> {
         is_female: bool,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let mut p1 = Person {
             is_male: false,
             stature: 48,
@@ -1722,7 +1725,7 @@ fn copy_struct() -> anyhow::Result<()> {
 
 #[test]
 fn copy_array() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let mut ar = [128, 256, 512]
 
         let mut arr = ar
@@ -1739,7 +1742,7 @@ fn copy_array() -> anyhow::Result<()> {
 
 #[test]
 fn copy_tuple() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let mut tup = (false, 123)
 
         let mut tupp = tup
@@ -1768,11 +1771,11 @@ fn struct_as_mutable_argument() -> anyhow::Result<()> {
         is_female: bool,
     }
 
-    fn f(p: mut Person) {
+    fun f(p: mut Person) {
         p.age = 10
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let mut p1 = Person {
             is_male: false,
             stature: 48,
@@ -1800,7 +1803,7 @@ fn struct_in_struct() -> anyhow::Result<()> {
         age: Age,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let mut p = Person {
             age: Age { n: 0 },
         }
@@ -1818,7 +1821,7 @@ fn struct_in_struct() -> anyhow::Result<()> {
 
 #[test]
 fn copy_scalar_type_data() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let n = 58
 
         let mut m = n
@@ -1835,7 +1838,7 @@ fn copy_scalar_type_data() -> anyhow::Result<()> {
 #[test]
 fn assign_to_immutable_to_mutable() {
     // Array
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let ar = [128, 256, 512]
 
         let mut arr = ar
@@ -1849,7 +1852,7 @@ fn assign_to_immutable_to_mutable() {
     ));
 
     // Tuple
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let tup = (58, true)
 
         let mut t = tup
@@ -1867,7 +1870,7 @@ fn assign_to_immutable_to_mutable() {
         n: i32,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let n = Number { n: 58 }
 
         let mut m = n
@@ -1887,11 +1890,11 @@ fn return_struct() -> anyhow::Result<()> {
         age: i32,
     }
 
-    fn f(): Person {
+    fun f() -> Person {
         return Person { age: 58 }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let s = f()
 
         return s.age
@@ -1909,7 +1912,7 @@ fn struct_literal_field_init_shorthand() -> anyhow::Result<()> {
         stature: i32,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let age = 10
         let stature = 48
         let person = Person { age, stature }
@@ -1923,11 +1926,11 @@ fn struct_literal_field_init_shorthand() -> anyhow::Result<()> {
 
 #[test]
 fn return_tuple() -> anyhow::Result<()> {
-    let program = r#"fn f(): (i32, bool) {
+    let program = r#"fun f() -> (i32, bool) {
         return (58, true)
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let t = f()
 
         if t.1 {
@@ -1944,11 +1947,11 @@ fn return_tuple() -> anyhow::Result<()> {
 
 #[test]
 fn return_array() -> anyhow::Result<()> {
-    let program = r#"fn f(): [i32; 2] {
+    let program = r#"fun f() -> [i32; 2] {
         return [48, 10]
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let ar = f()
 
         return ar[0] + ar[1]
@@ -1961,7 +1964,7 @@ fn return_array() -> anyhow::Result<()> {
 
 #[test]
 fn array_to_slice_param_codegen() -> anyhow::Result<()> {
-    let program = r#"fn sum(s: [i32]): i32 {
+    let program = r#"fun sum(s: [i32]) -> i32 {
         let mut sum = 0
         let mut i = 0
 
@@ -1976,7 +1979,7 @@ fn array_to_slice_param_codegen() -> anyhow::Result<()> {
         return sum
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let ar1: [i32; 2] = [1, 2]
         let ar2 = [10, 20, 30]
 
@@ -1990,11 +1993,11 @@ fn array_to_slice_param_codegen() -> anyhow::Result<()> {
 
 #[test]
 fn array_to_slice_return_codegen() -> anyhow::Result<()> {
-    let program = r#"fn make(): [i32] {
+    let program = r#"fun make() -> [i32] {
         return [48, 10]
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let s = make()
 
         return s[0] + s[1]
@@ -2007,11 +2010,11 @@ fn array_to_slice_return_codegen() -> anyhow::Result<()> {
 
 #[test]
 fn slice_len_method_codegen() -> anyhow::Result<()> {
-    let program = r#"fn len_of(s: [i32]): u64 {
+    let program = r#"fun len_of(s: [i32]) -> u64 {
         return s.len()
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let ar = [5, 6, 7]
         return len_of(ar) as i32
     }"#;
@@ -2023,12 +2026,12 @@ fn slice_len_method_codegen() -> anyhow::Result<()> {
 
 #[test]
 fn slice_as_ptr_method_codegen() -> anyhow::Result<()> {
-    let program = r#"fn first_plus_len(s: [i32]): i32 {
+    let program = r#"fun first_plus_len(s: [i32]) -> i32 {
         let ptr = s.as_ptr()
         return ptr[0] + s.len() as i32
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let ar = [10, 20]
         return first_plus_len(ar)
     }"#;
@@ -2040,7 +2043,7 @@ fn slice_as_ptr_method_codegen() -> anyhow::Result<()> {
 
 #[test]
 fn slice_full_range_codegen() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let ar = [1, 2, 3, 4]
         let s = ar[:]
         return s.len() as i32 + s[0] + s[3]
@@ -2053,7 +2056,7 @@ fn slice_full_range_codegen() -> anyhow::Result<()> {
 
 #[test]
 fn slice_range_codegen() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let ar = [5, 6, 7, 8, 9]
         let s = ar[1:4] // 6,7,8
         return s.len() as i32 + s[0] + s[2]
@@ -2066,7 +2069,7 @@ fn slice_range_codegen() -> anyhow::Result<()> {
 
 #[test]
 fn slice_trailing_and_nested_codegen() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let ar = [10, 20, 30, 40]
         let mid = ar[1:4] // 20,30,40
         let tail = mid[1:] // 30,40
@@ -2080,7 +2083,7 @@ fn slice_trailing_and_nested_codegen() -> anyhow::Result<()> {
 
 #[test]
 fn slice_empty_codegen() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let ar = [1, 2, 3]
         let empty = ar[2:2]
         return empty.len() as i32
@@ -2097,11 +2100,11 @@ fn if_in_loop() -> anyhow::Result<()> {
         age: i32,
     }
 
-    fn get_age(p: Person): i32 {
+    fun get_age(p: Person) -> i32 {
         return p.age
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let mut p = Person { age: 0 }
 
         loop {
@@ -2127,12 +2130,12 @@ fn simple_method() -> anyhow::Result<()> {
     }
 
     impl Person {
-        fn get_age(self): i32 {
+        fun get_age(self) -> i32 {
             return self.age
         }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let mut p = Person { age: 123 }
 
         p.age = 58
@@ -2152,16 +2155,16 @@ fn mutable_method() -> anyhow::Result<()> {
     }
 
     impl Person {
-        fn get_age(self): i32 {
+        fun get_age(self) -> i32 {
             return self.age
         }
 
-        fn change_age_to(mut self, new_age: i32) {
+        fun change_age_to(mut self, new_age: i32) {
             self.age = new_age
         }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let mut p = Person { age: 123 }
 
         p.change_age_to(58)
@@ -2181,16 +2184,16 @@ fn call_mutable_methods_from_immutable() {
     }
 
     impl Person {
-        fn get_age(self): i32 {
+        fun get_age(self) -> i32 {
             return self.age
         }
 
-        fn change_age_to(mut self, new_age: i32) {
+        fun change_age_to(mut self, new_age: i32) {
             self.age = new_age
         }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let p = Person { age: 123 }
 
         p.change_age_to(58)
@@ -2211,16 +2214,16 @@ fn modify_fields_in_immutable_methods() {
     }
 
     impl Person {
-        fn get_age(self): i32 {
+        fun get_age(self) -> i32 {
             return self.age
         }
 
-        fn change_age_to(self, new_age: i32) {
+        fun change_age_to(self, new_age: i32) {
             self.age = new_age
         }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let mut p = Person { age: 123 }
 
         p.change_age_to(58)
@@ -2241,16 +2244,16 @@ fn static_method() -> anyhow::Result<()> {
     }
 
     impl Person {
-        fn new(age: i32): Person {
+        fun new(age: i32) -> Person {
             return Person { age: age }
         }
 
-        fn get_age(self): i32 {
+        fun get_age(self) -> i32 {
             return self.age
         }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let p = Person::new(58)
 
         return p.get_age()
@@ -2269,7 +2272,7 @@ fn create_simple_enum() -> anyhow::Result<()> {
         C,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = Simple::A
         let b = Simple::B
         let c = Simple::C
@@ -2290,7 +2293,7 @@ fn eq_ne_on_unit_enum_variants() -> anyhow::Result<()> {
         C,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = E::A
         let b = E::B
         let a2 = E::A
@@ -2319,7 +2322,7 @@ fn create_tagged_enum() -> anyhow::Result<()> {
         B(Fruits),
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let e1 = E::A
         let e2 = E::B(Fruits { apple: 48, ichigo: 10 })
         return 58
@@ -2337,7 +2340,7 @@ fn eq_on_tagged_enum_is_rejected() -> anyhow::Result<()> {
         B(i32),
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = E::A(1)
         let b = E::B(2)
         if a == b {
@@ -2359,7 +2362,7 @@ fn match_stmt_on_enum() -> anyhow::Result<()> {
         B,
     }
 
-    fn f(): i32 {
+    fun f() -> i32 {
         let e = E::B
 
         match e {
@@ -2370,7 +2373,7 @@ fn match_stmt_on_enum() -> anyhow::Result<()> {
         return 124
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let e = E::A
 
         match e {
@@ -2393,7 +2396,7 @@ fn match_on_enum() -> anyhow::Result<()> {
         B,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let e = E::A
 
         return match e {
@@ -2414,7 +2417,7 @@ fn match_on_enum_with_wildcard() -> anyhow::Result<()> {
         B,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let e = E::A
 
         return match e {
@@ -2440,7 +2443,7 @@ fn match_on_tagged_enum() -> anyhow::Result<()> {
         B(Fruits),
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let e = E::B(Fruits { apple: 48, ichigo: 10 })
 
         return match e {
@@ -2466,7 +2469,7 @@ fn match_on_tagged_enum_to_discard_value() -> anyhow::Result<()> {
         B(Fruits),
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let e = E::B(Fruits { apple: 48, ichigo: 10 })
 
         return match e {
@@ -2492,7 +2495,7 @@ fn match_on_tagged_enum_with_wildcard() -> anyhow::Result<()> {
         B(Fruits),
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let e = E::B(Fruits { apple: 48, ichigo: 10 })
 
         return match e {
@@ -2508,7 +2511,7 @@ fn match_on_tagged_enum_with_wildcard() -> anyhow::Result<()> {
 
 #[test]
 fn match_on_int_without_wildcard() {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let n = 25
 
         return match n {
@@ -2526,7 +2529,7 @@ fn match_on_int_without_wildcard() {
 
 #[test]
 fn match_on_int_with_wildcard() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let n = 58
 
         return match n {
@@ -2544,7 +2547,7 @@ fn match_on_int_with_wildcard() -> anyhow::Result<()> {
 
 #[test]
 fn match_on_bool_without_true() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let flag = false
 
         return match flag {
@@ -2562,7 +2565,7 @@ fn match_on_bool_without_true() -> anyhow::Result<()> {
 
 #[test]
 fn match_on_bool_without_false() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let flag = true
 
         return match flag {
@@ -2580,7 +2583,7 @@ fn match_on_bool_without_false() -> anyhow::Result<()> {
 
 #[test]
 fn match_on_bool() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let flag = true
 
         return match flag {
@@ -2596,7 +2599,7 @@ fn match_on_bool() -> anyhow::Result<()> {
 
 #[test]
 fn match_on_bool_with_wildcard() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let flag = true
 
         return match flag {
@@ -2618,7 +2621,7 @@ fn non_exhaustive_patterns() {
         C,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let e = E::A
 
         return match e {
@@ -2641,7 +2644,7 @@ fn duplicate_pattern() {
         B,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let e = E::A
 
         return match e {
@@ -2665,7 +2668,7 @@ fn enum_as_argument() -> anyhow::Result<()> {
         C,
     }
 
-    fn f(e: E): i32 {
+    fun f(e: E) -> i32 {
         return match e {
             E::A => 123,
             E::B => 124,
@@ -2673,7 +2676,7 @@ fn enum_as_argument() -> anyhow::Result<()> {
         }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         return f(E::C)
     }"#;
 
@@ -2694,14 +2697,14 @@ fn tagged_enum_as_argument() -> anyhow::Result<()> {
         B(Fruits),
     }
 
-    fn sum_fruits(e: E): i32 {
+    fun sum_fruits(e: E) -> i32 {
         return match e {
             E::A => 116,
             E::B(fruits) => fruits.apple + fruits.ichigo,
         }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let e1 = E::A
         let e2 = E::B(Fruits { apple: 48, ichigo: 10 })
         return sum_fruits(e1) - sum_fruits(e2)
@@ -2714,11 +2717,11 @@ fn tagged_enum_as_argument() -> anyhow::Result<()> {
 
 #[test]
 fn generic_function_with_single_parameter() -> anyhow::Result<()> {
-    let program = r#"fn add_10<T>(n: T):T {
+    let program = r#"fun add_10<T>(n: T) -> T {
         return n + 10
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         return add_10<i32>(48)
     }"#;
 
@@ -2729,7 +2732,7 @@ fn generic_function_with_single_parameter() -> anyhow::Result<()> {
 
 #[test]
 fn generic_function_with_multiple_parameters() -> anyhow::Result<()> {
-    let program = r#"fn add_or_mul<T1, T2, SwitchT>(n1: T1, n2: T2, switcher: SwitchT): T1 {
+    let program = r#"fun add_or_mul<T1, T2, SwitchT>(n1: T1, n2: T2, switcher: SwitchT) -> T1 {
         return if switcher {
             n1 + n2
         } else {
@@ -2737,7 +2740,7 @@ fn generic_function_with_multiple_parameters() -> anyhow::Result<()> {
         }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         return add_or_mul<i32, i32, bool>(48, 10, true)
     }"#;
 
@@ -2748,7 +2751,7 @@ fn generic_function_with_multiple_parameters() -> anyhow::Result<()> {
 
 #[test]
 fn generic_function_param_inference() -> anyhow::Result<()> {
-    let program = r#"fn add_or_mul<T1, T2, SwitchT>(n1: T1, n2: T2, switcher: SwitchT): T1 {
+    let program = r#"fun add_or_mul<T1, T2, SwitchT>(n1: T1, n2: T2, switcher: SwitchT) -> T1 {
         return if switcher {
             n1 + n2
         } else {
@@ -2756,7 +2759,7 @@ fn generic_function_param_inference() -> anyhow::Result<()> {
         }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         return add_or_mul(48, 10, true)
     }"#;
 
@@ -2767,11 +2770,11 @@ fn generic_function_param_inference() -> anyhow::Result<()> {
 
 #[test]
 fn generic_function_identity_param_inference() -> anyhow::Result<()> {
-    let program = r#"fn id<T>(x: T): T {
+    let program = r#"fun id<T>(x: T) -> T {
         return x
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         return id(58)
     }"#;
 
@@ -2786,11 +2789,11 @@ fn generic_function_with_struct_type() -> anyhow::Result<()> {
         n: i32,
     }
 
-    fn get_n<S>(o: S): i32 {
+    fun get_n<S>(o: S) -> i32 {
         return o.n
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let s = Sample { n: 58 }
         return get_n<Sample>(s)
     }"#;
@@ -2802,11 +2805,11 @@ fn generic_function_with_struct_type() -> anyhow::Result<()> {
 
 #[test]
 fn generic_function_with_tuple_type() -> anyhow::Result<()> {
-    let program = r#"fn get_third<T>(t: T): i32 {
+    let program = r#"fun get_third<T>(t: T) -> i32 {
         return t.2
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let tup = (48, 10, 58)
         return get_third<(i32, i32, i32)>(tup)
     }"#;
@@ -2818,11 +2821,11 @@ fn generic_function_with_tuple_type() -> anyhow::Result<()> {
 
 #[test]
 fn generic_function_with_array_type() -> anyhow::Result<()> {
-    let program = r#"fn get_third<T>(a: T): i32 {
+    let program = r#"fun get_third<T>(a: T) -> i32 {
         return a[2]
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = [48, 10, 58]
         return get_third<[i32; 3]>(a)
     }"#;
@@ -2837,7 +2840,7 @@ fn generic_struct_with_single_parameter() -> anyhow::Result<()> {
     let program = r#"struct A<T> {
         value: T,
     }
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = A<i32> { value: 58 }
 
         return a.value
@@ -2854,11 +2857,11 @@ fn generic_struct_as_function_argument() -> anyhow::Result<()> {
         n: T,
     }
 
-    fn get_n(s: Sample<i32>): i32 {
+    fun get_n(s: Sample<i32>) -> i32 {
         return s.n
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let s = Sample<i32> { n: 58 }
         return get_n(s)
     }"#;
@@ -2880,7 +2883,7 @@ fn generic_struct_with_multiple_parameters() -> anyhow::Result<()> {
     struct Number {
         value: i32,
     }
-    fn main(): i32 {
+    fun main() -> i32 {
         let fr1 = Fruits<i32, i32> { apple: 48, ichigo: 10 }
         let fr2 = Fruits<A<i32>, Number> { apple: A<i32> { value: 48 }, ichigo: Number { value: 10 } }
 
@@ -2901,10 +2904,10 @@ fn generic_struct_with_multiple_parameters() -> anyhow::Result<()> {
 
 #[test]
 fn block() -> anyhow::Result<()> {
-    let program = r#"fn f(): i32 {
+    let program = r#"fun f() -> i32 {
         return 58
     }
-    fn main(): i32 {
+    fun main() -> i32 {
         let n = {
             let a = 48
             let b = 10
@@ -2926,7 +2929,7 @@ fn block() -> anyhow::Result<()> {
 
 #[test]
 fn match_with_block() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let n = 58
 
         return match n {
@@ -2951,7 +2954,7 @@ fn match_unpack_unit_variant() {
         B,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let e = E::A
 
         return match e {
@@ -2968,9 +2971,9 @@ fn match_unpack_unit_variant() {
 
 #[test]
 fn c_ffi() -> anyhow::Result<()> {
-    let program = r#"extern "C" fn abs(n: i32): i32
+    let program = r#"extern "C" fun abs(n: i32) -> i32
 
-    fn main(): i32 {
+    fun main() -> i32 {
         return abs(-48) + abs(10)
     }"#;
 
@@ -2981,9 +2984,9 @@ fn c_ffi() -> anyhow::Result<()> {
 
 #[test]
 fn c_ffi_with_ptr_and_vararg() -> anyhow::Result<()> {
-    let program = r#"extern "C" fn printf(format: *u8, ...): i32
+    let program = r#"extern "C" fun printf(format: *u8, ...) -> i32
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let format = "%s%d\n"
         let n = printf(format.as_ptr(), "hello, ".as_ptr(), 58)
         return 48 + n
@@ -2997,16 +3000,16 @@ fn c_ffi_with_ptr_and_vararg() -> anyhow::Result<()> {
 #[test]
 fn method_for_i32() -> anyhow::Result<()> {
     let program = r#"impl i32 {
-        fn twice(self): i32 {
+        fun twice(self) -> i32 {
             return self * 2
         }
 
-        fn twice_then_add(self, n: i32): i32 {
+        fun twice_then_add(self, n: i32) -> i32 {
             return self.twice() + n
         }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let n = 14.twice_then_add(1)
         return n.twice()
     }"#;
@@ -3023,16 +3026,16 @@ fn method_forward_reference_in_same_impl() -> anyhow::Result<()> {
     }
 
     impl Counter {
-        fn value_plus_one(self): i32 {
+        fun value_plus_one(self) -> i32 {
             return self.plus(1)
         }
 
-        fn plus(self, add: i32): i32 {
+        fun plus(self, add: i32) -> i32 {
             return self.value + add
         }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         return Counter { value: 57 }.value_plus_one()
     }"#;
 
@@ -3043,12 +3046,12 @@ fn method_forward_reference_in_same_impl() -> anyhow::Result<()> {
 
 #[test]
 fn cast_integer() -> anyhow::Result<()> {
-    let program = r#"fn f(): i64 {
+    let program = r#"fun f() -> i64 {
         let n = 58
         return n as i64
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         return f() as i32
     }"#;
 
@@ -3059,7 +3062,7 @@ fn cast_integer() -> anyhow::Result<()> {
 
 #[test]
 fn all_integer_types_arithmetic_and_casts() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let i8v: i8 = 1
         let u8v: u8 = 2
         let i16v: i16 = 3
@@ -3088,7 +3091,7 @@ fn all_integer_types_arithmetic_and_casts() -> anyhow::Result<()> {
 
 #[test]
 fn cast_str_to_pointer() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let s = "hello, world" as *str as *u8
         return 58
     }"#;
@@ -3108,7 +3111,7 @@ fn single_variant_enum() -> anyhow::Result<()> {
         B(C),
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = A::B(C { apple: 58 })
 
         return match a {
@@ -3128,7 +3131,7 @@ fn generic_enum_with_single_parameter() -> anyhow::Result<()> {
         None,
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = Opt<i32>::Some(58)
 
         return match a {
@@ -3149,14 +3152,14 @@ fn generic_enum_as_function_argument() -> anyhow::Result<()> {
         None,
     }
 
-    fn get(opt: Opt<i32>): i32 {
+    fun get(opt: Opt<i32>) -> i32 {
         return match opt {
             Opt::Some(n) => n,
             Opt::None => 123,
         }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let opt = Opt<i32>::Some(58)
         return get(opt)
     }"#;
@@ -3173,7 +3176,7 @@ fn generic_enum_with_multiple_parameters() -> anyhow::Result<()> {
         Err(T2),
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let res1 = Res<i32, bool>::Err(false)
         let res2 = Res<i32, bool>::Ok(58)
 
@@ -3204,7 +3207,7 @@ fn omit_comma_at_end_of_struct_fields() -> anyhow::Result<()> {
         m: i32
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = S { n: 48, m: 10 }
         return a.n + a.m
     }"#;
@@ -3221,7 +3224,7 @@ fn omit_comma_at_end_of_enum_variants() -> anyhow::Result<()> {
         C(i32)
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = A::C(58)
 
         return match a {
@@ -3242,7 +3245,7 @@ fn omit_comma_at_end_of_match_arms() -> anyhow::Result<()> {
         C(i32),
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = A::C(58)
 
         return match a {
@@ -3258,7 +3261,7 @@ fn omit_comma_at_end_of_match_arms() -> anyhow::Result<()> {
 
 #[test]
 fn less_than_with_variables() -> anyhow::Result<()> {
-    let program = r#"fn main(): i32 {
+    let program = r#"fun main() -> i32 {
         let a = 48
         let b = 10
 
@@ -3282,14 +3285,14 @@ fn static_method_with_no_args() -> anyhow::Result<()> {
         size: i32,
     }
     impl A {
-        fn new(): A {
+        fun new() -> A {
             return A { size: 58 }
         }
-        fn get_size(self): i32 {
+        fun get_size(self) -> i32 {
             return self.size
         }
     }
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = A::new()
         return a.get_size()
     }"#;
@@ -3305,17 +3308,17 @@ fn generic_method() -> anyhow::Result<()> {
         value: T,
     }
     impl<T> A<T> {
-        fn new(value: T): A<T> {
+        fun new(value: T) -> A<T> {
             return A<T> { value: value }
         }
-        fn get_value(self): T {
+        fun get_value(self) -> T {
             return self.value
         }
-        fn is_equal(self, other: A<T>): bool {
+        fun is_equal(self, other: A<T>) -> bool {
             return self.value == other.value
         }
     }
-    fn main(): i32 {
+    fun main() -> i32 {
         let a = A<i32>::new(58)
         if a.is_equal(A<i32>::new(58)) {
             return a.get_value()
@@ -3334,17 +3337,17 @@ fn generic_method_forward_reference_in_same_impl() -> anyhow::Result<()> {
         value: T,
     }
     impl<T> Box<T> {
-        fn new(value: T): Box<T> {
+        fun new(value: T) -> Box<T> {
             return Box<T> { value: value }
         }
-        fn value_plus(self, add: i32): i32 {
+        fun value_plus(self, add: i32) -> i32 {
             return self.plus(add)
         }
-        fn plus(self, add: i32): i32 {
+        fun plus(self, add: i32) -> i32 {
             return self.value + add
         }
     }
-    fn main(): i32 {
+    fun main() -> i32 {
         let b = Box<i32>::new(48)
         return b.value_plus(10)
     }"#;
@@ -3356,7 +3359,7 @@ fn generic_method_forward_reference_in_same_impl() -> anyhow::Result<()> {
 
 #[test]
 fn complex_generic_struct_method() -> anyhow::Result<()> {
-    let program = r#"pub enum MyOption<T> {
+    let program = r#"export enum MyOption<T> {
         Some(T),
         None,
     }
@@ -3367,11 +3370,11 @@ fn complex_generic_struct_method() -> anyhow::Result<()> {
     }
 
     impl<T> MyList<T> {
-        fn new(): mut MyList<T> {
+        fun new() -> mut MyList<T> {
             return MyList<T> { value: MyOption<T>::None, next: MyOption<MyList<T>>::None }
         }
 
-        fn len(self): u32 {
+        fun len(self) -> u32 {
             return match self.next {
                 MyOption::Some(ne) => (1 as u32) + ne.len(),
                 MyOption::None => {
@@ -3383,7 +3386,7 @@ fn complex_generic_struct_method() -> anyhow::Result<()> {
             }
         }
 
-        fn push(mut self, elem: T) {
+        fun push(mut self, elem: T) {
             match self.next {
                 MyOption::Some(ne) => {
                     ne.push(elem)
@@ -3404,7 +3407,7 @@ fn complex_generic_struct_method() -> anyhow::Result<()> {
             }
         }
 
-        fn at(self, idx: u32): MyOption<T> {
+        fun at(self, idx: u32) -> MyOption<T> {
             return match self.next {
                 MyOption::Some(ne) => {
                     if idx == (0 as u32) {
@@ -3421,7 +3424,7 @@ fn complex_generic_struct_method() -> anyhow::Result<()> {
         }
     }
 
-    fn main(): i32 {
+    fun main() -> i32 {
         let mut v = MyList<i32>::new()
         v.push(48)
         v.push(10)
@@ -3455,7 +3458,7 @@ fn complex_generic_struct_method() -> anyhow::Result<()> {
 #[test]
 fn recursive_function() -> anyhow::Result<()> {
     let program = r#"
-        fn f(n: i32): i32 {
+        fun f(n: i32) -> i32 {
             if n == 10 {
                 return n
             }
@@ -3463,7 +3466,7 @@ fn recursive_function() -> anyhow::Result<()> {
             return f(n + 1)
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             return f(0)
         }
     "#;
@@ -3476,7 +3479,7 @@ fn recursive_function() -> anyhow::Result<()> {
 #[test]
 fn prelude() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut v = Vector<i32>::new()
             v.push(58)
             return match v.at(0) {
@@ -3494,7 +3497,7 @@ fn prelude() -> anyhow::Result<()> {
 #[test]
 fn prelude_vector_new_infers_type_from_push() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut v = Vector::new()
             v.push(58)
             return match v.at(0) {
@@ -3512,7 +3515,7 @@ fn prelude_vector_new_infers_type_from_push() -> anyhow::Result<()> {
 #[test]
 fn option_some_infers_type_without_explicit_args() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let opt = Option::Some(58)
             return match opt {
                 Option::Some(n) => n,
@@ -3529,7 +3532,7 @@ fn option_some_infers_type_without_explicit_args() -> anyhow::Result<()> {
 #[test]
 fn option_none_infers_type_without_explicit_args_from_return() -> anyhow::Result<()> {
     let program = r#"
-        fn maybe_number(flag: bool): Option<i32> {
+        fun maybe_number(flag: bool) -> Option<i32> {
             if flag {
                 return Option::Some(58)
             }
@@ -3537,7 +3540,7 @@ fn option_none_infers_type_without_explicit_args_from_return() -> anyhow::Result
             return Option::None
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             return match maybe_number(false) {
                 Option::Some(n) => n,
                 Option::None => 58,
@@ -3553,7 +3556,7 @@ fn option_none_infers_type_without_explicit_args_from_return() -> anyhow::Result
 #[test]
 fn option_none_infers_type_without_explicit_args_from_annotated_let() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let opt: Option<i32> = Option::None
             return match opt {
                 Option::Some(n) => n,
@@ -3570,14 +3573,14 @@ fn option_none_infers_type_without_explicit_args_from_annotated_let() -> anyhow:
 #[test]
 fn option_none_infers_type_without_explicit_args_from_fn_param() -> anyhow::Result<()> {
     let program = r#"
-        fn unwrap_or_default(opt: Option<i32>): i32 {
+        fun unwrap_or_default(opt: Option<i32>) -> i32 {
             return match opt {
                 Option::Some(n) => n,
                 Option::None => 58,
             }
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             return unwrap_or_default(Option::None)
         }
     "#;
@@ -3595,7 +3598,7 @@ fn generic_enum_unit_variant_infers_type_without_explicit_args() -> anyhow::Resu
             None,
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let opt: MyOption<i32> = MyOption::None
             return match opt {
                 MyOption::Some(value) => value,
@@ -3616,7 +3619,7 @@ fn vector_new_infers_struct_from_push() -> anyhow::Result<()> {
             x: i32,
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut v = Vector::new()
             v.push(S { x: 123 })
             return 58
@@ -3631,7 +3634,7 @@ fn vector_new_infers_struct_from_push() -> anyhow::Result<()> {
 #[test]
 fn vector_remove_preserves_order() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut v = Vector<i32>::new()
             v.push(10)
             v.push(20)
@@ -3674,7 +3677,7 @@ fn vector_remove_preserves_order() -> anyhow::Result<()> {
 #[test]
 fn vector_swap_remove_replaces_with_last() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut v = Vector<i32>::new()
             v.push(10)
             v.push(20)
@@ -3717,7 +3720,7 @@ fn vector_swap_remove_replaces_with_last() -> anyhow::Result<()> {
 #[test]
 fn vector_retain_accepts_capturing_closure() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut v = Vector<i32>::new()
             v.push(10)
             v.push(20)
@@ -3757,7 +3760,7 @@ fn vector_retain_accepts_capturing_closure() -> anyhow::Result<()> {
 #[test]
 fn vector_filter_accepts_capturing_closure() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut v = Vector<i32>::new()
             v.push(10)
             v.push(20)
@@ -3797,7 +3800,7 @@ fn vector_filter_accepts_capturing_closure() -> anyhow::Result<()> {
 #[test]
 fn string_push_line_appends_newline() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut out = String::new()
             out.push_line("alpha")
             out.push_line("beta")
@@ -3821,7 +3824,7 @@ fn option_some_infers_struct_without_explicit_args() -> anyhow::Result<()> {
             n: i32,
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let opt = Option::Some(S { n: 58 })
             return match opt {
                 Option::Some(v) => v.n,
@@ -3842,11 +3845,11 @@ fn hashmap_basic_crud() -> anyhow::Result<()> {
 
         use std.collections.hash_str
 
-        fn eq_str(a: str, b: str): bool {
+        fun eq_str(a: str, b: str) -> bool {
             return a == b
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut m = HashMap<str, i32>::new(hash_str, eq_str)
             if !m.is_empty() {
                 return 1
@@ -3903,11 +3906,11 @@ fn hashmap_overwrite_returns_old_value() -> anyhow::Result<()> {
 
         use std.collections.hash_str
 
-        fn eq_str(a: str, b: str): bool {
+        fun eq_str(a: str, b: str) -> bool {
             return a == b
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut m = HashMap<str, i32>::new(hash_str, eq_str)
 
             let r1 = m.insert("k", 11)
@@ -3945,7 +3948,7 @@ fn string_push_str_appends_text() -> anyhow::Result<()> {
 
         use std.string.String
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut out = String::from("kae")
             out.push_str("de")
 
@@ -3972,7 +3975,7 @@ fn string_clone_copies_contents() -> anyhow::Result<()> {
 
         use std.string.String
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut first = String::from("kae")
             let second = first.clone()
             first.push_str("de")
@@ -3998,18 +4001,18 @@ fn hashmap_collision_and_rehash() -> anyhow::Result<()> {
     let program = r#"
         import std.collections
 
-        fn hash_i32_const(n: i32): u64 {
+        fun hash_i32_const(n: i32) -> u64 {
             if n == -2147483648 {
                 return 1
             }
             return 1
         }
 
-        fn eq_i32(a: i32, b: i32): bool {
+        fun eq_i32(a: i32, b: i32) -> bool {
             return a == b
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut m = HashMap<i32, i32>::with_capacity(8, hash_i32_const, eq_i32)
 
             let mut i = 0
@@ -4056,7 +4059,7 @@ fn hashmap_collision_and_rehash() -> anyhow::Result<()> {
 #[test]
 fn string_indexing() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let s = "Hello, World!"
             return s[0] as i32
         }
@@ -4070,7 +4073,7 @@ fn string_indexing() -> anyhow::Result<()> {
 #[test]
 fn char_type() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let c1 = 'a'
             let c2 = "abc"[0]
             if c1 == c2 {
@@ -4088,7 +4091,7 @@ fn char_type() -> anyhow::Result<()> {
 #[test]
 fn unicode_string_indexing_returns_unicode_scalar() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let s = "aあb"
             if s[1] == 'あ' {
                 return 58
@@ -4108,7 +4111,7 @@ fn string_len_counts_unicode_scalars() -> anyhow::Result<()> {
 
         use std.string.String
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let s = String::from("aあb")
             if s.len() != 3 {
                 return 1
@@ -4130,7 +4133,7 @@ fn string_len_counts_unicode_scalars() -> anyhow::Result<()> {
 #[test]
 fn match_with_catch_all_and_non_catch_all() {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let n = 123
             return match n {
                 _ => 124
@@ -4153,11 +4156,11 @@ fn match_with_catch_all() -> anyhow::Result<()> {
             C,
         }
 
-        fn f(): i32 {
+        fun f() -> i32 {
             return 123
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let e = E::C
             return match e {
                 E::A => 124,
@@ -4181,7 +4184,7 @@ fn recursive_field_type_on_struct() -> anyhow::Result<()> {
             a: Option<A>,
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let a = A { a: Option<A>::None }
             return 123
         }
@@ -4201,7 +4204,7 @@ fn recursive_field_type_on_enum() -> anyhow::Result<()> {
             C(Option<E>),
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let e = E::C(Option<E>::None)
             return 123
         }
@@ -4219,7 +4222,7 @@ fn not_wrapped_option() {
             opt: Option<i32>,
         }
 
-        fn f(): i32 {
+        fun f() -> i32 {
             let test = Test {
                 opt: 123,
             }
@@ -4235,7 +4238,7 @@ fn not_wrapped_option() {
 #[test]
 fn shadowing_in_match_arms() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let n = Option<i32>::Some(123)
             return match n {
                 Option::Some(n) => n,
@@ -4252,11 +4255,11 @@ fn shadowing_in_match_arms() -> anyhow::Result<()> {
 #[test]
 fn bidirectional_type_inference() -> anyhow::Result<()> {
     let program = r#"
-        fn f(n: u64): i32 {
+        fun f(n: u64) -> i32 {
             return n as i32
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let n = 123
             return f(n) // n is inferred as u64
         }
@@ -4270,7 +4273,7 @@ fn bidirectional_type_inference() -> anyhow::Result<()> {
 #[test]
 fn add_assign() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut n: i32 = 10
             n += 20
             return n
@@ -4284,7 +4287,7 @@ fn add_assign() -> anyhow::Result<()> {
 #[test]
 fn sub_assign() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut n: i32 = 100
             n -= 45
             return n
@@ -4298,7 +4301,7 @@ fn sub_assign() -> anyhow::Result<()> {
 #[test]
 fn mul_assign() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut n: i32 = 29
             n *= 3
             return n
@@ -4312,7 +4315,7 @@ fn mul_assign() -> anyhow::Result<()> {
 #[test]
 fn div_assign() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut n: i32 = 116
             n /= 4
             return n
@@ -4326,7 +4329,7 @@ fn div_assign() -> anyhow::Result<()> {
 #[test]
 fn rem_assign() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut n: i32 = 117
             n %= 4
             return n
@@ -4340,7 +4343,7 @@ fn rem_assign() -> anyhow::Result<()> {
 #[test]
 fn closure_without_params_captures_values() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let a = 48
             let b = 10
 
@@ -4357,7 +4360,7 @@ fn closure_without_params_captures_values() -> anyhow::Result<()> {
 #[test]
 fn closure_with_param_and_captured_copy() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut base = 50
             let add = |n| base + n
             base = 0
@@ -4373,7 +4376,7 @@ fn closure_with_param_and_captured_copy() -> anyhow::Result<()> {
 #[test]
 fn closure_with_multiple_params() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let add = |a, b| a + b
             return add(48, 10)
         }
@@ -4389,7 +4392,7 @@ fn closure_with_captured_udt() -> anyhow::Result<()> {
             n: i32,
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut a = A { n: 48 }
             let f = |b| a.n + b
             a.n = 10
@@ -4408,12 +4411,12 @@ fn closure_with_captured_udt_method() -> anyhow::Result<()> {
         }
 
         impl A {
-            fn add(self, b: i32): i32 {
+            fun add(self, b: i32) -> i32 {
                 return self.n + b
             }
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let a = A { n: 123 }
             let f = |b| a.add(b)
             return f(10)
@@ -4426,7 +4429,7 @@ fn closure_with_captured_udt_method() -> anyhow::Result<()> {
 #[test]
 fn closure_with_block_body() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let a = 48
             let b = 10
             let add = || {
@@ -4442,7 +4445,7 @@ fn closure_with_block_body() -> anyhow::Result<()> {
 #[test]
 fn closure_with_explicit_return_value() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let add = |a, b| {
                 return a + b
             }
@@ -4456,12 +4459,12 @@ fn closure_with_explicit_return_value() -> anyhow::Result<()> {
 #[test]
 fn unit_closure_with_empty_return() -> anyhow::Result<()> {
     let program = r#"
-        fn call(f: fn()): i32 {
+        fun call(f: fun()) -> i32 {
             f()
             return 58
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             return call(|| {
                 return
             })
@@ -4474,11 +4477,11 @@ fn unit_closure_with_empty_return() -> anyhow::Result<()> {
 #[test]
 fn closure_type_as_function_param() -> anyhow::Result<()> {
     let program = r#"
-        fn apply(f: fn(i32) -> i32, x: i32): i32 {
+        fun apply(f: fun(i32) -> i32, x: i32) -> i32 {
             return f(x)
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             return apply(|n| n + 10, 48)
         }
     "#;
@@ -4490,8 +4493,8 @@ fn closure_type_as_function_param() -> anyhow::Result<()> {
 #[test]
 fn closure_type_as_variable() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
-            let f: fn(i32) -> i32 = |x| x + 1
+        fun main() -> i32 {
+            let f: fun(i32) -> i32 = |x| x + 1
             return f(57)
         }
     "#;
@@ -4503,11 +4506,11 @@ fn closure_type_as_variable() -> anyhow::Result<()> {
 #[test]
 fn closure_type_as_function_return_type() -> anyhow::Result<()> {
     let program = r#"
-        fn f(): fn(i32) -> i32 {
+        fun f() -> fun(i32) -> i32 {
             return |x| x + 1
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let g = f()
             return g(48)
         }
@@ -4519,11 +4522,11 @@ fn closure_type_as_function_return_type() -> anyhow::Result<()> {
 #[test]
 fn closure_type_with_generic_param() -> anyhow::Result<()> {
     let program = r#"
-        fn apply<T>(f: fn(T) -> T, x: T): T {
+        fun apply<T>(f: fun(T) -> T, x: T) -> T {
             return f(x)
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             return apply<i32>(|n| n + 10, 48)
         }
     "#;
@@ -4534,7 +4537,7 @@ fn closure_type_with_generic_param() -> anyhow::Result<()> {
 #[test]
 fn closure_immediate_call() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             return (|n| n + 1)(10)
         }
     "#;
@@ -4545,7 +4548,7 @@ fn closure_immediate_call() -> anyhow::Result<()> {
 #[test]
 fn closure_immediate_call_with_multiple_params() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             return (|x, y| x + y)(15, 25)
         }
     "#;
@@ -4556,7 +4559,7 @@ fn closure_immediate_call_with_multiple_params() -> anyhow::Result<()> {
 #[test]
 fn closure_immediate_call_nested() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             return (|x| (|y| x + y)(20))(30)
         }
     "#;
@@ -4567,11 +4570,11 @@ fn closure_immediate_call_nested() -> anyhow::Result<()> {
 #[test]
 fn closure_as_return_value_immediate_call() -> anyhow::Result<()> {
     let program = r#"
-        fn f(): fn(i32) -> i32 {
+        fun f() -> fun(i32) -> i32 {
             return |x| x + 1
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             return f()(20)
         }
     "#;
@@ -4582,11 +4585,11 @@ fn closure_as_return_value_immediate_call() -> anyhow::Result<()> {
 #[test]
 fn function_value_assigned_and_called() -> anyhow::Result<()> {
     let program = r#"
-        fn add(x: i32, y: i32): i32 {
+        fun add(x: i32, y: i32) -> i32 {
             return x + y
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let f = add
             return f(2, 3)
         }
@@ -4598,15 +4601,15 @@ fn function_value_assigned_and_called() -> anyhow::Result<()> {
 #[test]
 fn function_value_passed_as_argument() -> anyhow::Result<()> {
     let program = r#"
-        fn apply(f: fn(i32, i32) -> i32, x: i32, y: i32): i32 {
+        fun apply(f: fun(i32, i32) -> i32, x: i32, y: i32) -> i32 {
             return f(x, y)
         }
 
-        fn mul(x: i32, y: i32): i32 {
+        fun mul(x: i32, y: i32) -> i32 {
             return x * y
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             return apply(mul, 6, 7)
         }
     "#;
@@ -4617,16 +4620,16 @@ fn function_value_passed_as_argument() -> anyhow::Result<()> {
 #[test]
 fn function_and_closure_share_fn_type() -> anyhow::Result<()> {
     let program = r#"
-        fn apply_twice(f: fn(i32) -> i32, x: i32): i32 {
+        fun apply_twice(f: fun(i32) -> i32, x: i32) -> i32 {
             return f(f(x))
         }
 
-        fn inc(n: i32): i32 {
+        fun inc(n: i32) -> i32 {
             return n + 1
         }
 
-        fn main(): i32 {
-            let closure: fn(i32) -> i32 = |n| n + 2
+        fun main() -> i32 {
+            let closure: fun(i32) -> i32 = |n| n + 2
             return apply_twice(inc, 10) + apply_twice(closure, 0)
         }
     "#;
@@ -4644,14 +4647,14 @@ fn spawn_mutex_waitgroup() -> anyhow::Result<()> {
         use std.sync.WaitGroup
         use std.collections.Vector
 
-        fn worker(id: i32, lock: mut Mutex, wg: mut WaitGroup, xs: mut Vector<i32>) {
+        fun worker(id: i32, lock: mut Mutex, wg: mut WaitGroup, xs: mut Vector<i32>) {
             lock.lock()
             xs.push(id)
             lock.unlock()
             wg.done()
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut lock = Mutex::new()
             let mut wg = WaitGroup::new()
             let mut xs = Vector<i32>::new()
@@ -4687,22 +4690,22 @@ fn spawn_preserves_queued_gc_managed_args_during_collection() -> anyhow::Result<
         use std.collections.Vector
         use std.string.String
 
-        extern "C" fn GC_gcollect()
+        extern "C" fun GC_gcollect()
 
-        fn blocker(gate: mut Mutex, wg: mut WaitGroup) {
+        fun blocker(gate: mut Mutex, wg: mut WaitGroup) {
             gate.lock()
             gate.unlock()
             wg.done()
         }
 
-        fn consumer(msg: String, lock: mut Mutex, out: mut Vector<String>, wg: mut WaitGroup) {
+        fun consumer(msg: String, lock: mut Mutex, out: mut Vector<String>, wg: mut WaitGroup) {
             lock.lock()
             out.push(msg)
             lock.unlock()
             wg.done()
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut gate = Mutex::new()
             let mut lock = Mutex::new()
             let mut out = Vector<String>::new()
@@ -4761,7 +4764,7 @@ fn spawn_preserves_queued_gc_managed_args_during_collection() -> anyhow::Result<
 #[test]
 fn panic_basic() -> anyhow::Result<()> {
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             panic("Something went wrong")
             return 0
         }
@@ -4777,7 +4780,7 @@ fn panic_basic() -> anyhow::Result<()> {
 fn panic_never_type_in_if() -> anyhow::Result<()> {
     // Test that panic returns Never type and works in if expressions
     let program = r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let x = if false {
                 panic("unreachable")
             } else {
@@ -4800,7 +4803,7 @@ fn panic_never_type_in_match() -> anyhow::Result<()> {
             Err,
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let r = TestResult::Ok(58)
             let x = match r {
                 TestResult::Ok(v) => v,

--- a/compiler/driver/src/main.rs
+++ b/compiler/driver/src/main.rs
@@ -160,7 +160,7 @@ pub(crate) fn select_entry_unit(unit_infos: &mut [CompileUnitInfo]) -> anyhow::R
                 .collect::<Vec<_>>()
                 .join(", ");
             anyhow::bail!(
-                "Entry unit is ambiguous. Exactly one compile unit may contain top-level statements or `fn main`: {}",
+                "Entry unit is ambiguous. Exactly one compile unit may contain top-level statements or `fun main`: {}",
                 candidates
             )
         }

--- a/compiler/driver/src/new.rs
+++ b/compiler/driver/src/new.rs
@@ -16,7 +16,7 @@ fn create_kaede_only_project(project_dir: &Path, project_name: &str) -> anyhow::
     fs::create_dir_all(&src_dir)?;
     fs::write(
         src_dir.join("main.kd"),
-        r#"fn main() {
+        r#"fun main() {
     println("hello, world!")
 }"#,
     )?;
@@ -68,7 +68,7 @@ fn create_rust_bridge_project(project_dir: &Path, project_name: &str) -> anyhow:
     fs::write(
         src_dir.join("main.kd"),
         format!(
-            "import rust::{project_name}\n\nfn main(): i32 {{\n    return rust::{project_name}::add(10, 20)\n}}"
+            "import rust::{project_name}\n\nfun main() -> i32 {{\n    return rust::{project_name}::add(10, 20)\n}}"
         ),
     )?;
 

--- a/compiler/driver/tests/cli.rs
+++ b/compiler/driver/tests/cli.rs
@@ -40,7 +40,7 @@ fn new_creates_hello_world_main() -> anyhow::Result<()> {
     main.assert(predicate::path::is_file());
     assert_eq!(
         fs::read_to_string(main.path())?,
-        r#"fn main() {
+        r#"fun main() {
     println("hello, world!")
 }"#,
     );
@@ -55,7 +55,7 @@ fn direct_compile_uses_unique_entry_candidate_even_if_not_main_kd() -> anyhow::R
     let app = temp_dir.child("app.kd");
     let exe = temp_dir.child("a.out");
 
-    lib.write_str("fn helper(): i32 { return 0 }")?;
+    lib.write_str("fun helper() -> i32 { return 0 }")?;
     app.write_str("return 42")?;
 
     Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
@@ -83,7 +83,7 @@ fn direct_compile_fails_when_entry_candidate_is_ambiguous() -> anyhow::Result<()
     let exe = temp_dir.child("a.out");
 
     app1.write_str("return 1")?;
-    app2.write_str("fn main(): i32 { return 2 }")?;
+    app2.write_str("fun main() -> i32 { return 2 }")?;
 
     Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
         .args([
@@ -111,12 +111,12 @@ fn direct_compile_rejects_try_outside_result_function() -> anyhow::Result<()> {
         r#"import std.result
 use std.result.Result
 
-fn fail(): i32 {
+fun fail() -> i32 {
     value := Result::Ok(1)?;
     return value
 }
 
-fn main(): i32 {
+fun main() -> i32 {
     return fail()
 }"#,
     )?;

--- a/compiler/driver/tests/cli_args.rs
+++ b/compiler/driver/tests/cli_args.rs
@@ -31,9 +31,9 @@ use predicates::prelude::*;
 use std::process::Command;
 
 /// Test program that checks command line arguments with safe validation
-const TEST_PROGRAM: &str = r#"extern "C" fn strcmp(s1: *u8, s2: *u8): i32
+const TEST_PROGRAM: &str = r#"extern "C" fun strcmp(s1: *u8, s2: *u8) -> i32
 
-fn main(args: Vector<str>): i32 {
+fun main(args: Vector<str>) -> i32 {
     let mut i = 0
 
     // Check if we have enough arguments (program name + at least 1 argument)

--- a/compiler/driver/tests/import.rs
+++ b/compiler/driver/tests/import.rs
@@ -73,16 +73,16 @@ fn import_functions() -> anyhow::Result<()> {
     let tempdir = assert_fs::TempDir::new()?;
 
     let module1 = tempdir.child("m1.kd");
-    module1.write_str("pub fn f(): i32 { return 48 }")?;
+    module1.write_str("export fun f() -> i32 { return 48 }")?;
 
     let module2 = tempdir.child("m2.kd");
-    module2.write_str("pub fn f(): i32 { return 10 }")?;
+    module2.write_str("export fun f() -> i32 { return 10 }")?;
 
     let main = tempdir.child("main.kd");
     main.write_str(
         r#"import m1
         import m2
-        fn main(): i32 {
+        fun main() -> i32 {
             return m1.f() + m2.f()
         }"#,
     )?;
@@ -97,7 +97,7 @@ fn import_i32_methods() -> anyhow::Result<()> {
     let module = tempdir.child("m.kd");
     module.write_str(
         r#"impl i32 {
-            pub fn add(self, other: i32): i32 {
+            export fun add(self, other: i32) -> i32 {
                 return self + other
             }
         }"#,
@@ -106,7 +106,7 @@ fn import_i32_methods() -> anyhow::Result<()> {
     let main = tempdir.child("main.kd");
     main.write_str(
         r#"import m
-        fn main(): i32 {
+        fun main() -> i32 {
             return 48.add(10)
         }"#,
     )?;
@@ -120,12 +120,12 @@ fn import_i32_method_returning_imported_struct() -> anyhow::Result<()> {
 
     let module = tempdir.child("m.kd");
     module.write_str(
-        r#"pub struct Wrap {
+        r#"export struct Wrap {
             value: i32,
         }
 
         impl i32 {
-            pub fn to_wrap(self): Wrap {
+            export fun to_wrap(self) -> Wrap {
                 return Wrap { value: self }
             }
         }"#,
@@ -134,7 +134,7 @@ fn import_i32_method_returning_imported_struct() -> anyhow::Result<()> {
     let main = tempdir.child("main.kd");
     main.write_str(
         r#"import m
-        fn main(): i32 {
+        fun main() -> i32 {
             let w = 58.to_wrap()
             return w.value
         }"#,
@@ -149,15 +149,15 @@ fn import_struct_methods() -> anyhow::Result<()> {
 
     let module1 = tempdir.child("m1.kd");
     module1.write_str(
-        r#"pub struct Apple {
+        r#"export struct Apple {
             size: i32,
         }
         impl Apple {
-            pub fn new(size: i32): Apple {
+            export fun new(size: i32) -> Apple {
                 return Apple { size: size }
             }
 
-            pub fn is_orange(self): bool {
+            export fun is_orange(self) -> bool {
                 return false
             }
         }"#,
@@ -165,11 +165,11 @@ fn import_struct_methods() -> anyhow::Result<()> {
 
     let module2 = tempdir.child("m2.kd");
     module2.write_str(
-        r#"pub struct Ichigo {
+        r#"export struct Ichigo {
             size: i32,
         }
         impl Ichigo {
-            pub fn get_size(self): i32 {
+            export fun get_size(self) -> i32 {
                 return self.size
             }
         }
@@ -180,7 +180,7 @@ fn import_struct_methods() -> anyhow::Result<()> {
     main.write_str(
         r#"import m1
         import m2
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = m1.Apple::new(48);
             let ichigo = m2.Ichigo { size: 10 }
             if !apple.is_orange() {
@@ -199,15 +199,15 @@ fn import_struct_methods_with_arg_of_self_type() -> anyhow::Result<()> {
 
     let module = tempdir.child("m.kd");
     module.write_str(
-        r#"pub struct Apple {
+        r#"export struct Apple {
             size: i32,
         }
         impl Apple {
-            pub fn new(size: i32): Apple {
+            export fun new(size: i32) -> Apple {
                 return Apple { size: size }
             }
 
-            pub fn equals(self, other: Apple): bool {
+            export fun equals(self, other: Apple) -> bool {
                 return self.size == other.size
             }
         }"#,
@@ -216,7 +216,7 @@ fn import_struct_methods_with_arg_of_self_type() -> anyhow::Result<()> {
     let main = tempdir.child("main.kd");
     main.write_str(
         r#"import m
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = m.Apple::new(48);
             let ichigo = m.Apple::new(10);
             if !apple.equals(ichigo) {
@@ -235,7 +235,7 @@ fn import_struct_methods_with_name_conflict() -> anyhow::Result<()> {
 
     let module = tempdir.child("m1.kd");
     module.write_str(
-        r#"pub struct Apple {
+        r#"export struct Apple {
             size: i32,
         }"#,
     )?;
@@ -246,7 +246,7 @@ fn import_struct_methods_with_name_conflict() -> anyhow::Result<()> {
         struct Apple {
             size: i32,
         }
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple1 = m1.Apple { size: 48 };
             let apple2 = Apple { size: 10 }
             return apple1.size + apple2.size
@@ -262,7 +262,7 @@ fn imported_typed_member() -> anyhow::Result<()> {
 
     let module = tempdir.child("m.kd");
     module.write_str(
-        r#"pub struct Apple {
+        r#"export struct Apple {
             size: i32,
         }"#,
     )?;
@@ -273,7 +273,7 @@ fn imported_typed_member() -> anyhow::Result<()> {
         struct Fruit {
             apple: m.Apple,
         }
-        fn main(): i32 {
+        fun main() -> i32 {
             let fruit = Fruit { apple: m.Apple { size: 58 } }
             return fruit.apple.size
         }"#,
@@ -288,7 +288,7 @@ fn import_enum() -> anyhow::Result<()> {
 
     let module = tempdir.child("m.kd");
     module.write_str(
-        r#"pub enum Fruit {
+        r#"export enum Fruit {
             Apple(i32),
             Orange,
         }"#,
@@ -297,7 +297,7 @@ fn import_enum() -> anyhow::Result<()> {
     let main = tempdir.child("main.kd");
     main.write_str(
         r#"import m
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = m.Fruit::Apple(58);
 
             match apple {
@@ -320,15 +320,15 @@ fn import_enum_methods() -> anyhow::Result<()> {
 
     let module = tempdir.child("m.kd");
     module.write_str(
-        r#"pub enum Fruit {
+        r#"export enum Fruit {
             Apple(i32),
             Orange,
         }
         impl Fruit {
-            pub fn new(s: i32): mut Fruit {
+            export fun new(s: i32) -> mut Fruit {
                 return Fruit::Apple(s)
             }
-            pub fn get(self): i32 {
+            export fun get(self) -> i32 {
                 return match self {
                     Fruit::Apple(s) => s,
                     Fruit::Orange => 123
@@ -340,7 +340,7 @@ fn import_enum_methods() -> anyhow::Result<()> {
     let main = tempdir.child("main.kd");
     main.write_str(
         r#"import m
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = m.Fruit::new(58)
             return apple.get()
         }"#,
@@ -355,11 +355,11 @@ fn import_complex_enum() -> anyhow::Result<()> {
 
     let module = tempdir.child("m.kd");
     module.write_str(
-        r#"pub struct Apple {
+        r#"export struct Apple {
             size: i32,
         }
 
-        pub enum Fruit {
+        export enum Fruit {
             Apple(Apple),
             Ichigo(i32),
         }"#,
@@ -368,7 +368,7 @@ fn import_complex_enum() -> anyhow::Result<()> {
     let main = tempdir.child("main.kd");
     main.write_str(
         r#"import m
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = m.Fruit::Apple(m.Apple { size: 48 });
             let ichigo = m.Fruit::Ichigo(10);
 
@@ -397,11 +397,11 @@ fn enum_with_imported_struct() -> anyhow::Result<()> {
 
     let module = tempdir.child("m.kd");
     module.write_str(
-        r#"pub struct Apple {
+        r#"export struct Apple {
             size: i32,
         }
         impl Apple {
-            pub fn get_size(self): i32 {
+            export fun get_size(self) -> i32 {
                 return self.size
             }
         }"#,
@@ -415,7 +415,7 @@ fn enum_with_imported_struct() -> anyhow::Result<()> {
             Ichigo(i32),
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = Fruit::Apple(m.Apple { size: 48 });
             let ichigo = Fruit::Ichigo(10);
 
@@ -444,17 +444,17 @@ fn import_enum_and_call_variant_method() -> anyhow::Result<()> {
 
     let module = tempdir.child("m.kd");
     module.write_str(
-        r#"pub struct Apple {
+        r#"export struct Apple {
             size: i32,
         }
 
         impl Apple {
-            pub fn get_size(self): i32 {
+            export fun get_size(self) -> i32 {
                 return self.size
             }
         }
 
-        pub enum Fruit {
+        export enum Fruit {
             Apple(Apple),
             Ichigo(i32),
         }"#,
@@ -463,7 +463,7 @@ fn import_enum_and_call_variant_method() -> anyhow::Result<()> {
     let main = tempdir.child("main.kd");
     main.write_str(
         r#"import m
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = m.Fruit::Apple(m.Apple { size: 58 });
 
             match apple {
@@ -486,11 +486,11 @@ fn nested_import() -> anyhow::Result<()> {
 
     let m1 = tempdir.child("m1.kd");
     m1.write_str(
-        r#"pub struct Apple {
+        r#"export struct Apple {
             size: i32,
         }
 
-        pub enum Fruit {
+        export enum Fruit {
             Apple(Apple),
             Ichigo(i32),
         }"#,
@@ -499,17 +499,17 @@ fn nested_import() -> anyhow::Result<()> {
     let m2 = tempdir.child("m2.kd");
     m2.write_str(
         r#"import m1
-        pub fn get_value(fruit: m1.Fruit): i32 {
+        export fun get_value(fruit: m1.Fruit) -> i32 {
             return match fruit {
                 m1.Fruit::Apple(a) => a.size,
                 m1.Fruit::Ichigo(n) => n,
             }
         }
-        pub fn f(): i32 {
+        export fun f() -> i32 {
             let fruit = m1.Fruit::Apple(m1.Apple { size: 48 });
             return get_value(fruit)
         }
-        pub fn g(): i32 {
+        export fun g() -> i32 {
             let fruit = m1.Fruit::Ichigo(10);
             return get_value(fruit)
         }"#,
@@ -518,7 +518,7 @@ fn nested_import() -> anyhow::Result<()> {
     let main = tempdir.child("main.kd");
     main.write_str(
         r#"import m2
-        fn main(): i32 {
+        fun main() -> i32 {
             return m2.f() + m2.g()
         }"#,
     )?;
@@ -533,29 +533,29 @@ fn import_generic_struct_methods() -> anyhow::Result<()> {
     let module = tempdir.child("m.kd");
     module
         .write_str(
-            r#"pub struct Apple<T> {
+            r#"export struct Apple<T> {
             height: T,
             width: T,
         }
 
         impl<T> Apple<T> {
-            pub fn new(height: T, width: T): mut Apple<T> {
+            export fun new(height: T, width: T) -> mut Apple<T> {
                 return Apple<T> { height: height, width: width }
             }
 
-            pub fn set_height(mut self, height: T) {
+            export fun set_height(mut self, height: T) {
                 self.height = height
             }
 
-            pub fn set_width(mut self, width: T) {
+            export fun set_width(mut self, width: T) {
                 self.width = width
             }
 
-            pub fn get_height(self): i32 {
+            export fun get_height(self) -> i32 {
                 return self.height
             }
 
-            pub fn get_width(self): i32 {
+            export fun get_width(self) -> i32 {
                 return self.width
             }
         }"#,
@@ -565,7 +565,7 @@ fn import_generic_struct_methods() -> anyhow::Result<()> {
     let main = tempdir.child("main.kd");
     main.write_str(
         r#"import m
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut apple = m.Apple<i32>::new(123, 456)
             apple.set_height(48)
             apple.set_width(10)
@@ -584,17 +584,17 @@ fn import_generic_enum_methods_with_arg_of_self_type() -> anyhow::Result<()> {
     let module = tempdir.child("m.kd");
     module
         .write_str(
-            r#"pub enum Apple<T> {
+            r#"export enum Apple<T> {
             Ringo(i32),
             Budo,
         }
 
         impl<T> Apple<T> {
-            pub fn new_ringo(size: T): mut Apple<T> {
+            export fun new_ringo(size: T) -> mut Apple<T> {
                 return Apple<T>::Ringo(size)
             }
 
-            pub fn add(self, other: Apple<T>): T {
+            export fun add(self, other: Apple<T>) -> T {
                 let self_size = match self {
                     Apple::Ringo(s) => s,
                     Apple::Budo => 123,
@@ -612,7 +612,7 @@ fn import_generic_enum_methods_with_arg_of_self_type() -> anyhow::Result<()> {
     let main = tempdir.child("main.kd");
     main.write_str(
         r#"import m
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = m.Apple<i32>::new_ringo(48)
             return apple.add(m.Apple<i32>::new_ringo(10))
         }"#,
@@ -629,21 +629,21 @@ fn import_generic_methods_with_arg_of_self_type() -> anyhow::Result<()> {
     let module = tempdir.child("m.kd");
     module
         .write_str(
-            r#"pub struct Apple<T> {
+            r#"export struct Apple<T> {
             height: T,
             width: T,
         }
 
         impl<T> Apple<T> {
-            pub fn new(height: T, width: T): mut Apple<T> {
+            export fun new(height: T, width: T) -> mut Apple<T> {
                 return Apple<T> { height: height, width: width }
             }
 
-            pub fn get(self): T {
+            export fun get(self) -> T {
                 return self.height + self.width
             }
 
-            pub fn equals(self, other: Apple<T>): bool {
+            export fun equals(self, other: Apple<T>) -> bool {
                 return self.height == other.height && self.width == other.width
             }
         }"#,
@@ -653,7 +653,7 @@ fn import_generic_methods_with_arg_of_self_type() -> anyhow::Result<()> {
     let main = tempdir.child("main.kd");
     main.write_str(
         r#"import m
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = m.Apple<i32>::new(48, 10)
             if apple.equals(m.Apple<i32>::new(48, 10)) {
                 return apple.get()
@@ -672,11 +672,11 @@ fn import_function_with_arg_of_external_struct() -> anyhow::Result<()> {
 
     let module1 = tempdir.child("m1.kd");
     module1.write_str(
-        r#"pub struct Apple {
+        r#"export struct Apple {
             size: i32,
         }
 
-        pub fn get_size(apple: Apple): i32 {
+        export fun get_size(apple: Apple) -> i32 {
             return apple.size
         }"#,
     )?;
@@ -684,7 +684,7 @@ fn import_function_with_arg_of_external_struct() -> anyhow::Result<()> {
     let module2 = tempdir.child("m2.kd");
     module2.write_str(
         r#"import m1
-        fn main(): i32 {
+        fun main() -> i32 {
             return m1.get_size(m1.Apple { size: 58 })
         }"#,
     )?;
@@ -698,12 +698,12 @@ fn import_function_with_arg_of_external_enum() -> anyhow::Result<()> {
 
     let module1 = tempdir.child("m1.kd");
     module1.write_str(
-        r#"pub enum Apple {
+        r#"export enum Apple {
             Ringo(i32),
             Budo,
         }
 
-        pub fn get_size(apple: Apple): i32 {
+        export fun get_size(apple: Apple) -> i32 {
             return match apple {
                 Apple::Ringo(s) => s,
                 Apple::Budo => 123,
@@ -714,7 +714,7 @@ fn import_function_with_arg_of_external_enum() -> anyhow::Result<()> {
     let module2 = tempdir.child("m2.kd");
     module2.write_str(
         r#"import m1
-        fn main(): i32 {
+        fun main() -> i32 {
             return m1.get_size(m1.Apple::Ringo(58))
         }"#,
     )?;
@@ -728,30 +728,30 @@ fn use_declaration() -> anyhow::Result<()> {
 
     let module1 = tempdir.child("m1.kd");
     module1.write_str(
-        r#"pub fn get_58(): i32 {
+        r#"export fun get_58() -> i32 {
             return 58
         }
 
-        pub struct Apple {
+        export struct Apple {
             size: i32,
         }
 
         impl Apple {
-            pub fn new(size: i32): Apple {
+            export fun new(size: i32) -> Apple {
                 return Apple { size: size }
             }
 
-            pub fn get_size(self): i32 {
+            export fun get_size(self) -> i32 {
                 return self.size
             }
         }
 
-        pub enum Fruit {
+        export enum Fruit {
             Ringo(Apple)
         }
 
         impl Fruit {
-            pub fn get_size(self): i32 {
+            export fun get_size(self) -> i32 {
                 return match self {
                     Fruit::Ringo(a) => a.get_size()
                 }
@@ -765,7 +765,7 @@ fn use_declaration() -> anyhow::Result<()> {
         use m1.Apple
         use m1.get_58
         use m1.Fruit
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = Apple::new(58)
             let fruit = Fruit::Ringo(apple)
             let size = fruit.get_size()
@@ -785,16 +785,16 @@ fn use_declaration_with_generic_struct() -> anyhow::Result<()> {
 
     let module1 = tempdir.child("m1.kd");
     module1.write_str(
-        r#"pub struct Apple<T> {
+        r#"export struct Apple<T> {
             size: T,
         }
 
         impl<T> Apple<T> {
-            pub fn new(size: T): Apple<T> {
+            export fun new(size: T) -> Apple<T> {
                 return Apple<T> { size: size }
             }
 
-            pub fn get_size(self): T {
+            export fun get_size(self) -> T {
                 return self.size
             }
         }"#,
@@ -804,7 +804,7 @@ fn use_declaration_with_generic_struct() -> anyhow::Result<()> {
     module2.write_str(
         r#"import m1
         use m1.Apple
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = Apple<i32>::new(58)
             return apple.get_size()
         }"#,
@@ -819,17 +819,17 @@ fn use_declaration_with_generic_enum() -> anyhow::Result<()> {
 
     let module1 = tempdir.child("m1.kd");
     module1.write_str(
-        r#"pub enum Apple<T> {
+        r#"export enum Apple<T> {
             Ringo(T),
             Budo,
         }
 
         impl<T> Apple<T> {
-            pub fn new_ringo(size: T): Apple<T> {
+            export fun new_ringo(size: T) -> Apple<T> {
                 return Apple<T>::Ringo(size)
             }
 
-            pub fn get_size(self): T {
+            export fun get_size(self) -> T {
                 return match self {
                     Apple::Ringo(s) => s,
                     Apple::Budo => 123,
@@ -842,7 +842,7 @@ fn use_declaration_with_generic_enum() -> anyhow::Result<()> {
     module2.write_str(
         r#"import m1
         use m1.Apple
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = Apple<i32>::new_ringo(58)
             return apple.get_size()
         }"#,
@@ -857,16 +857,16 @@ fn import_module_in_directory() -> anyhow::Result<()> {
 
     let module1 = tempdir.child("dir/m1.kd");
     module1.write_str(
-        "pub struct Apple { size: i32 }
-        pub enum Fruit { Ringo(Apple), Ichigo(i32) }
-        pub fn get_58(): i32 { return 58 }",
+        "export struct Apple { size: i32 }
+        export enum Fruit { Ringo(Apple), Ichigo(i32) }
+        export fun get_58() -> i32 { return 58 }",
     )?;
 
     let module2 = tempdir.child("m2.kd");
     module2.write_str(
         r#"import dir.m1
         use dir.m1.Fruit
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = Fruit::Ringo(dir.m1.Apple { size: 58 });
             let n = match apple {
                 Fruit::Ringo(a) => a.size,
@@ -888,7 +888,7 @@ fn import_hierarchical_module() -> anyhow::Result<()> {
 
     let module1 = tempdir.child("dir/dir2/m1.kd");
     module1.write_str(
-        "pub struct Apple {
+        "export struct Apple {
             size: i32,
         }",
     )?;
@@ -896,21 +896,21 @@ fn import_hierarchical_module() -> anyhow::Result<()> {
     let module2 = tempdir.child("dir/dir2/m2.kd");
     module2.write_str(
         "import m1
-        pub enum Fruit { Ringo(m1.Apple), Ichigo(i32) }
-        pub fn get_48(): i32 { return 48 }
-        pub fn get_10(): i32 { return 10 }",
+        export enum Fruit { Ringo(m1.Apple), Ichigo(i32) }
+        export fun get_48() -> i32 { return 48 }
+        export fun get_10() -> i32 { return 10 }",
     )?;
 
     let module3 = tempdir.child("dir/dir2/m3.kd");
     module3.write_str(
         "import m2
-        pub fn get_58(): i32 { return m2.get_48() + m2.get_10() }",
+        export fun get_58() -> i32 { return m2.get_48() + m2.get_10() }",
     )?;
 
     let module4 = tempdir.child("dir/m.kd");
     module4.write_str(
         r#"import dir2.m3
-        pub fn f(): i32 {
+        export fun f() -> i32 {
             return dir2.m3.get_58()
         }"#,
     )?;
@@ -922,7 +922,7 @@ fn import_hierarchical_module() -> anyhow::Result<()> {
         import dir.dir2.m3
         import dir.m
         use dir.dir2.m2.Fruit
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = Fruit::Ringo(dir.dir2.m1.Apple { size: 58 });
             let n = match apple {
                 Fruit::Ringo(a) => a.size,
@@ -955,15 +955,15 @@ fn import_same_name_module_with_same_name_struct() -> anyhow::Result<()> {
     let module1 = tempdir.child("dir/m.kd");
     module1
         .write_str(
-            r#"pub struct Apple {
+            r#"export struct Apple {
             size: i32,
         }
 
         impl Apple {
-            pub fn new_ringo(size: i32): Apple {
+            export fun new_ringo(size: i32) -> Apple {
                 return Apple { size: 58 }
             }
-            pub fn get_size(self): i32 {
+            export fun get_size(self) -> i32 {
                 return self.size
             }
         }"#,
@@ -980,12 +980,12 @@ fn import_same_name_module_with_same_name_struct() -> anyhow::Result<()> {
         }
 
         impl Apple {
-            fn get(self): i32 {
+            fun get(self) -> i32 {
                 return self.width + self.height
             }
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = dir.m.Apple::new_ringo(58)
             let apple2 = Apple { width: 48, height: 10 }
 
@@ -1007,16 +1007,16 @@ fn import_generic_struct_from_module_in_directory() -> anyhow::Result<()> {
     let module1 = tempdir.child("dir/m.kd");
     module1
         .write_str(
-            r#"pub struct Apple<T> {
+            r#"export struct Apple<T> {
             size: T,
         }
 
         impl<T> Apple<T> {
-            pub fn new(size: T): Apple<T> {
+            export fun new(size: T) -> Apple<T> {
                 return Apple<T> { size: size }
             }
 
-            pub fn get_size(self): T {
+            export fun get_size(self) -> T {
                 return self.size
             }
         }"#,
@@ -1027,7 +1027,7 @@ fn import_generic_struct_from_module_in_directory() -> anyhow::Result<()> {
     module2
         .write_str(
             r#"import dir.m
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = dir.m.Apple<i32>::new(58)
             return apple.get_size()
         }"#,
@@ -1049,12 +1049,12 @@ fn import_function_with_non_public_generic_struct() -> anyhow::Result<()> {
         }
 
         impl<T> Apple<T> {
-            fn new(size: T): Apple {
+            fun new(size: T) -> Apple {
                 return Apple { size: size }
             }
         }
 
-        pub fn get_58(): i32 {
+        export fun get_58() -> i32 {
             return 58
         }"#,
         )
@@ -1064,7 +1064,7 @@ fn import_function_with_non_public_generic_struct() -> anyhow::Result<()> {
     module2
         .write_str(
             r#"import m1
-        fn main(): i32 {
+        fun main() -> i32 {
             return m1.get_58()
         }"#,
         )
@@ -1080,12 +1080,12 @@ fn import_generic_struct_and_impl_with_use_declaration() -> anyhow::Result<()> {
     let module1 = tempdir.child("dir/m.kd");
     module1
         .write_str(
-            r#"pub enum Apple<T> {
+            r#"export enum Apple<T> {
                 Ringo(T),
                 Mango,
             }
             impl<T> Apple<T> {
-                pub fn get_size(self): T {
+                export fun get_size(self) -> T {
                     return match self {
                         Apple::Ringo(s) => s,
                         Apple::Mango => 123,
@@ -1101,17 +1101,17 @@ fn import_generic_struct_and_impl_with_use_declaration() -> anyhow::Result<()> {
             r#"import dir.m
             use dir.m.Apple
 
-            pub struct Test<T> {
+            export struct Test<T> {
                 age: Apple<T>,
             }
 
             impl<T> Test<T> {
-                pub fn new(): Test<T> {
+                export fun new() -> Test<T> {
                     let apple = Apple<T>::Ringo(58)
                     return Test<T> { age: apple }
                 }
 
-                pub fn get_age(self): Apple<T> {
+                export fun get_age(self) -> Apple<T> {
                     return self.age
                 }
             }"#,
@@ -1122,7 +1122,7 @@ fn import_generic_struct_and_impl_with_use_declaration() -> anyhow::Result<()> {
     module3
         .write_str(
             r#"import m2
-            fn main(): i32 {
+            fun main() -> i32 {
                 let test = m2.Test<i32>::new()
                 let age = test.get_age()
                 return age.get_size()
@@ -1144,12 +1144,12 @@ fn import_function_returning_external_struct_with_methods() -> anyhow::Result<()
     // m2.kd - defines a public struct with methods
     let m2 = tempdir.child("m2.kd");
     m2.write_str(
-        r#"pub struct Person {
+        r#"export struct Person {
             age: i32
         }
 
         impl Person {
-            pub fn get_age(self): i32 {
+            export fun get_age(self) -> i32 {
                 return self.age
             }
         }"#,
@@ -1161,7 +1161,7 @@ fn import_function_returning_external_struct_with_methods() -> anyhow::Result<()
         r#"import m2
         use m2.Person
 
-        pub fn create_person(): Person {
+        export fun create_person() -> Person {
             return Person { age: 58 }
         }"#,
     )?;
@@ -1171,7 +1171,7 @@ fn import_function_returning_external_struct_with_methods() -> anyhow::Result<()
     test_m.write_str(
         r#"import m1
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let p = m1.create_person()
             return p.get_age()
         }"#,
@@ -1187,13 +1187,13 @@ fn import_generic_symbol_multiply_defined_linkonce_odr() -> anyhow::Result<()> {
     // m2.kd - defines a generic enum with implementation
     let m2 = tempdir.child("m2.kd");
     m2.write_str(
-        r#"pub enum Person<T> {
+        r#"export enum Person<T> {
             Bob(T),
             Alice,
         }
 
         impl<T> Person<T> {
-            pub fn get_age(self): T {
+            export fun get_age(self) -> T {
                 return match self {
                     Person::Bob(n) => n,
                     Person::Alice => 3,
@@ -1208,7 +1208,7 @@ fn import_generic_symbol_multiply_defined_linkonce_odr() -> anyhow::Result<()> {
         r#"import m2
         use m2.Person
 
-        pub fn create_person(): Person<i32> {
+        export fun create_person() -> Person<i32> {
             return Person<i32>::Bob(58)
         }"#,
     )?;
@@ -1218,7 +1218,7 @@ fn import_generic_symbol_multiply_defined_linkonce_odr() -> anyhow::Result<()> {
     test_m.write_str(
         r#"import m1
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let p = m1.create_person()
             return p.get_age()
         }"#,
@@ -1232,12 +1232,12 @@ fn import_extern_c() -> anyhow::Result<()> {
     let tempdir = assert_fs::TempDir::new()?;
 
     let extern_c = tempdir.child("extern_c.kd");
-    extern_c.write_str(r#"pub extern "C" fn printf(format: *u8, ...): i32"#)?;
+    extern_c.write_str(r#"export extern "C" fun printf(format: *u8, ...) -> i32"#)?;
 
     let module = tempdir.child("m.kd");
     module.write_str(
         r#"import extern_c
-        fn main(): i32 {
+        fun main() -> i32 {
             return extern_c.printf("Hello, world!\n".as_ptr())
         }"#,
     )?;
@@ -1251,21 +1251,21 @@ fn import_and_use_with_wildcard() -> anyhow::Result<()> {
 
     let module = tempdir.child("m.kd");
     module.write_str(
-        r#"pub struct Apple {
+        r#"export struct Apple {
             size: i32,
         }
 
         impl Apple {
-            pub fn get_size(self): i32 {
+            export fun get_size(self) -> i32 {
                 return self.size
             }
         }
 
-        pub fn f(): Apple {
+        export fun f() -> Apple {
             return Apple { size: 10 }
         }
 
-        pub fn g(a: Apple): i32 {
+        export fun g(a: Apple) -> i32 {
             return a.get_size()
         }"#,
     )?;
@@ -1274,7 +1274,7 @@ fn import_and_use_with_wildcard() -> anyhow::Result<()> {
     main.write_str(
         r#"import m
         use m.*
-        fn main(): i32 {
+        fun main() -> i32 {
             let apple = Apple { size: 20 }
             return f().get_size() + g(apple)
         }"#,
@@ -1289,7 +1289,7 @@ fn call_imported_function_with_local_variable() -> anyhow::Result<()> {
 
     let module = tempdir.child("m.kd");
     module.write_str(
-        r#"pub fn f(n: i32): i32 {
+        r#"export fun f(n: i32) -> i32 {
             return n
         }"#,
     )?;
@@ -1297,7 +1297,7 @@ fn call_imported_function_with_local_variable() -> anyhow::Result<()> {
     let main = tempdir.child("test.kd");
     main.write_str(
         r#"import m
-        fn main(): i32 {
+        fun main() -> i32 {
             let n = 10
             return m.f(n)
         }"#,
@@ -1330,7 +1330,7 @@ pub fn touch() {}"#,
     main.write_str(
         r#"import rust::primitive_probe
 
-        fn main(): i32 {
+        fun main() -> i32 {
             rust::primitive_probe::touch()
 
             if rust::primitive_probe::add_i8(20 as i8, 22 as i8) != (42 as i8) {
@@ -1383,7 +1383,7 @@ fn import_rust_function_with_str_param() -> anyhow::Result<()> {
     main.write_str(
         r#"import rust::str_probe
 
-        fn main(): i32 {
+        fun main() -> i32 {
             return rust::str_probe::strlen("hello")
         }"#,
     )?;
@@ -1406,7 +1406,7 @@ fn import_rust_function_with_multiple_str_params() -> anyhow::Result<()> {
     main.write_str(
         r#"import rust::multi_str_probe
 
-        fn main(): i32 {
+        fun main() -> i32 {
             return rust::multi_str_probe::total_len("kae", "de")
         }"#,
     )?;
@@ -1429,7 +1429,7 @@ fn import_rust_function_with_str_and_primitives() -> anyhow::Result<()> {
     main.write_str(
         r#"import rust::mixed_str_probe
 
-        fn main(): i32 {
+        fun main() -> i32 {
             if rust::mixed_str_probe::starts_with_len("kaede", 5) {
                 return 58
             }
@@ -1458,7 +1458,7 @@ pub fn unicode() -> String { "あ".to_string() }"#,
     main.write_str(
         r#"import rust::string_probe
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let greet = rust::string_probe::greet()
             if greet.len() != 5 {
                 return 1
@@ -1506,7 +1506,7 @@ pub fn bounce(ch: char) -> char { if ch == 'あ' { 'い' } else { ch } }"#,
     main.write_str(
         r#"import rust::string_char_probe
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let owned = String::from("あい")
             if rust::string_char_probe::count_chars(owned) != 2 {
                 return 1
@@ -1548,7 +1548,7 @@ pub fn ng_ptr(v: *const i8) -> *const i8 { v }"#,
     main.write_str(
         r#"import rust::skip_probe
 
-        fn main(): i32 {
+        fun main() -> i32 {
             return rust::skip_probe::ok_i64(53 as i64) as i32 + rust::skip_probe::strlen("kaede")
         }"#,
     )?;
@@ -1578,7 +1578,7 @@ pub fn normalize(s: &mut str) -> i32 { s.len() as i32 }"#,
     main.write_str(
         r#"import rust::mut_str_probe
 
-        fn main(): i32 {
+        fun main() -> i32 {
             return rust::mut_str_probe::ok("kaede")
         }"#,
     )?;

--- a/compiler/driver/tests/leak.rs
+++ b/compiler/driver/tests/leak.rs
@@ -8,13 +8,13 @@ const TEST_PROGRAM: &str = r"struct Num {
     n: i32,
 }
 
-fn f(): ([i32; 3], (i32, i32, Num)) {
+fun f() -> ([i32; 3], (i32, i32, Num)) {
     let a = [1, 2, 3]
     let t = (48, 10, Num { n: 58 })
     return (a, t)
 }
 
-fn main(): i32 {
+fun main() -> i32 {
     let mut c = 0
 
     loop {

--- a/compiler/driver/tests/run.rs
+++ b/compiler/driver/tests/run.rs
@@ -41,7 +41,7 @@ fn run_executes_build_main_and_propagates_exit_code() -> anyhow::Result<()> {
 
     create_project(
         &temp_dir,
-        r#"fn main(): i32 {
+        r#"fun main() -> i32 {
     return 42
 }"#,
     )?;
@@ -82,7 +82,7 @@ fn run_uses_unique_entry_candidate_even_if_not_main_kd() -> anyhow::Result<()> {
     create_project_files(
         &temp_dir,
         &[
-            ("main.kd", "fn helper(): i32 { return 0 }"),
+            ("main.kd", "fun helper() -> i32 { return 0 }"),
             (
                 "app.kd",
                 r#"let mut n = 40
@@ -108,7 +108,7 @@ fn run_fails_when_entry_candidate_is_ambiguous() -> anyhow::Result<()> {
     create_project_files(
         &temp_dir,
         &[
-            ("main.kd", "fn main(): i32 { return 0 }"),
+            ("main.kd", "fun main() -> i32 { return 0 }"),
             ("app.kd", "return 42"),
         ],
     )?;
@@ -129,9 +129,9 @@ fn run_forwards_args_after_double_dash() -> anyhow::Result<()> {
 
     create_project(
         &temp_dir,
-        r#"extern "C" fn strcmp(s1: *u8, s2: *u8): i32
+        r#"extern "C" fun strcmp(s1: *u8, s2: *u8) -> i32
 
-fn main(args: Vector<str>): i32 {
+fun main(args: Vector<str>) -> i32 {
     if args.len() < 2 {
         return 125
     }
@@ -176,16 +176,16 @@ fn run_executes_result_try_program() -> anyhow::Result<()> {
         r#"import std.result
 use std.result.Result
 
-fn inner(): Result<i32, str> {
+fun inner() -> Result<i32, str> {
     return Result::Ok(42)
 }
 
-fn outer(): Result<i32, str> {
+fun outer() -> Result<i32, str> {
     value := inner()?;
     return Result::Ok(value)
 }
 
-fn main(): i32 {
+fun main() -> i32 {
     return match outer() {
         Result::Ok(value) => value,
         Result::Err(_) => 1,

--- a/compiler/driver/tests/runtime_channel.rs
+++ b/compiler/driver/tests/runtime_channel.rs
@@ -65,11 +65,11 @@ import std.option
 use std.sync.Channel
 use std.option.Option
 
-fn producer(ch: Channel<i32>) {
+fun producer(ch: Channel<i32>) {
     ch.send(42)
 }
 
-fn main(): i32 {
+fun main() -> i32 {
     let ch = Channel<i32>::new()
     spawn producer(ch)
 
@@ -97,11 +97,11 @@ import std.option
 use std.sync.Channel
 use std.option.Option
 
-fn producer(ch: Channel<i32>) {
+fun producer(ch: Channel<i32>) {
     ch <- 42
 }
 
-fn main(): i32 {
+fun main() -> i32 {
     let ch = Channel<i32>::new()
     spawn producer(ch)
 
@@ -130,13 +130,13 @@ use std.sync.Channel
 use std.sync.WaitGroup
 use std.option.Option
 
-fn sender(ch: Channel<i32>, wg: mut WaitGroup) {
+fun sender(ch: Channel<i32>, wg: mut WaitGroup) {
     ch.send(1)
     ch.send(2)
     wg.done()
 }
 
-fn main(): i32 {
+fun main() -> i32 {
     let ch = Channel<i32>::with_capacity(1)
     let mut wg = WaitGroup::new()
     wg.add(1)
@@ -175,7 +175,7 @@ import std.option
 use std.sync.Channel
 use std.option.Option
 
-fn main(): i32 {
+fun main() -> i32 {
     let ch = Channel<i32>::with_capacity(2)
     ch <- 10
     ch.send(20)
@@ -212,12 +212,12 @@ import std.option
 use std.sync.Channel
 use std.option.Option
 
-fn closer(ch: Channel<i32>) {
+fun closer(ch: Channel<i32>) {
     std.sys.sleep_ms(50)
     ch.close()
 }
 
-fn main(): i32 {
+fun main() -> i32 {
     let ch = Channel<i32>::new()
     spawn closer(ch)
 
@@ -239,7 +239,7 @@ import std.option
 use std.sync.Channel
 use std.option.Option
 
-fn main(): i32 {
+fun main() -> i32 {
     let ch = Channel<i32>::new()
     if ch.try_send(1) {
         return 1

--- a/compiler/driver/tests/runtime_init.rs
+++ b/compiler/driver/tests/runtime_init.rs
@@ -10,7 +10,7 @@ fn compiled_binary_initializes_runtime_before_running_main() -> anyhow::Result<(
     let exe = temp_dir.child("a.out");
 
     main.write_str(
-        r#"fn main(): i32 {
+        r#"fun main() -> i32 {
     return 0
 }"#,
     )?;

--- a/compiler/driver/tests/runtime_netpoll.rs
+++ b/compiler/driver/tests/runtime_netpoll.rs
@@ -115,7 +115,7 @@ import std.sync
 
 use std.sync.WaitGroup
 
-fn handle(conn: std.sys.Fd, wg: mut WaitGroup) {{
+fun handle(conn: std.sys.Fd, wg: mut WaitGroup) {{
     let mut buf = [0; 1]
     let n = match std.sys.read(conn, buf) {{
         std.option.Option::Some(value) => value,
@@ -136,7 +136,7 @@ fn handle(conn: std.sys.Fd, wg: mut WaitGroup) {{
     wg.done()
 }}
 
-fn main(): i32 {{
+fun main() -> i32 {{
     let listener = std.sys.socket_tcp4()
     std.sys.set_reuseaddr(listener)
     std.sys.bind_ipv4(listener, "127.0.0.1", {port})
@@ -207,19 +207,19 @@ import std.sync
 
 use std.sync.WaitGroup
 
-fn reader(conn: std.sys.Fd, wg: mut WaitGroup) {{
+fun reader(conn: std.sys.Fd, wg: mut WaitGroup) {{
     let mut buf = [0; 1]
     let _ = std.sys.read(conn, buf)
     wg.done()
 }}
 
-fn closer(conn: std.sys.Fd, wg: mut WaitGroup) {{
+fun closer(conn: std.sys.Fd, wg: mut WaitGroup) {{
     std.sys.sleep_ms(100)
     std.sys.close_quiet(conn)
     wg.done()
 }}
 
-fn main(): i32 {{
+fun main() -> i32 {{
     let listener = std.sys.socket_tcp4()
     std.sys.set_reuseaddr(listener)
     std.sys.bind_ipv4(listener, "127.0.0.1", {port})
@@ -271,12 +271,12 @@ fn runtime_shutdown_exits_with_background_tasks_still_parked_on_io() -> anyhow::
     main.write_str(&format!(
         r#"import std.sys
 
-fn reader(conn: std.sys.Fd) {{
+fun reader(conn: std.sys.Fd) {{
     let mut buf = [0; 1]
     let _ = std.sys.read(conn, buf)
 }}
 
-fn main(): i32 {{
+fun main() -> i32 {{
     let listener = std.sys.socket_tcp4()
     std.sys.set_reuseaddr(listener)
     std.sys.bind_ipv4(listener, "127.0.0.1", {port})

--- a/compiler/ir/src/ty.rs
+++ b/compiler/ir/src/ty.rs
@@ -510,7 +510,7 @@ impl std::fmt::Display for TyKind {
                     .map(|t| t.kind.to_string())
                     .collect::<Vec<_>>()
                     .join(", ");
-                write!(f, "fn({params}) -> {}", closure.ret_ty.kind)
+                write!(f, "fun({params}) -> {}", closure.ret_ty.kind)
             }
 
             Self::Reference(refee) => write!(f, "&{}", refee.refee_ty.kind),

--- a/compiler/lex/src/lib.rs
+++ b/compiler/lex/src/lib.rs
@@ -158,7 +158,8 @@ impl Cursor<'_> {
 
                 match ident.as_str() {
                     // Reserved words
-                    "fn" => self.create_token(TokenKind::Fn),
+                    "fun" => self.create_token(TokenKind::Fun),
+                    "fn" => self.create_token(TokenKind::OldFn),
                     "return" => self.create_token(TokenKind::Return),
                     "let" => self.create_token(TokenKind::Let),
                     "if" => self.create_token(TokenKind::If),
@@ -171,7 +172,8 @@ impl Cursor<'_> {
                     "true" => self.create_token(TokenKind::True),
                     "false" => self.create_token(TokenKind::False),
                     "import" => self.create_token(TokenKind::Import),
-                    "pub" => self.create_token(TokenKind::Pub),
+                    "export" => self.create_token(TokenKind::Export),
+                    "pub" => self.create_token(TokenKind::OldPub),
                     "impl" => self.create_token(TokenKind::Impl),
                     "enum" => self.create_token(TokenKind::Enum),
                     "match" => self.create_token(TokenKind::Match),

--- a/compiler/lex/src/token.rs
+++ b/compiler/lex/src/token.rs
@@ -104,8 +104,10 @@ pub enum TokenKind {
     Tilde,
 
     // Reserved words
-    /// "fn"
-    Fn,
+    /// "fun"
+    Fun,
+    /// "fn" (reserved old syntax)
+    OldFn,
     /// "return"
     Return,
     /// "let"
@@ -126,8 +128,10 @@ pub enum TokenKind {
     Struct,
     /// "import"
     Import,
-    /// "pub"
-    Pub,
+    /// "export"
+    Export,
+    /// "pub" (reserved old syntax)
+    OldPub,
     /// "impl"
     Impl,
     /// "enum"
@@ -218,7 +222,8 @@ impl std::fmt::Display for TokenKind {
                 Caret => "'^'",
                 Tilde => "'~'",
 
-                Fn => "'fn'",
+                Fun => "'fun'",
+                OldFn => "'fn'",
                 Return => "'return'",
                 Let => "'let'",
                 Mut => "'mut'",
@@ -229,7 +234,8 @@ impl std::fmt::Display for TokenKind {
                 While => "'while'",
                 Struct => "'struct'",
                 Import => "'import'",
-                Pub => "'pub'",
+                Export => "'export'",
+                OldPub => "'pub'",
                 Impl => "'impl'",
                 Enum => "'enum'",
                 Match => "'match'",

--- a/compiler/parse/src/top.rs
+++ b/compiler/parse/src/top.rs
@@ -20,6 +20,15 @@ use crate::{
 
 impl Parser {
     pub fn module_item(&mut self) -> ParseResult<ModuleItem> {
+        if self.check(&TokenKind::OldPub) || self.check(&TokenKind::OldFn) {
+            return Err(ParseError::ExpectedError {
+                expected: "new syntax keyword".to_string(),
+                but: self.first().kind.to_string(),
+                span: self.first().span,
+            }
+            .into());
+        }
+
         if self.is_top_level_decl_start() {
             return Ok(ModuleItem::Decl(self.top_level()?));
         }
@@ -30,7 +39,7 @@ impl Parser {
     }
 
     pub fn top_level(&mut self) -> ParseResult<TopLevel> {
-        let vis = self.consume_b(&TokenKind::Pub).into();
+        let vis = self.consume_b(&TokenKind::Export).into();
 
         let token = self.first();
 
@@ -40,7 +49,7 @@ impl Parser {
                 (kind.span, TopLevelKind::Import(kind))
             }
 
-            TokenKind::Fn => {
+            TokenKind::Fun => {
                 let kind = self.func(vis)?;
                 (kind.span, TopLevelKind::Fn(kind))
             }
@@ -96,14 +105,14 @@ impl Parser {
             None => return false,
         };
 
-        if matches!(token, TokenKind::Pub) {
+        if matches!(token, TokenKind::Export) {
             return true;
         }
 
         matches!(
             token,
             TokenKind::Import
-                | TokenKind::Fn
+                | TokenKind::Fun
                 | TokenKind::Struct
                 | TokenKind::Impl
                 | TokenKind::Enum
@@ -335,7 +344,7 @@ impl Parser {
     }
 
     fn fn_decl(&mut self, vis: Visibility) -> ParseResult<FnDecl> {
-        let start = self.consume(&TokenKind::Fn)?.start;
+        let start = self.consume(&TokenKind::Fun)?.start;
 
         let name = self.ident()?;
 
@@ -377,8 +386,10 @@ impl Parser {
             params
         };
 
-        let (return_ty, finish) = if let Ok(span) = self.consume(&TokenKind::Colon) {
-            (Rc::new(self.ty()?), span.finish)
+        let (return_ty, finish) = if self.consume_b(&TokenKind::Arrow) {
+            let ret_ty = Rc::new(self.ty()?);
+            let finish = ret_ty.span.finish;
+            (ret_ty, finish)
         } else {
             let unit_span = self.new_span(params.span.finish, params.span.finish);
             (Rc::new(Ty::new_unit(unit_span)), params.span.finish)

--- a/compiler/parse/src/ty.rs
+++ b/compiler/parse/src/ty.rs
@@ -130,10 +130,10 @@ impl Parser {
             return self.tuple_ty();
         }
 
-        if self.check(&TokenKind::Fn) {
+        if self.check(&TokenKind::Fun) {
             // Closure type
             self.checkpoint();
-            self.consume_b(&TokenKind::Fn);
+            self.consume_b(&TokenKind::Fun);
             let is_closure_ty = self.check(&TokenKind::OpenParen);
             self.backtrack();
 
@@ -307,15 +307,15 @@ impl Parser {
     }
 
     fn closure_ty(&mut self) -> ParseResult<Ty> {
-        // fn(i32) -> i32
+        // fun(i32) -> i32
         // ^
-        let start = self.consume(&TokenKind::Fn)?.start;
+        let start = self.consume(&TokenKind::Fun)?.start;
 
-        // fn(i32) -> i32
+        // fun(i32) -> i32
         //   ^
         self.consume(&TokenKind::OpenParen)?;
 
-        // fn(i32) -> i32
+        // fun(i32) -> i32
         //   ^~~
         let mut param_tys = Vec::new();
 
@@ -333,17 +333,17 @@ impl Parser {
             self.consume(&TokenKind::CloseParen)?.finish
         };
 
-        // fn(i32) -> i32
+        // fun(i32) -> i32
         //         ^^
         // Optional: return type can be omitted (defaults to unit type)
         let (ret_ty, finish) = if self.consume_b(&TokenKind::Arrow) {
-            // fn(i32) -> i32
+            // fun(i32) -> i32
             //            ^~~
             let ret_ty = self.ty()?;
             let finish = ret_ty.span.finish;
             (ret_ty.into(), finish)
         } else {
-            // fn(i32)
+            // fun(i32)
             // No return type specified, use unit type
             let unit_span = self.new_span(close_paren_finish, close_paren_finish);
             (Ty::new_unit(unit_span).into(), close_paren_finish)

--- a/compiler/parse/tests/fn_call_args.rs
+++ b/compiler/parse/tests/fn_call_args.rs
@@ -49,7 +49,7 @@ fn parse_positional_then_keyword_arguments() -> Result<()> {
 #[test]
 fn parse_fn_param_default() -> Result<()> {
     let mut parser = Parser::new(
-        "fn f(a: i32 = 1, b: i32) {}",
+        "fun f(a: i32 = 1, b: i32) {}",
         FilePath::from(PathBuf::from("test.kd")),
     );
     let compile_unit = parser.run()?;
@@ -59,7 +59,7 @@ fn parse_fn_param_default() -> Result<()> {
     };
 
     let TopLevelKind::Fn(func) = &top_level.kind else {
-        panic!("expected fn top-level");
+        panic!("expected function top-level");
     };
 
     let params: Vec<_> = func.decl.params.v.iter().collect();
@@ -159,7 +159,7 @@ fn parse_hex_integer_literal() -> Result<()> {
 #[test]
 fn parse_hex_array_size() -> Result<()> {
     let mut parser = Parser::new(
-        "fn f(values: [i32; 0x10]) {}",
+        "fun f(values: [i32; 0x10]) {}",
         FilePath::from(PathBuf::from("test.kd")),
     );
     let unit = parser.run()?;
@@ -169,7 +169,7 @@ fn parse_hex_array_size() -> Result<()> {
     };
 
     let TopLevelKind::Fn(func) = &top_level.kind else {
-        panic!("expected fn top-level");
+        panic!("expected function top-level");
     };
 
     let param = func.decl.params.v.front().expect("function parameter");
@@ -180,6 +180,37 @@ fn parse_hex_array_size() -> Result<()> {
         },
         other => panic!("expected reference type, got {other:?}"),
     }
+
+    Ok(())
+}
+
+#[test]
+fn parse_fun_type() -> Result<()> {
+    let mut parser = Parser::new("fun(i32) -> bool", FilePath::from(PathBuf::from("test.kd")));
+    let ty = parser.ty()?;
+
+    match ty.kind.as_ref() {
+        TyKind::Closure(closure) => {
+            assert_eq!(closure.param_tys.len(), 1);
+            assert!(matches!(
+                closure.ret_ty.kind.as_ref(),
+                TyKind::Fundamental(_)
+            ));
+        }
+        other => panic!("expected closure type, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn parse_old_fn_type_is_rejected() -> Result<()> {
+    let mut parser = Parser::new("fn(i32) -> bool", FilePath::from(PathBuf::from("test.kd")));
+
+    let err = parser.ty().expect_err("old fn type must fail");
+    let parse_err = err.downcast::<ParseError>().expect("expected parse error");
+
+    assert!(matches!(parse_err, ParseError::ExpectedError { .. }));
 
     Ok(())
 }
@@ -213,7 +244,7 @@ fn parse_foreign_rust_import() -> Result<()> {
 #[test]
 fn parse_mixed_module_items_keeps_source_order() -> Result<()> {
     let mut parser = Parser::new(
-        "fn helper() {}\nlet x = 1\nx",
+        "fun helper() {}\nlet x = 1\nx",
         FilePath::from(PathBuf::from("test.kd")),
     );
     let unit = parser.run()?;
@@ -228,7 +259,7 @@ fn parse_mixed_module_items_keeps_source_order() -> Result<()> {
 #[test]
 fn parse_bridge_is_plain_parse_error() -> Result<()> {
     let mut parser = Parser::new(
-        r#"pub bridge "Rust" fn hello()"#,
+        r#"export bridge "Rust" fun hello()"#,
         FilePath::from(PathBuf::from("test.kd")),
     );
 
@@ -241,10 +272,37 @@ fn parse_bridge_is_plain_parse_error() -> Result<()> {
 }
 
 #[test]
-fn parse_pub_let_is_rejected() -> Result<()> {
-    let mut parser = Parser::new("pub let x = 1", FilePath::from(PathBuf::from("test.kd")));
+fn parse_export_let_is_rejected() -> Result<()> {
+    let mut parser = Parser::new("export let x = 1", FilePath::from(PathBuf::from("test.kd")));
 
-    let err = parser.run().expect_err("pub let must fail");
+    let err = parser.run().expect_err("export let must fail");
+    let parse_err = err.downcast::<ParseError>().expect("expected parse error");
+
+    assert!(matches!(parse_err, ParseError::ExpectedError { .. }));
+
+    Ok(())
+}
+
+#[test]
+fn parse_old_fn_keyword_is_rejected() -> Result<()> {
+    let mut parser = Parser::new("fn legacy() {}", FilePath::from(PathBuf::from("test.kd")));
+
+    let err = parser.run().expect_err("old fn keyword must fail");
+    let parse_err = err.downcast::<ParseError>().expect("expected parse error");
+
+    assert!(matches!(parse_err, ParseError::ExpectedError { .. }));
+
+    Ok(())
+}
+
+#[test]
+fn parse_old_pub_keyword_is_rejected() -> Result<()> {
+    let mut parser = Parser::new(
+        "pub fun current() {}",
+        FilePath::from(PathBuf::from("test.kd")),
+    );
+
+    let err = parser.run().expect_err("old pub keyword must fail");
     let parse_err = err.downcast::<ParseError>().expect("expected parse error");
 
     assert!(matches!(parse_err, ParseError::ExpectedError { .. }));

--- a/compiler/semantic/src/error.rs
+++ b/compiler/semantic/src/error.rs
@@ -164,7 +164,7 @@ pub enum SemanticError {
     #[error("{}:{}:{} unsupported language linkage `{}`", span.file, span.start.line, span.start.column, lang_linkage)]
     UnsupportedLanguageLinkage { lang_linkage: Symbol, span: Span },
 
-    #[error("{}:{}:{} top-level statements cannot be combined with `fn main`", span.file, span.start.line, span.start.column)]
+    #[error("{}:{}:{} top-level statements cannot be combined with `fun main`", span.file, span.start.line, span.start.column)]
     TopLevelStatementsWithExplicitMain { span: Span },
 
     #[error("{}:{}:{} top-level statements are only allowed in the entry unit", span.file, span.start.line, span.start.column)]

--- a/compiler/semantic/tests/expr.rs
+++ b/compiler/semantic/tests/expr.rs
@@ -8,45 +8,45 @@ use kaede_symbol::Symbol;
 
 #[test]
 fn int() -> anyhow::Result<()> {
-    semantic_analyze("fn f() { 1 }")?;
+    semantic_analyze("fun f() { 1 }")?;
     Ok(())
 }
 
 #[test]
 fn array_literal() -> anyhow::Result<()> {
-    semantic_analyze("fn f() { [1, 2, 3] }")?;
+    semantic_analyze("fun f() { [1, 2, 3] }")?;
     Ok(())
 }
 
 #[test]
 fn boolean_literal() -> anyhow::Result<()> {
-    semantic_analyze("fn f() { true }")?;
-    semantic_analyze("fn f() { false }")?;
+    semantic_analyze("fun f() { true }")?;
+    semantic_analyze("fun f() { false }")?;
     Ok(())
 }
 
 #[test]
 fn block() -> anyhow::Result<()> {
-    semantic_analyze("fn f() { { 1 } }")?;
+    semantic_analyze("fun f() { { 1 } }")?;
     Ok(())
 }
 
 #[test]
 fn string_literal() -> anyhow::Result<()> {
-    semantic_analyze("fn f() { \"hello\" }")?;
+    semantic_analyze("fun f() { \"hello\" }")?;
     Ok(())
 }
 
 #[test]
 fn builtin_format() -> anyhow::Result<()> {
-    semantic_analyze("fn f() { __format(\"hello {}\", \"world\") }")?;
+    semantic_analyze("fun f() { __format(\"hello {}\", \"world\") }")?;
     Ok(())
 }
 
 #[test]
 fn builtin_format_requires_literal_template() -> anyhow::Result<()> {
     let err = semantic_analyze_expect_error(
-        "fn f() {
+        "fun f() {
             let t = \"hello {}\"
             __format(t, \"world\")
         }",
@@ -59,68 +59,68 @@ fn builtin_format_requires_literal_template() -> anyhow::Result<()> {
 
 #[test]
 fn builtin_format_requires_str_args() -> anyhow::Result<()> {
-    let err = semantic_analyze_expect_error("fn f() { __format(\"n = {}\", 42) }")?;
+    let err = semantic_analyze_expect_error("fun f() { __format(\"n = {}\", 42) }")?;
     assert!(err.to_string().contains("argument #1 must be `str`"));
     Ok(())
 }
 
 #[test]
 fn builtin_format_requires_matching_placeholder_count() -> anyhow::Result<()> {
-    let err = semantic_analyze_expect_error("fn f() { __format(\"{} {}\", \"x\") }")?;
+    let err = semantic_analyze_expect_error("fun f() { __format(\"{} {}\", \"x\") }")?;
     assert!(err.to_string().contains("placeholder count mismatch"));
     Ok(())
 }
 
 #[test]
 fn format_is_undeclared() -> anyhow::Result<()> {
-    let err = semantic_analyze_expect_error("fn f() { format(\"{}\", \"x\") }")?;
+    let err = semantic_analyze_expect_error("fun f() { format(\"{}\", \"x\") }")?;
     assert!(err.to_string().contains("`format` was not declared"));
     Ok(())
 }
 
 #[test]
 fn interpolated_string() -> anyhow::Result<()> {
-    semantic_analyze("fn f() { let name = \"kaede\"; $\"hello {name}\" }")?;
+    semantic_analyze("fun f() { let name = \"kaede\"; $\"hello {name}\" }")?;
     Ok(())
 }
 
 #[test]
 fn arithmetic_binary() -> anyhow::Result<()> {
-    semantic_analyze("fn f() { 1 + 2 }")?;
-    semantic_analyze("fn f() { 1 - 2 }")?;
-    semantic_analyze("fn f() { 1 * 2 }")?;
-    semantic_analyze("fn f() { 1 / 2 }")?;
-    semantic_analyze("fn f() { 1 % 2 }")?;
-    semantic_analyze("fn f() { 1 & 2 }")?;
-    semantic_analyze("fn f() { 1 | 2 }")?;
-    semantic_analyze("fn f() { 1 ^ 2 }")?;
-    semantic_analyze("fn f() { 1 << 2 }")?;
-    semantic_analyze("fn f() { 8 >> 1 }")?;
-    semantic_analyze("fn f() { 1 < 2 }")?;
-    semantic_analyze("fn f() { 1 <= 2 }")?;
-    semantic_analyze("fn f() { 1 > 2 }")?;
-    semantic_analyze("fn f() { 1 >= 2 }")?;
-    semantic_analyze("fn f() { 1 == 2 }")?;
-    semantic_analyze("fn f() { 1 != 2 }")?;
+    semantic_analyze("fun f() { 1 + 2 }")?;
+    semantic_analyze("fun f() { 1 - 2 }")?;
+    semantic_analyze("fun f() { 1 * 2 }")?;
+    semantic_analyze("fun f() { 1 / 2 }")?;
+    semantic_analyze("fun f() { 1 % 2 }")?;
+    semantic_analyze("fun f() { 1 & 2 }")?;
+    semantic_analyze("fun f() { 1 | 2 }")?;
+    semantic_analyze("fun f() { 1 ^ 2 }")?;
+    semantic_analyze("fun f() { 1 << 2 }")?;
+    semantic_analyze("fun f() { 8 >> 1 }")?;
+    semantic_analyze("fun f() { 1 < 2 }")?;
+    semantic_analyze("fun f() { 1 <= 2 }")?;
+    semantic_analyze("fun f() { 1 > 2 }")?;
+    semantic_analyze("fun f() { 1 >= 2 }")?;
+    semantic_analyze("fun f() { 1 == 2 }")?;
+    semantic_analyze("fun f() { 1 != 2 }")?;
     Ok(())
 }
 
 #[test]
 fn logical_binary() -> anyhow::Result<()> {
-    semantic_analyze("fn f() { true && false }")?;
-    semantic_analyze("fn f() { true || false }")?;
+    semantic_analyze("fun f() { true && false }")?;
+    semantic_analyze("fun f() { true || false }")?;
     Ok(())
 }
 
 #[test]
 fn logical_not() -> anyhow::Result<()> {
-    semantic_analyze("fn f() { !true }")?;
+    semantic_analyze("fun f() { !true }")?;
     Ok(())
 }
 
 #[test]
 fn bit_not() -> anyhow::Result<()> {
-    semantic_analyze("fn f() { ~1 }")?;
+    semantic_analyze("fun f() { ~1 }")?;
     Ok(())
 }
 
@@ -133,7 +133,7 @@ import std.option
 use std.sync.Channel
 use std.option.Option
 
-fn f(): i32 {
+fun f() -> i32 {
     let ch = Channel<i32>::with_capacity(1)
     ch <- 42
 
@@ -148,28 +148,28 @@ fn f(): i32 {
 
 #[test]
 fn channel_recv_requires_channel() -> anyhow::Result<()> {
-    let err = semantic_analyze_expect_error("fn f() { <-1 }")?;
+    let err = semantic_analyze_expect_error("fun f() { <-1 }")?;
     assert!(err.to_string().contains("channel receive requires"));
     Ok(())
 }
 
 #[test]
 fn channel_send_requires_channel() -> anyhow::Result<()> {
-    let err = semantic_analyze_expect_error("fn f() { 1 <- 2 }")?;
+    let err = semantic_analyze_expect_error("fun f() { 1 <- 2 }")?;
     assert!(err.to_string().contains("channel send requires"));
     Ok(())
 }
 
 #[test]
 fn array_indexing() -> anyhow::Result<()> {
-    semantic_analyze("fn f() { [0, 1, 2][1] }")?;
+    semantic_analyze("fun f() { [0, 1, 2][1] }")?;
     Ok(())
 }
 
 #[test]
 fn slice_type_annotation() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn len(s: [i32]) {
+        "fun len(s: [i32]) {
             let _ = s[0]
         }",
     )?;
@@ -179,8 +179,8 @@ fn slice_type_annotation() -> anyhow::Result<()> {
 #[test]
 fn array_to_slice_param() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn take(s: [i32]) { let _ = s[1]; }
-        fn main() {
+        "fun take(s: [i32]) { let _ = s[1]; }
+        fun main() {
             take([1, 2, 3])
         }",
     )?;
@@ -190,8 +190,8 @@ fn array_to_slice_param() -> anyhow::Result<()> {
 #[test]
 fn array_to_slice_return() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn make(): [i32] { [10, 20, 30] }
-        fn use_slice() {
+        "fun make() -> [i32] { [10, 20, 30] }
+        fun use_slice() {
             let s = make()
             let _ = s[2]
         }",
@@ -202,9 +202,9 @@ fn array_to_slice_return() -> anyhow::Result<()> {
 #[test]
 fn array_to_slice_var() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn take(s: [i32]): i32 { return s[1] }
+        "fun take(s: [i32]) -> i32 { return s[1] }
 
-        fn f(): i32 {
+        fun f() -> i32 {
             let a: [i32; 3] = [1, 2, 3]
             return take(a)
         }",
@@ -215,7 +215,7 @@ fn array_to_slice_var() -> anyhow::Result<()> {
 #[test]
 fn slice_full_range() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f() {
+        "fun f() {
             let ar = [0, 1, 2]
             let _ = ar[:]
         }",
@@ -226,7 +226,7 @@ fn slice_full_range() -> anyhow::Result<()> {
 #[test]
 fn slice_from_start() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f() {
+        "fun f() {
             let ar = [0, 1, 2, 3, 4]
             let _ = ar[:3]
         }",
@@ -237,7 +237,7 @@ fn slice_from_start() -> anyhow::Result<()> {
 #[test]
 fn slice_to_end() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f() {
+        "fun f() {
             let ar = [0, 1, 2, 3, 4]
             let _ = ar[2:]
         }",
@@ -248,7 +248,7 @@ fn slice_to_end() -> anyhow::Result<()> {
 #[test]
 fn slice_range() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f() {
+        "fun f() {
             let ar = [0, 1, 2, 3, 4]
             let _ = ar[1:4]
         }",
@@ -259,7 +259,7 @@ fn slice_range() -> anyhow::Result<()> {
 #[test]
 fn slice_of_slice() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f(s: [i32]) {
+        "fun f(s: [i32]) {
             let mid = s[1:4]
             let tail = mid[1:]
             let _ = tail[0]
@@ -271,7 +271,7 @@ fn slice_of_slice() -> anyhow::Result<()> {
 #[test]
 fn slice_type_inference() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f(): [i32] {
+        "fun f() -> [i32] {
             let ar = [1, 2, 3, 4]
             return ar[1:]
         }",
@@ -282,7 +282,7 @@ fn slice_type_inference() -> anyhow::Result<()> {
 #[test]
 fn slice_bounds_error() -> anyhow::Result<()> {
     semantic_analyze_expect_error(
-        "fn f() {
+        "fun f() {
             let _ = true[:]
         }",
     )?;
@@ -292,8 +292,8 @@ fn slice_bounds_error() -> anyhow::Result<()> {
 #[test]
 fn function_call() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f(a: i32, b: i32): i32 { return a + b }\n
-        fn g(): i32 { return f(48, 10) }
+        "fun f(a: i32, b: i32) -> i32 { return a + b }\n
+        fun g() -> i32 { return f(48, 10) }
     ",
     )?;
     Ok(())
@@ -302,7 +302,7 @@ fn function_call() -> anyhow::Result<()> {
 #[test]
 fn if_() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f(a: i32): i32 {
+        "fun f(a: i32) -> i32 {
             return if a == 0 {
                 1
             } else if a > 0 {
@@ -315,7 +315,7 @@ fn if_() -> anyhow::Result<()> {
 
     // Test that `a < 0` is correctly parsed as a comparison, not generic syntax
     semantic_analyze(
-        "fn f(a: i32): i32 {
+        "fun f(a: i32) -> i32 {
             return if a == 0 {
                 1
             } else if a < 0 {
@@ -332,7 +332,7 @@ fn if_() -> anyhow::Result<()> {
 #[test]
 fn tuple_literal() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f(): (i32, bool) {
+        "fun f() -> (i32, bool) {
             return (42, true)
         }",
     )?;
@@ -342,7 +342,7 @@ fn tuple_literal() -> anyhow::Result<()> {
 #[test]
 fn tuple_indexing() -> anyhow::Result<()> {
     semantic_analyze(
-        r#"fn f(): i32 {
+        r#"fun f() -> i32 {
             let t = (42, true, "hello, world")
             return t.0
         }"#,
@@ -354,7 +354,7 @@ fn tuple_indexing() -> anyhow::Result<()> {
 fn struct_literal() -> anyhow::Result<()> {
     semantic_analyze(
         "struct Foo { a: i32, b: bool }
-        fn f(): Foo {
+        fun f() -> Foo {
             return Foo { a: 42, b: true }
         }",
     )?;
@@ -365,7 +365,7 @@ fn struct_literal() -> anyhow::Result<()> {
 fn struct_literal_field_init_shorthand() -> anyhow::Result<()> {
     semantic_analyze(
         "struct Foo { a: i32, b: bool }
-        fn f(): Foo {
+        fun f() -> Foo {
             let a = 42
             let b = true
             return Foo { a, b }
@@ -378,7 +378,7 @@ fn struct_literal_field_init_shorthand() -> anyhow::Result<()> {
 fn struct_access() -> anyhow::Result<()> {
     semantic_analyze(
         "struct Foo { a: i32 }
-        fn f(): i32 {
+        fun f() -> i32 {
             let a = Foo { a: 58 }
             return a.a
         }",
@@ -389,7 +389,7 @@ fn struct_access() -> anyhow::Result<()> {
 #[test]
 fn loop_and_break() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f() {
+        "fun f() {
             loop {
                 break
             }
@@ -401,7 +401,7 @@ fn loop_and_break() -> anyhow::Result<()> {
 #[test]
 fn match_on_bool() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f(x: bool): i32 {
+        "fun f(x: bool) -> i32 {
             return match x {
                 true => 1,
                 false => 0,
@@ -414,7 +414,7 @@ fn match_on_bool() -> anyhow::Result<()> {
 #[test]
 fn match_on_int() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f(x: i32): i32 {
+        "fun f(x: i32) -> i32 {
             return match x {
                 0 => 1,
                 1 => 2,
@@ -429,7 +429,7 @@ fn match_on_int() -> anyhow::Result<()> {
 fn match_on_enum() -> anyhow::Result<()> {
     semantic_analyze(
         "enum Foo { A, B, C }
-        fn f(x: Foo): i32 {
+        fun f(x: Foo) -> i32 {
             return match x {
                 Foo::A => 1,
                 Foo::B => 2,
@@ -443,7 +443,7 @@ fn match_on_enum() -> anyhow::Result<()> {
 #[test]
 fn match_with_catch_all() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f(x: i32): i32 {
+        "fun f(x: i32) -> i32 {
             return match x {
                 0 => 1,
                 _ => 0,
@@ -457,7 +457,7 @@ fn match_with_catch_all() -> anyhow::Result<()> {
 fn match_not_exhaustive_enum() -> anyhow::Result<()> {
     semantic_analyze_expect_error(
         "enum Foo { A, B, C }
-        fn f(x: Foo): i32 {
+        fun f(x: Foo) -> i32 {
             return match x {
                 Foo::A => 1,
                 Foo::B => 2,
@@ -470,7 +470,7 @@ fn match_not_exhaustive_enum() -> anyhow::Result<()> {
 #[test]
 fn match_not_exhaustive_int() -> anyhow::Result<()> {
     semantic_analyze_expect_error(
-        "fn f(x: i32): i32 {
+        "fun f(x: i32) -> i32 {
             return match x {
                 0 => 1,
                 1 => 0,
@@ -483,7 +483,7 @@ fn match_not_exhaustive_int() -> anyhow::Result<()> {
 #[test]
 fn match_not_exhaustive_bool() -> anyhow::Result<()> {
     semantic_analyze_expect_error(
-        "fn f(x: bool): i32 {
+        "fun f(x: bool) -> i32 {
             return match x {
                 true => 1,
             }
@@ -496,7 +496,7 @@ fn match_not_exhaustive_bool() -> anyhow::Result<()> {
 fn enum_variant() -> anyhow::Result<()> {
     semantic_analyze(
         "enum Foo { A, B(i32), C }
-        fn f(): i32 {
+        fun f() -> i32 {
             let x = Foo::B(1)
             return match x {
                 Foo::A => 1,
@@ -511,7 +511,7 @@ fn enum_variant() -> anyhow::Result<()> {
 #[test]
 fn match_catch_all_only_int_error() -> anyhow::Result<()> {
     semantic_analyze_expect_error(
-        "fn f(): i32 {
+        "fun f() -> i32 {
             let x = 42
             return match x {
                 _ => 1
@@ -525,7 +525,7 @@ fn match_catch_all_only_int_error() -> anyhow::Result<()> {
 fn match_catch_all_only_enum_error() -> anyhow::Result<()> {
     semantic_analyze_expect_error(
         "enum Foo { A, B }
-        fn f(): i32 {
+        fun f() -> i32 {
             let x = Foo::A
             return match x {
                 _ => 1
@@ -538,7 +538,7 @@ fn match_catch_all_only_enum_error() -> anyhow::Result<()> {
 #[test]
 fn match_catch_all_undefined_function_int_error() -> anyhow::Result<()> {
     semantic_analyze_expect_error(
-        "fn f(): i32 {
+        "fun f() -> i32 {
             let x = 42
             return match x {
                 1 => 10,
@@ -554,7 +554,7 @@ fn match_catch_all_undefined_function_int_error() -> anyhow::Result<()> {
 fn match_catch_all_undefined_function_enum_error() -> anyhow::Result<()> {
     semantic_analyze_expect_error(
         "enum Foo { A, B }
-        fn f(): i32 {
+        fun f() -> i32 {
             let x = Foo::A
             return match x {
                 Foo::A => 10,
@@ -570,7 +570,7 @@ fn field_access_and_indexing() -> anyhow::Result<()> {
     // Test that field access with indexing works correctly
     semantic_analyze(
         "struct Container { data: [i32; 3] }
-        fn f(): i32 {
+        fun f() -> i32 {
             let c = Container { data: [1, 2, 3] }
             return c.data[0]
         }",
@@ -583,7 +583,7 @@ fn indexing_and_field_access() -> anyhow::Result<()> {
     // Test that indexing followed by field access works correctly
     semantic_analyze(
         "struct Item { value: i32 }
-        fn f(): i32 {
+        fun f() -> i32 {
             let item1 = Item { value: 10 }
             let item2 = Item { value: 20 }
             let item3 = Item { value: 30 }
@@ -598,7 +598,7 @@ fn indexing_and_field_access() -> anyhow::Result<()> {
 fn multiple_indexing() -> anyhow::Result<()> {
     // Test that multiple indexing operations work correctly
     semantic_analyze(
-        "fn f(): i32 {
+        "fun f() -> i32 {
             let row1: [i32; 2] = [1, 2]
             let row2: [i32; 2] = [3, 4]
             let matrix: [[i32; 2]; 2] = [row1, row2]
@@ -614,11 +614,11 @@ fn method_call_and_indexing() -> anyhow::Result<()> {
     semantic_analyze(
         "struct Container { items: [i32; 3] }
         impl Container {
-            fn get_items(self): [i32; 3] {
+            fun get_items(self) -> [i32; 3] {
                 return self.items
             }
         }
-        fn f(): i32 {
+        fun f() -> i32 {
             let c = Container { items: [10, 20, 30] }
             return c.get_items()[1]
         }",
@@ -632,7 +632,7 @@ fn complex_chaining() -> anyhow::Result<()> {
     semantic_analyze(
         "struct Inner { values: [i32; 2] }
         struct Outer { inners: [Inner; 2] }
-        fn f(): i32 {
+        fun f() -> i32 {
             let inner1 = Inner { values: [1, 2] }
             let inner2 = Inner { values: [3, 4] }
             let outer = Outer { inners: [inner1, inner2] }
@@ -657,7 +657,7 @@ fn find_function_body(ir: kaede_ir::CompileUnit, name: &str) -> kaede_ir::stmt::
 fn closure_captures_outer_variables() -> anyhow::Result<()> {
     let ir = semantic_analyze(
         "
-        fn f(): i32 {
+        fun f() -> i32 {
             let a: i32 = 10
             let b: i32 = 2
             let c = | | a + b
@@ -707,8 +707,8 @@ fn closure_captures_outer_variables() -> anyhow::Result<()> {
 #[test]
 fn keyword_arguments_reorder() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn add(a: i32, b: i32): i32 { return a + b }
-        fn main(): i32 { return add(b = 2, a = 1) }",
+        "fun add(a: i32, b: i32) -> i32 { return a + b }
+        fun main() -> i32 { return add(b = 2, a = 1) }",
     )?;
     Ok(())
 }
@@ -716,8 +716,8 @@ fn keyword_arguments_reorder() -> anyhow::Result<()> {
 #[test]
 fn keyword_arguments_mixed_with_positionals() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn mix(a: i32, b: i32, c: i32): i32 { return a + b + c }
-        fn main(): i32 { return mix(1, c = 3, b = 2) }",
+        "fun mix(a: i32, b: i32, c: i32) -> i32 { return a + b + c }
+        fun main() -> i32 { return mix(1, c = 3, b = 2) }",
     )?;
     Ok(())
 }
@@ -725,8 +725,8 @@ fn keyword_arguments_mixed_with_positionals() -> anyhow::Result<()> {
 #[test]
 fn keyword_argument_unknown_param() -> anyhow::Result<()> {
     let err = semantic_analyze_expect_error(
-        "fn f(a: i32) { }
-        fn main() { f(b = 1) }",
+        "fun f(a: i32) { }
+        fun main() { f(b = 1) }",
     )?;
 
     assert!(err.to_string().contains("unknown parameter `b`"));
@@ -736,8 +736,8 @@ fn keyword_argument_unknown_param() -> anyhow::Result<()> {
 #[test]
 fn keyword_argument_duplicate() -> anyhow::Result<()> {
     let err = semantic_analyze_expect_error(
-        "fn f(a: i32) { }
-        fn main() { f(a = 1, a = 2) }",
+        "fun f(a: i32) { }
+        fun main() { f(a = 1, a = 2) }",
     )?;
 
     assert!(err
@@ -749,8 +749,8 @@ fn keyword_argument_duplicate() -> anyhow::Result<()> {
 #[test]
 fn positional_after_keyword_is_error() -> anyhow::Result<()> {
     let err = semantic_analyze_expect_error(
-        "fn f(a: i32, b: i32) { }
-        fn main() { f(a = 1, 2) }",
+        "fun f(a: i32, b: i32) { }
+        fun main() { f(a = 1, 2) }",
     )?;
 
     assert!(err
@@ -762,8 +762,8 @@ fn positional_after_keyword_is_error() -> anyhow::Result<()> {
 #[test]
 fn default_argument_used() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn greet(message: i32 = 7) { let _ = message }
-        fn main() { greet() }",
+        "fun greet(message: i32 = 7) { let _ = message }
+        fun main() { greet() }",
     )?;
     Ok(())
 }
@@ -771,8 +771,8 @@ fn default_argument_used() -> anyhow::Result<()> {
 #[test]
 fn default_argument_with_keyword_override() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn mix(a: i32, b: i32 = 2, c: i32 = 3): i32 { return a + b + c }
-        fn main(): i32 { return mix(1, c = 10) }",
+        "fun mix(a: i32, b: i32 = 2, c: i32 = 3) -> i32 { return a + b + c }
+        fun main() -> i32 { return mix(1, c = 10) }",
     )?;
     Ok(())
 }
@@ -780,8 +780,8 @@ fn default_argument_with_keyword_override() -> anyhow::Result<()> {
 #[test]
 fn missing_required_argument_is_error() -> anyhow::Result<()> {
     let err = semantic_analyze_expect_error(
-        "fn f(a: i32, b: i32 = 1) { }
-        fn main() { f() }",
+        "fun f(a: i32, b: i32 = 1) { }
+        fun main() { f() }",
     )?;
 
     assert!(err.to_string().contains("too few arguments"));

--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -101,10 +101,10 @@ impl ImportTestCase {
 fn import_basic_function() -> anyhow::Result<()> {
     ImportTestCase {
         name: "basic_function",
-        modules: HashMap::from([("utils", "pub fn helper(): i32 { return 42 }")]),
+        modules: HashMap::from([("utils", "export fun helper() -> i32 { return 42 }")]),
         main_content: r#"
             import utils
-            fn main(): i32 {
+            fun main() -> i32 {
                 return utils.helper()
             }
         "#,
@@ -121,25 +121,25 @@ fn import_struct_and_impl() -> anyhow::Result<()> {
         modules: HashMap::from([(
             "math",
             r#"
-                pub struct Point {
+                export struct Point {
                     x: i32,
                     y: i32
                 }
 
                 impl Point {
-                    pub fn new(x: i32, y: i32): Point {
+                    export fun new(x: i32, y: i32) -> Point {
                         return Point { x: x, y: y }
                     }
 
-                    pub fn add(self, other: Point): Point {
+                    export fun add(self, other: Point) -> Point {
                         return Point { x: self.x + other.x, y: self.y + other.y }
                     }
 
-                    pub fn get_x(self): i32 {
+                    export fun get_x(self) -> i32 {
                         return self.x
                     }
 
-                    pub fn get_y(self): i32 {
+                    export fun get_y(self) -> i32 {
                         return self.y
                     }
                 }
@@ -147,7 +147,7 @@ fn import_struct_and_impl() -> anyhow::Result<()> {
         )]),
         main_content: r#"
             import math
-            fn main(): i32 {
+            fun main() -> i32 {
                 let p1 = math.Point::new(1, 2)
                 let p2 = math.Point::new(3, 4)
                 let p3 = p1.add(p2)
@@ -167,12 +167,12 @@ fn import_builtin_method_returning_imported_struct() -> anyhow::Result<()> {
         modules: HashMap::from([(
             "m",
             r#"
-                pub struct Wrap {
+                export struct Wrap {
                     value: i32
                 }
 
                 impl i32 {
-                    pub fn to_wrap(self): Wrap {
+                    export fun to_wrap(self) -> Wrap {
                         return Wrap { value: self }
                     }
                 }
@@ -180,7 +180,7 @@ fn import_builtin_method_returning_imported_struct() -> anyhow::Result<()> {
         )]),
         main_content: r#"
             import m
-            fn main(): i32 {
+            fun main() -> i32 {
                 let w = 58.to_wrap()
                 return w.value
             }
@@ -197,11 +197,11 @@ fn import_nested_module() -> anyhow::Result<()> {
         name: "nested_module",
         modules: HashMap::from([(
             "nested/deep/module",
-            "pub fn deep_function(): i32 { return 999 }",
+            "export fun deep_function() -> i32 { return 999 }",
         )]),
         main_content: r#"
             import nested.deep.module
-            fn main(): i32 {
+            fun main() -> i32 {
                 return nested.deep.module.deep_function()
             }
         "#,
@@ -216,13 +216,13 @@ fn import_multiple_modules() -> anyhow::Result<()> {
     ImportTestCase {
         name: "multiple_modules",
         modules: HashMap::from([
-            ("utils", "pub fn util_func(): i32 { return 1 }"),
-            ("math", "pub fn math_func(): i32 { return 2 }"),
+            ("utils", "export fun util_func() -> i32 { return 1 }"),
+            ("math", "export fun math_func() -> i32 { return 2 }"),
         ]),
         main_content: r#"
             import utils
             import math
-            fn main(): i32 {
+            fun main() -> i32 {
                 return utils.util_func() + math.math_func()
             }
         "#,
@@ -236,11 +236,11 @@ fn import_multiple_modules() -> anyhow::Result<()> {
 fn import_duplicate_modules() -> anyhow::Result<()> {
     ImportTestCase {
         name: "duplicate_modules",
-        modules: HashMap::from([("utils", "pub fn helper(): i32 { return 42 }")]),
+        modules: HashMap::from([("utils", "export fun helper() -> i32 { return 42 }")]),
         main_content: r#"
             import utils
             import utils  // Duplicate import should be handled gracefully
-            fn main(): i32 {
+            fun main() -> i32 {
                 return utils.helper()
             }
         "#,
@@ -255,12 +255,15 @@ fn import_chained_modules() -> anyhow::Result<()> {
     ImportTestCase {
         name: "chained_modules",
         modules: HashMap::from([
-            ("math", "pub fn add(a: i32, b: i32): i32 { return a + b }"),
+            (
+                "math",
+                "export fun add(a: i32, b: i32) -> i32 { return a + b }",
+            ),
             (
                 "utils",
                 r#"
                 import math
-                pub fn double_add(a: i32, b: i32): i32 {
+                export fun double_add(a: i32, b: i32) -> i32 {
                     return math.add(a, b) * 2
                 }
             "#,
@@ -268,7 +271,7 @@ fn import_chained_modules() -> anyhow::Result<()> {
         ]),
         main_content: r#"
             import utils
-            fn main(): i32 {
+            fun main() -> i32 {
                 return utils.double_add(5, 3)
             }
         "#,
@@ -285,16 +288,16 @@ fn import_generic_types() -> anyhow::Result<()> {
         modules: HashMap::from([(
             "container",
             r#"
-                pub struct Container<T> {
+                export struct Container<T> {
                     value: T
                 }
 
                 impl<T> Container<T> {
-                    pub fn new(value: T): Container<T> {
+                    export fun new(value: T) -> Container<T> {
                         return Container<T> { value: value }
                     }
 
-                    pub fn get(self): T {
+                    export fun get(self) -> T {
                         return self.value
                     }
                 }
@@ -302,7 +305,7 @@ fn import_generic_types() -> anyhow::Result<()> {
         )]),
         main_content: r#"
             import container
-            fn main(): i32 {
+            fun main() -> i32 {
                 let c = container.Container<i32>::new(42)
                 return c.get()
             }
@@ -320,25 +323,25 @@ fn import_enums() -> anyhow::Result<()> {
         modules: HashMap::from([(
             "types",
             r#"
-                pub enum Color {
+                export enum Color {
                     Red,
                     Green,
                     Blue
                 }
 
-                pub enum Opt<T> {
+                export enum Opt<T> {
                     Some(T),
                     None
                 }
 
-                pub fn get_red(): Color {
+                export fun get_red() -> Color {
                     return Color::Red
                 }
             "#,
         )]),
         main_content: r#"
             import types
-            fn main(): i32 {
+            fun main() -> i32 {
                 let c = types.Color::Red
                 match c {
                     types.Color::Red => return 0,
@@ -360,11 +363,11 @@ fn import_with_use_statement() -> anyhow::Result<()> {
         modules: HashMap::from([(
             "graphics/shapes",
             r#"
-                pub struct Circle {
+                export struct Circle {
                     radius: i32
                 }
 
-                pub fn get_radius(c: Circle): i32 {
+                export fun get_radius(c: Circle) -> i32 {
                     return c.radius
                 }
             "#,
@@ -374,7 +377,7 @@ fn import_with_use_statement() -> anyhow::Result<()> {
             use graphics.shapes.Circle
             use graphics.shapes.get_radius
 
-            fn main(): i32 {
+            fun main() -> i32 {
                 let c = Circle { radius: 5 }
                 return get_radius(c)
             }
@@ -392,7 +395,7 @@ fn import_nonexistent_file() -> anyhow::Result<()> {
         modules: HashMap::new(),
         main_content: r#"
             import nonexistent
-            fn main(): i32 {
+            fun main() -> i32 {
                 return 0
             }
         "#,
@@ -407,7 +410,7 @@ fn import_empty_module() -> anyhow::Result<()> {
     ImportTestCase {
         name: "empty_module",
         modules: HashMap::from([("empty", "")]),
-        main_content: "import empty\nfn main(): i32 { return 0 }",
+        main_content: "import empty\nfun main() -> i32 { return 0 }",
         expected_min_top_levels: 1,
         should_fail: false,
     }
@@ -418,8 +421,8 @@ fn import_empty_module() -> anyhow::Result<()> {
 fn import_module_with_only_private_items() -> anyhow::Result<()> {
     ImportTestCase {
         name: "module_with_only_private_items",
-        modules: HashMap::from([("private", "fn private_func(): i32 { return 42 }")]),
-        main_content: "import private\nfn main(): i32 { return 0 }",
+        modules: HashMap::from([("private", "fun private_func() -> i32 { return 42 }")]),
+        main_content: "import private\nfun main() -> i32 { return 0 }",
         expected_min_top_levels: 1,
         should_fail: false,
     }
@@ -430,8 +433,8 @@ fn import_module_with_only_private_items() -> anyhow::Result<()> {
 fn import_private_items() -> anyhow::Result<()> {
     ImportTestCase {
         name: "import_private_items",
-        modules: HashMap::from([("private", "fn private_func(): i32 { return 42 }")]),
-        main_content: "import private\nfn main(): i32 { return private.private_func() }",
+        modules: HashMap::from([("private", "fun private_func() -> i32 { return 42 }")]),
+        main_content: "import private\nfun main() -> i32 { return private.private_func() }",
         expected_min_top_levels: 1,
         should_fail: true,
     }
@@ -443,7 +446,7 @@ fn import_module_with_top_level_statements_fails() -> anyhow::Result<()> {
     ImportTestCase {
         name: "module_with_top_level_statements",
         modules: HashMap::from([("side_effect", "let x = 1")]),
-        main_content: "import side_effect\nfn main(): i32 { return 0 }",
+        main_content: "import side_effect\nfun main() -> i32 { return 0 }",
         expected_min_top_levels: 0,
         should_fail: true,
     }
@@ -454,8 +457,8 @@ fn import_module_with_top_level_statements_fails() -> anyhow::Result<()> {
 fn import_module_with_main_fails() -> anyhow::Result<()> {
     ImportTestCase {
         name: "module_with_main",
-        modules: HashMap::from([("nested", "fn main(): i32 { return 0 }")]),
-        main_content: "import nested\nfn main(): i32 { return 0 }",
+        modules: HashMap::from([("nested", "fun main() -> i32 { return 0 }")]),
+        main_content: "import nested\nfun main() -> i32 { return 0 }",
         expected_min_top_levels: 0,
         should_fail: true,
     }
@@ -469,16 +472,16 @@ fn import_mutual_recursive_functions() -> anyhow::Result<()> {
         modules: HashMap::from([(
             "a",
             r#"
-            pub fn a(i: i32): i32 {
+            export fun a(i: i32) -> i32 {
                 if i == 0 {
                     return 0
                 }
                 return b(i - 1)
             }
-            fn b(i: i32): i32 { return a(i - 1) }
+            fun b(i: i32) -> i32 { return a(i - 1) }
         "#,
         )]),
-        main_content: "import a\nfn main(): i32 { return a.a(10) }",
+        main_content: "import a\nfun main() -> i32 { return a.a(10) }",
         expected_min_top_levels: 1,
         should_fail: false,
     }

--- a/compiler/semantic/tests/stmt.rs
+++ b/compiler/semantic/tests/stmt.rs
@@ -7,7 +7,7 @@ use crate::common::semantic_analyze_expect_error;
 #[test]
 fn simple_let() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f() {
+        "fun f() {
             let x = 1
         }
     ",
@@ -18,7 +18,7 @@ fn simple_let() -> anyhow::Result<()> {
 #[test]
 fn let_with_mutability() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f() {
+        "fun f() {
             let mut x = 1
         }
     ",
@@ -29,7 +29,7 @@ fn let_with_mutability() -> anyhow::Result<()> {
 #[test]
 fn let_with_ty() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f() {
+        "fun f() {
             let x: i32 = 1
         }
     ",
@@ -40,7 +40,7 @@ fn let_with_ty() -> anyhow::Result<()> {
 #[test]
 fn let_mismatched_types() -> anyhow::Result<()> {
     semantic_analyze_expect_error(
-        r#"fn f() {
+        r#"fun f() {
             let x: i32 = "hello, world"
         }
     "#,
@@ -51,7 +51,7 @@ fn let_mismatched_types() -> anyhow::Result<()> {
 #[test]
 fn let_and_access() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn f(): i32 {
+        "fun f() -> i32 {
             let x = 57
             return x + 1
         }

--- a/compiler/semantic/tests/top.rs
+++ b/compiler/semantic/tests/top.rs
@@ -86,7 +86,7 @@ fn main_generic_callee_name(ir: &CompileUnit) -> kaede_ir::qualified_symbol::Qua
 
 #[test]
 fn empty_function() -> anyhow::Result<()> {
-    semantic_analyze("fn foo() {}")?;
+    semantic_analyze("fun foo() {}")?;
     Ok(())
 }
 
@@ -104,7 +104,7 @@ fn empty_enum() -> anyhow::Result<()> {
 
 #[test]
 fn function_with_return() -> anyhow::Result<()> {
-    semantic_analyze("fn foo(): i32 { return 1 }")?;
+    semantic_analyze("fun foo() -> i32 { return 1 }")?;
     Ok(())
 }
 
@@ -122,45 +122,45 @@ fn simple_enum() -> anyhow::Result<()> {
 
 #[test]
 fn function_with_params() -> anyhow::Result<()> {
-    semantic_analyze("fn foo(a: i32, b: i32): i32 { return a + b }")?;
+    semantic_analyze("fun foo(a: i32, b: i32) -> i32 { return a + b }")?;
     Ok(())
 }
 
 #[test]
 fn function_with_generic_params() -> anyhow::Result<()> {
     semantic_analyze(
-        "fn foo<T, U>(a: T, b: U): T {
+        "fun foo<T, U>(a: T, b: U) -> T {
         return a + b
     }
-    fn f() {
+    fun f() {
         foo<i32, i32>(1, 2)
     }",
     )?;
 
     semantic_analyze_expect_error(
-        "fn foo<T>(a: T, b: U): T {
+        "fun foo<T>(a: T, b: U) -> T {
         return a + b
     }
-    fn f() {
+    fun f() {
         foo<i32>(1, 2)
     }",
     )?;
 
     semantic_analyze_expect_error(
-        "fn foo<T, U>(a: T, b: U): T {
+        "fun foo<T, U>(a: T, b: U) -> T {
         return a + b
     }
-    fn f() {
+    fun f() {
         foo<123>(1, 2)
     }",
     )?;
 
     // Generic function arguments should be inferred from call arguments.
     semantic_analyze(
-        "fn foo<T, U>(a: T, b: U): T {
+        "fun foo<T, U>(a: T, b: U) -> T {
         return a + b
     }
-    fn f(): i32 {
+    fun f() -> i32 {
         return foo(1, 2)
     }",
     )?;
@@ -172,28 +172,28 @@ fn function_with_generic_params() -> anyhow::Result<()> {
 fn generic_type() -> anyhow::Result<()> {
     semantic_analyze(
         "struct Foo<T> { a: T }
-        fn f() {
+        fun f() {
             let x = Foo<i32> { a: 1 }
         }
     ",
     )?;
     semantic_analyze(
         "enum Foo<T> { A, B(T) }
-        fn f() {
+        fun f() {
             let x = Foo<i32>::B(1)
         }
     ",
     )?;
     semantic_analyze(
-        "fn foo<T>(a: T): T { return a }
-        fn f() {
+        "fun foo<T>(a: T) -> T { return a }
+        fun f() {
             foo<i32>(1)
         }
     ",
     )?;
     semantic_analyze(
-        "fn foo<T>(a: T): T { return a }
-        fn f() {
+        "fun foo<T>(a: T) -> T { return a }
+        fun f() {
             foo<i32>(1)
         }
     ",
@@ -206,11 +206,11 @@ fn impl_for_generic_type() -> anyhow::Result<()> {
     semantic_analyze(
         "struct Foo<T> { a: T }
         impl<T> Foo<T> {
-            fn f(self): T {
+            fun f(self) -> T {
                 return self.a
             }
         }
-        fn f() {
+        fun f() {
             let foo = Foo<i32> { a: 1 }
             let x = foo.f()
         }
@@ -224,11 +224,11 @@ fn impl_() -> anyhow::Result<()> {
     semantic_analyze(
         "struct Foo { a: i32 }
         impl Foo {
-            fn f(self): i32 {
+            fun f(self) -> i32 {
                 return self.a
             }
         }
-        fn f() {
+        fun f() {
             let foo = Foo { a: 1 }
             let x = foo.f()
         }
@@ -242,14 +242,14 @@ fn impl_with_static_method() -> anyhow::Result<()> {
     semantic_analyze(
         "struct Foo { a: i32 }
         impl Foo {
-            fn new(n: i32): Foo {
+            fun new(n: i32) -> Foo {
                 return Foo { a: n }
             }
-            fn get_a(self): i32 {
+            fun get_a(self) -> i32 {
                 return self.a
             }
         }
-        fn f(): i32 {
+        fun f() -> i32 {
             let foo = Foo::new(1)
             return foo.get_a()
         }
@@ -263,14 +263,14 @@ fn impl_with_static_method_for_generic_type() -> anyhow::Result<()> {
     semantic_analyze(
         "struct Foo<T> { a: T }
         impl<T> Foo<T> {
-            fn new(n: T): Foo<T> {
+            fun new(n: T) -> Foo<T> {
                 return Foo<T> { a: n }
             }
-            fn get_a(self): T {
+            fun get_a(self) -> T {
                 return self.a
             }
         }
-        fn f(): i32 {
+        fun f() -> i32 {
             let foo = Foo<i32>::new(1)
             return foo.get_a()
         }
@@ -282,8 +282,8 @@ fn impl_with_static_method_for_generic_type() -> anyhow::Result<()> {
 #[test]
 fn extern_() -> anyhow::Result<()> {
     semantic_analyze(
-        r#"extern "C" fn foo(): i32
-        fn f() {
+        r#"extern "C" fun foo() -> i32
+        fun f() {
             foo()
         }
     "#,
@@ -296,7 +296,7 @@ fn type_alias() -> anyhow::Result<()> {
     // Type alias resolved and used in function signature
     semantic_analyze(
         "type MyInt = i32
-        fn foo(x: MyInt): i32 {
+        fun foo(x: MyInt) -> i32 {
             return x
         }",
     )?;
@@ -306,8 +306,8 @@ fn type_alias() -> anyhow::Result<()> {
 #[test]
 fn type_alias_pub() -> anyhow::Result<()> {
     semantic_analyze(
-        "pub type MyInt = i32
-        fn foo(x: MyInt): i32 {
+        "export type MyInt = i32
+        fun foo(x: MyInt) -> i32 {
             return x
         }",
     )?;
@@ -318,11 +318,11 @@ fn type_alias_pub() -> anyhow::Result<()> {
 fn generated_generic_function_has_concrete_types_after_inference() -> anyhow::Result<()> {
     let ir = semantic_analyze(
         r#"
-        fn __test_id<T>(x: T): T {
+        fun __test_id<T>(x: T) -> T {
             return x
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let n: i32 = __test_id(1)
             return 58
         }
@@ -364,12 +364,12 @@ fn generated_generic_impl_method_has_concrete_types_after_inference() -> anyhow:
         }
 
         impl<T> __TestBox<T> {
-            fn __test_get(self): T {
+            fun __test_get(self) -> T {
                 return self.value
             }
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let b = __TestBox<i32> { value: 58 }
             return b.__test_get()
         }
@@ -417,7 +417,7 @@ fn generated_generic_impl_method_has_concrete_types_after_inference() -> anyhow:
 fn static_method_on_generic_type_allows_omitted_type_args() -> anyhow::Result<()> {
     semantic_analyze(
         r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut v = Vector::new()
             v.push(58)
             return match v.at(0) {
@@ -435,7 +435,7 @@ fn static_method_on_generic_type_allows_omitted_type_args() -> anyhow::Result<()
 fn option_some_allows_omitted_type_args() -> anyhow::Result<()> {
     semantic_analyze(
         r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let opt = Option::Some(58)
             return match opt {
                 Option::Some(n) => n,
@@ -456,7 +456,7 @@ fn vector_new_infers_struct_type_from_push() -> anyhow::Result<()> {
             x: i32,
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let mut v = Vector::new()
             v.push(S { x: 123 })
             return 0
@@ -475,7 +475,7 @@ fn option_some_struct_payload_without_explicit_args() -> anyhow::Result<()> {
             n: i32,
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let opt = Option::Some(S { n: 58 })
             return match opt {
                 Option::Some(v) => v.n,
@@ -492,7 +492,7 @@ fn option_some_struct_payload_without_explicit_args() -> anyhow::Result<()> {
 fn option_none_allows_omitted_type_args_when_expected_type_is_known() -> anyhow::Result<()> {
     semantic_analyze(
         r#"
-        fn wrap(flag: bool): Option<i32> {
+        fun wrap(flag: bool) -> Option<i32> {
             if flag {
                 return Option::Some(58)
             }
@@ -500,7 +500,7 @@ fn option_none_allows_omitted_type_args_when_expected_type_is_known() -> anyhow:
             return Option::None
         }
 
-        fn main(): i32 {
+        fun main() -> i32 {
             let opt: Option<i32> = Option::None
             return match wrap(false) {
                 Option::Some(n) => n,
@@ -520,7 +520,7 @@ fn option_none_allows_omitted_type_args_when_expected_type_is_known() -> anyhow:
 fn option_none_without_context_still_requires_type_args() -> anyhow::Result<()> {
     let err = semantic_analyze_expect_error(
         r#"
-        fn main(): i32 {
+        fun main() -> i32 {
             let opt = Option::None
             return 0
         }
@@ -537,7 +537,7 @@ fn type_alias_struct() -> anyhow::Result<()> {
     semantic_analyze(
         "struct S { x: i32 }
          type AliasS = S
-         fn foo(): S {
+         fun foo() -> S {
             return AliasS { x: 1 }
          }",
     )?;
@@ -574,7 +574,7 @@ fn top_level_statements_conflict_with_explicit_main() -> anyhow::Result<()> {
     let err = semantic_analyze_expect_error(
         r#"
         let x = 1
-        fn main(): i32 { return x }
+        fun main() -> i32 { return x }
         "#,
     )?;
 
@@ -596,7 +596,7 @@ fn top_level_statements_are_rejected_in_non_entry_units() -> anyhow::Result<()> 
 
 #[test]
 fn main_is_rejected_in_non_entry_units() -> anyhow::Result<()> {
-    let err = semantic_analyze_non_entry_expect_error("fn main(): i32 { return 0 }")?;
+    let err = semantic_analyze_non_entry_expect_error("fun main() -> i32 { return 0 }")?;
 
     assert!(err.to_string().contains("`main` is only allowed"));
 
@@ -608,7 +608,7 @@ fn top_level_functions_do_not_capture_script_locals() -> anyhow::Result<()> {
     let err = semantic_analyze_expect_error(
         r#"
         let x = 1
-        fn helper(): i32 { return x }
+        fun helper() -> i32 { return x }
         return helper()
         "#,
     )?;
@@ -620,6 +620,6 @@ fn top_level_functions_do_not_capture_script_locals() -> anyhow::Result<()> {
 
 #[test]
 fn plain_functions_are_allowed_in_non_entry_units() -> anyhow::Result<()> {
-    semantic_analyze_as_non_entry("fn helper(): i32 { return 0 }")?;
+    semantic_analyze_as_non_entry("fun helper() -> i32 { return 0 }")?;
     Ok(())
 }

--- a/example/calculator/src/ast.kd
+++ b/example/calculator/src/ast.kd
@@ -1,4 +1,4 @@
-pub enum NodeKind {
+export enum NodeKind {
     Add,
     Sub,
     Mul,
@@ -6,7 +6,7 @@ pub enum NodeKind {
     Num(i32),
 }
 
-pub struct Node {
+export struct Node {
     kind: NodeKind,
     left: Option<Node>,
     right: Option<Node>,

--- a/example/calculator/src/eval.kd
+++ b/example/calculator/src/eval.kd
@@ -3,14 +3,14 @@ import std.io
 
 use ast.NodeKind
 
-pub struct Evaluator {}
+export struct Evaluator {}
 
 impl Evaluator {
-    pub fn new(): Evaluator {
+    export fun new() -> Evaluator {
         return Evaluator {}
     }
 
-    pub fn eval(self, node: ast.Node): i32 {
+    export fun eval(self, node: ast.Node) -> i32 {
         match node.kind {
             NodeKind::Num(n) => {
                 return n

--- a/example/calculator/src/main.kd
+++ b/example/calculator/src/main.kd
@@ -6,7 +6,7 @@ use tokenize.Tokenizer
 use parse.Parser
 use eval.Evaluator
 
-fn main(args: Vector<str>): i32 {
+fun main(args: Vector<str>) -> i32 {
     expr := String::from(match args.at(1) {
         Option::Some(expr) => expr,
 

--- a/example/calculator/src/parse.kd
+++ b/example/calculator/src/parse.kd
@@ -4,28 +4,28 @@ import tokenize
 use ast.*
 use tokenize.Token
 
-pub struct Parser {
+export struct Parser {
     current_idx: u64,
     tokens: Vector<Token>,
 }
 
 impl Parser {
-    pub fn new(): mut Parser {
+    export fun new() -> mut Parser {
         return Parser {
             current_idx: 0,
             tokens: Vector<Token>::new(),
         }
     }
 
-    fn clear(mut self) {
+    fun clear(mut self) {
         self.current_idx = 0
     }
 
-    fn increment_current_idx(mut self) {
+    fun increment_current_idx(mut self) {
         self.current_idx += 1
     }
 
-    fn consume(mut self, token: Token): bool {
+    fun consume(mut self, token: Token) -> bool {
         current_token := self.tokens.at(self.current_idx)
 
         return match current_token {
@@ -42,7 +42,7 @@ impl Parser {
         }
     }
 
-    fn expect_number(mut self): mut Node {
+    fun expect_number(mut self) -> mut Node {
         token := self.tokens.at(self.current_idx).unwrap()
 
         match token {
@@ -62,14 +62,14 @@ impl Parser {
         __unreachable()
     }
 
-    pub fn parse(mut self, tokens: Vector<Token>): Node {
+    export fun parse(mut self, tokens: Vector<Token>) -> Node {
         self.clear()
         self.tokens = tokens
         return self.add_or_sub()
     }
 
 
-    fn add_or_sub(mut self): mut Node {
+    fun add_or_sub(mut self) -> mut Node {
         mut node := self.mul_or_div()
 
         loop {
@@ -93,7 +93,7 @@ impl Parser {
         __unreachable()
     }
 
-    fn mul_or_div(mut self): mut Node {
+    fun mul_or_div(mut self) -> mut Node {
         mut node := self.primary()
 
         loop {
@@ -117,7 +117,7 @@ impl Parser {
         __unreachable()
     }
 
-    fn primary(mut self): mut Node {
+    fun primary(mut self) -> mut Node {
         if self.consume(Token::LParen) {
             node := self.add_or_sub()
             self.consume(Token::RParen)

--- a/example/calculator/src/tokenize.kd
+++ b/example/calculator/src/tokenize.kd
@@ -1,4 +1,4 @@
-pub enum Token {
+export enum Token {
     Num(i32),
     Add,
     Sub,
@@ -9,7 +9,7 @@ pub enum Token {
 }
 
 impl Token {
-    pub fn eq(self, other: Token): bool {
+    export fun eq(self, other: Token) -> bool {
         return match self {
             Token::Add => match other {
                 Token::Add => true,
@@ -49,14 +49,14 @@ impl Token {
     }
 }
 
-pub struct Tokenizer {}
+export struct Tokenizer {}
 
 impl Tokenizer {
-    pub fn new(): Tokenizer {
+    export fun new() -> Tokenizer {
         return Tokenizer {}
     }
 
-    fn string_to_int(s: String): i32 {
+    fun string_to_int(s: String) -> i32 {
         mut i := 0
         mut n := 0
 
@@ -74,7 +74,7 @@ impl Tokenizer {
         return n
     }
 
-    pub fn tokenize(self, program: String): Option<Vector<Token>> {
+    export fun tokenize(self, program: String) -> Option<Vector<Token>> {
         mut tokens := Vector<Token>::new()
 
         mut i := 0

--- a/example/comment_app/src/main.kd
+++ b/example/comment_app/src/main.kd
@@ -20,11 +20,11 @@ struct Counter {
 }
 
 impl Counter {
-    fn new(start: u64): mut Counter {
+    fun new(start: u64) -> mut Counter {
         return Counter { value: start }
     }
 
-    fn next(mut self): u64 {
+    fun next(mut self) -> u64 {
         id := self.value
         self.value = id + 1
         return id
@@ -177,14 +177,14 @@ app.ws("/ws/comments", |req, ws| {
 
 app.listen(port=8080)
 
-fn parse_since(req: std.http.Request): Option<u64> {
+fun parse_since(req: std.http.Request) -> Option<u64> {
     return match req.query("since") {
         Option::Some(value) => value.as_str().parse_u64(),
         Option::None => Option::Some(0),
     }
 }
 
-fn ws_reader(ws: mut std.http.WebSocket, events: Channel<String>) {
+fun ws_reader(ws: mut std.http.WebSocket, events: Channel<String>) {
     loop {
         match ws.receive() {
             Option::Some(msg) => {

--- a/example/http_kv_store/src/main.kd
+++ b/example/http_kv_store/src/main.kd
@@ -315,21 +315,21 @@ struct Counter {
 }
 
 impl Counter {
-    fn new(start: u64): mut Counter {
+    fun new(start: u64) -> mut Counter {
         return Counter { value: start }
     }
 
-    fn next(mut self): u64 {
+    fun next(mut self) -> u64 {
         id := self.value
         self.value = id + 1
         return id
     }
 }
 
-fn hash_string(s: String): u64 {
+fun hash_string(s: String) -> u64 {
     return hash_str(s.as_str())
 }
 
-fn eq_string(a: String, b: String): bool {
+fun eq_string(a: String, b: String) -> bool {
     return a.as_str() == b.as_str()
 }

--- a/example/rust_interop/src/main.kd
+++ b/example/rust_interop/src/main.kd
@@ -1,6 +1,6 @@
 import rust::rust_interop
 
-fn main(): i32 {
+fun main() -> i32 {
     rust::rust_interop::greetings()
     return rust::rust_interop::add(10, 20)
 }

--- a/library/src/autoload/slice.kd
+++ b/library/src/autoload/slice.kd
@@ -1,9 +1,9 @@
 impl<T> [T] {
-    pub fn as_ptr(self): *T {
+    export fun as_ptr(self) -> *T {
         return self.0
     }
 
-    pub fn len(self): u64 {
+    export fun len(self) -> u64 {
         return self.1
     }
 }

--- a/library/src/autoload/str.kd
+++ b/library/src/autoload/str.kd
@@ -1,9 +1,9 @@
 impl str {
-    pub fn as_ptr(self): *u8 {
+    export fun as_ptr(self) -> *u8 {
         return self.0
     }
 
-    pub fn len(self): u64 {
+    export fun len(self) -> u64 {
         return self.1
     }
 }

--- a/library/src/prelude.kd
+++ b/library/src/prelude.kd
@@ -9,14 +9,14 @@ import std.string
 import std.sync
 import std.ffi.args
 
-pub use std.collections.Vector
-pub use std.collections.HashMap
-pub use std.option.Option
-pub use std.result.Result
-pub use std.string.String
-pub use std.sync.Channel
-pub use std.ffi.args.__prepare_command_line_arguments
-pub use std.io.print
-pub use std.io.println
-pub use std.io.eprint
-pub use std.io.eprintln
+export use std.collections.Vector
+export use std.collections.HashMap
+export use std.option.Option
+export use std.result.Result
+export use std.string.String
+export use std.sync.Channel
+export use std.ffi.args.__prepare_command_line_arguments
+export use std.io.print
+export use std.io.println
+export use std.io.eprint
+export use std.io.eprintln

--- a/library/src/std/collections.kd
+++ b/library/src/std/collections.kd
@@ -5,34 +5,34 @@ use std.option.Option
 use std.ffi.mem.__mem_alloc
 use std.ffi.mem.__mem_realloc
 
-pub struct Vector<T> {
+export struct Vector<T> {
     ptr: *T,
     len: u64,
     capacity: u64,
 }
 
 impl<T> Vector<T> {
-    pub fn new(): mut Vector<T> {
+    export fun new() -> mut Vector<T> {
         return Vector<T> { ptr: __mem_alloc(0) as *T, len: 0, capacity: 0 }
     }
 
-    pub fn as_ptr(self): *T {
+    export fun as_ptr(self) -> *T {
         return self.ptr
     }
 
-    pub fn as_slice(self): [T] {
+    export fun as_slice(self) -> [T] {
         return __slice_from_raw_parts(self.ptr, self.len)
     }
 
-    pub fn len(self): u64 {
+    export fun len(self) -> u64 {
         return self.len
     }
 
-    pub fn capacity(self): u64 {
+    export fun capacity(self) -> u64 {
         return self.capacity
     }
 
-    pub fn push(mut self, elem: T) {
+    export fun push(mut self, elem: T) {
         let elem_size = __sizeof(elem)
 
         self.ensure_capacity(elem_size)
@@ -41,7 +41,7 @@ impl<T> Vector<T> {
         self.len += 1
     }
 
-    pub fn pop(mut self): Option<T> {
+    export fun pop(mut self) -> Option<T> {
         if self.len == 0 {
             return Option::None
         }
@@ -50,7 +50,7 @@ impl<T> Vector<T> {
         return Option::Some(self.ptr[self.len])
     }
 
-    pub fn at(self, idx: u64): Option<T> {
+    export fun at(self, idx: u64) -> Option<T> {
         if idx >= self.len {
             return Option::None
         }
@@ -58,7 +58,7 @@ impl<T> Vector<T> {
         return Option::Some(self.ptr[idx])
     }
 
-    pub fn set(mut self, idx: u64, value: T): bool {
+    export fun set(mut self, idx: u64, value: T) -> bool {
         if idx >= self.len {
             return false
         }
@@ -67,7 +67,7 @@ impl<T> Vector<T> {
         return true
     }
 
-    pub fn replace(mut self, idx: u64, value: T): Option<T> {
+    export fun replace(mut self, idx: u64, value: T) -> Option<T> {
         if idx >= self.len {
             return Option::None
         }
@@ -77,7 +77,7 @@ impl<T> Vector<T> {
         return Option::Some(old)
     }
 
-    pub fn remove(mut self, idx: u64): Option<T> {
+    export fun remove(mut self, idx: u64) -> Option<T> {
         if idx >= self.len {
             return Option::None
         }
@@ -96,7 +96,7 @@ impl<T> Vector<T> {
 
     // Removes an element in O(1) by replacing it with the last element.
     // This does not preserve order.
-    pub fn swap_remove(mut self, idx: u64): Option<T> {
+    export fun swap_remove(mut self, idx: u64) -> Option<T> {
         if idx >= self.len {
             return Option::None
         }
@@ -111,7 +111,7 @@ impl<T> Vector<T> {
         return Option::Some(removed)
     }
 
-    pub fn retain(mut self, pred: fn(T) -> bool) {
+    export fun retain(mut self, pred: fun(T) -> bool) {
         let mut write = 0
         let mut read = 0
 
@@ -129,7 +129,7 @@ impl<T> Vector<T> {
         self.len = write
     }
 
-    pub fn filter(self, pred: fn(T) -> bool): mut Vector<T> {
+    export fun filter(self, pred: fun(T) -> bool) -> mut Vector<T> {
         let mut out = Vector<T>::new()
         let mut i = 0
 
@@ -144,7 +144,7 @@ impl<T> Vector<T> {
         return out
     }
 
-    pub fn from_slice(s: [T]): mut Vector<T> {
+    export fun from_slice(s: [T]) -> mut Vector<T> {
         let mut v = Vector<T>::new()
         let mut i = 0
         while i < s.len() {
@@ -154,7 +154,7 @@ impl<T> Vector<T> {
         return v
     }
 
-    fn ensure_capacity(mut self, elem_size: u64) {
+    fun ensure_capacity(mut self, elem_size: u64) {
         if self.capacity == 0 {
             self.capacity = 4
             let new_size = elem_size * self.capacity
@@ -173,29 +173,29 @@ impl<T> Vector<T> {
     }
 }
 
-pub enum HashSlotState {
+export enum HashSlotState {
     Empty,
     Filled,
     Deleted,
 }
 
-pub struct HashMap<K, V> {
+export struct HashMap<K, V> {
     keys: Vector<Option<K>>,
     values: Vector<Option<V>>,
     states: Vector<HashSlotState>,
     len: u64,
     used: u64,
     capacity: u64,
-    hash: fn(K) -> u64,
-    equals: fn(K, K) -> bool,
+    hash: fun(K) -> u64,
+    equals: fun(K, K) -> bool,
 }
 
 impl<K, V> HashMap<K, V> {
-    pub fn new(hash: fn(K) -> u64, equals: fn(K, K) -> bool): mut HashMap<K, V> {
+    export fun new(hash: fun(K) -> u64, equals: fun(K, K) -> bool) -> mut HashMap<K, V> {
         return HashMap<K, V>::with_capacity(8, hash, equals)
     }
 
-    pub fn with_capacity(capacity: u64, hash: fn(K) -> u64, equals: fn(K, K) -> bool): mut HashMap<K, V> {
+    export fun with_capacity(capacity: u64, hash: fun(K) -> u64, equals: fun(K, K) -> bool) -> mut HashMap<K, V> {
         let normalized_capacity = HashMap<K, V>::normalize_capacity(capacity)
 
         let mut map = HashMap<K, V> {
@@ -213,15 +213,15 @@ impl<K, V> HashMap<K, V> {
         return map
     }
 
-    pub fn len(self): u64 {
+    export fun len(self) -> u64 {
         return self.len
     }
 
-    pub fn is_empty(self): bool {
+    export fun is_empty(self) -> bool {
         return self.len == 0
     }
 
-    pub fn insert(mut self, key: K, value: V): Option<V> {
+    export fun insert(mut self, key: K, value: V) -> Option<V> {
         if self.should_grow() {
             self.rehash(self.capacity * 2)
         }
@@ -229,7 +229,7 @@ impl<K, V> HashMap<K, V> {
         return self.insert_without_grow(key, value)
     }
 
-    pub fn get(self, key: K): Option<V> {
+    export fun get(self, key: K) -> Option<V> {
         if self.capacity == 0 {
             return Option::None
         }
@@ -242,14 +242,14 @@ impl<K, V> HashMap<K, V> {
         return self.values.at(idx).unwrap()
     }
 
-    pub fn contains(self, key: K): bool {
+    export fun contains(self, key: K) -> bool {
         return match self.get(key) {
             Option::Some(_) => true,
             Option::None => false,
         }
     }
 
-    pub fn remove(mut self, key: K): Option<V> {
+    export fun remove(mut self, key: K) -> Option<V> {
         if self.capacity == 0 {
             return Option::None
         }
@@ -267,7 +267,7 @@ impl<K, V> HashMap<K, V> {
         return old_value
     }
 
-    fn normalize_capacity(capacity: u64): u64 {
+    fun normalize_capacity(capacity: u64) -> u64 {
         let want = if capacity < 8 { 8 } else { capacity }
 
         let mut n = 8
@@ -278,7 +278,7 @@ impl<K, V> HashMap<K, V> {
         return n
     }
 
-    fn init_storage(mut self, capacity: u64) {
+    fun init_storage(mut self, capacity: u64) {
         self.capacity = capacity
         self.len = 0
         self.used = 0
@@ -292,11 +292,11 @@ impl<K, V> HashMap<K, V> {
         }
     }
 
-    fn should_grow(self): bool {
+    fun should_grow(self) -> bool {
         return (self.used * 100) >= (self.capacity * 70)
     }
 
-    fn find_slot(self, key: K): (bool, u64) {
+    fun find_slot(self, key: K) -> (bool, u64) {
         let h = self.hash
         let equals = self.equals
 
@@ -340,7 +340,7 @@ impl<K, V> HashMap<K, V> {
         panic("HashMap is full")
     }
 
-    fn insert_without_grow(mut self, key: K, value: V): Option<V> {
+    fun insert_without_grow(mut self, key: K, value: V) -> Option<V> {
         let (found, idx) = self.find_slot(key)
         let state = self.states.at(idx).unwrap()
 
@@ -366,7 +366,7 @@ impl<K, V> HashMap<K, V> {
         return Option::None
     }
 
-    fn rehash(mut self, new_capacity: u64) {
+    fun rehash(mut self, new_capacity: u64) {
         let capacity = HashMap<K, V>::normalize_capacity(new_capacity)
 
         let old_keys = self.keys
@@ -400,7 +400,7 @@ impl<K, V> HashMap<K, V> {
     }
 }
 
-pub fn hash_str(s: str): u64 {
+export fun hash_str(s: str) -> u64 {
     let mut h: u64 = 0xcbf29ce484222325 // FNV-1a 64-bit offset basis
     let prime: u64 = 0x100000001b3 // FNV-1a 64-bit prime
 

--- a/library/src/std/ffi/args.kd
+++ b/library/src/std/ffi/args.kd
@@ -2,9 +2,9 @@ import std.collections
 
 use std.collections.Vector
 
-pub extern "C" fn strlen(s: *u8): u64
+export extern "C" fun strlen(s: *u8) -> u64
 
-pub fn __prepare_command_line_arguments(argc: i32, argv: **u8): Vector<str> {
+export fun __prepare_command_line_arguments(argc: i32, argv: **u8) -> Vector<str> {
     let mut i = 0
     let mut args = Vector<str>::new()
     while i < argc {

--- a/library/src/std/ffi/http.kd
+++ b/library/src/std/ffi/http.kd
@@ -1,6 +1,6 @@
-pub extern "C" fn kaede_http_ws_accept(key: *u8, key_len: u64, out: *u8, out_len: u64): i32
+export extern "C" fun kaede_http_ws_accept(key: *u8, key_len: u64, out: *u8, out_len: u64) -> i32
 
 // Wraps the native helper that computes Sec-WebSocket-Accept.
-pub fn __http_ws_accept(key: [u8], out: mut [u8]): i32 {
+export fun __http_ws_accept(key: [u8], out: mut [u8]) -> i32 {
     return kaede_http_ws_accept(key.as_ptr(), key.len(), out.as_ptr(), out.len())
 }

--- a/library/src/std/ffi/io.kd
+++ b/library/src/std/ffi/io.kd
@@ -1,21 +1,21 @@
-pub extern "C" fn kaede_rt_stdin(): *u8
-pub extern "C" fn kaede_rt_stdout(): *u8
-pub extern "C" fn kaede_rt_stderr(): *u8
+export extern "C" fun kaede_rt_stdin() -> *u8
+export extern "C" fun kaede_rt_stdout() -> *u8
+export extern "C" fun kaede_rt_stderr() -> *u8
 
-pub extern "C" fn kaede_io_write(fd: i32, buf: *u8, byte: u64): i32
+export extern "C" fun kaede_io_write(fd: i32, buf: *u8, byte: u64) -> i32
 
-pub fn write(fd: i32, msg: str): i32 {
+export fun write(fd: i32, msg: str) -> i32 {
     return kaede_io_write(fd, msg.as_ptr(), msg.len())
 }
 
-pub fn __stdin(): *u8 {
+export fun __stdin() -> *u8 {
     return kaede_rt_stdin()
 }
 
-pub fn __stdout(): *u8 {
+export fun __stdout() -> *u8 {
     return kaede_rt_stdout()
 }
 
-pub fn __stderr(): *u8 {
+export fun __stderr() -> *u8 {
     return kaede_rt_stderr()
 }

--- a/library/src/std/ffi/mem.kd
+++ b/library/src/std/ffi/mem.kd
@@ -1,10 +1,10 @@
-pub extern "C" fn kaede_mem_alloc(size: u64): *u8
-pub extern "C" fn kaede_mem_realloc(ptr: *u8, size: u64): *u8
+export extern "C" fun kaede_mem_alloc(size: u64) -> *u8
+export extern "C" fun kaede_mem_realloc(ptr: *u8, size: u64) -> *u8
 
-pub fn __mem_alloc(size: u64): *u8 {
+export fun __mem_alloc(size: u64) -> *u8 {
     return kaede_mem_alloc(size)
 }
 
-pub fn __mem_realloc(ptr: *u8, size: u64): *u8 {
+export fun __mem_realloc(ptr: *u8, size: u64) -> *u8 {
     return kaede_mem_realloc(ptr, size)
 }

--- a/library/src/std/ffi/sync.kd
+++ b/library/src/std/ffi/sync.kd
@@ -1,19 +1,19 @@
 // Mutex FFI
-pub extern "C" fn kaede_mutex_new(): *u8
-pub extern "C" fn kaede_mutex_lock(m: *u8)
-pub extern "C" fn kaede_mutex_unlock(m: *u8)
+export extern "C" fun kaede_mutex_new() -> *u8
+export extern "C" fun kaede_mutex_lock(m: *u8)
+export extern "C" fun kaede_mutex_unlock(m: *u8)
 
 // WaitGroup FFI
-pub extern "C" fn kaede_wg_new(): *u8
-pub extern "C" fn kaede_wg_add(wg: *u8, delta: i32)
-pub extern "C" fn kaede_wg_done(wg: *u8)
-pub extern "C" fn kaede_wg_wait(wg: *u8)
+export extern "C" fun kaede_wg_new() -> *u8
+export extern "C" fun kaede_wg_add(wg: *u8, delta: i32)
+export extern "C" fun kaede_wg_done(wg: *u8)
+export extern "C" fun kaede_wg_wait(wg: *u8)
 
 // Channel FFI
-pub extern "C" fn kaede_chan_new(elem_size: u64, capacity: u64): *u8
-pub extern "C" fn kaede_chan_send(ch: *u8, value: *u8): i32
-pub extern "C" fn kaede_chan_try_send(ch: *u8, value: *u8): i32
-pub extern "C" fn kaede_chan_recv(ch: *u8, out: *u8): i32
-pub extern "C" fn kaede_chan_try_recv(ch: *u8, out: *u8): i32
-pub extern "C" fn kaede_chan_close(ch: *u8)
-pub extern "C" fn kaede_chan_is_closed(ch: *u8): i32
+export extern "C" fun kaede_chan_new(elem_size: u64, capacity: u64) -> *u8
+export extern "C" fun kaede_chan_send(ch: *u8, value: *u8) -> i32
+export extern "C" fun kaede_chan_try_send(ch: *u8, value: *u8) -> i32
+export extern "C" fun kaede_chan_recv(ch: *u8, out: *u8) -> i32
+export extern "C" fun kaede_chan_try_recv(ch: *u8, out: *u8) -> i32
+export extern "C" fun kaede_chan_close(ch: *u8)
+export extern "C" fun kaede_chan_is_closed(ch: *u8) -> i32

--- a/library/src/std/ffi/sys.kd
+++ b/library/src/std/ffi/sys.kd
@@ -1,65 +1,65 @@
-pub extern "C" fn kaede_sys_socket_tcp4(): i32
-pub extern "C" fn kaede_sys_set_reuseaddr(fd: i32): i32
-pub extern "C" fn kaede_sys_bind_ipv4(fd: i32, ip_or_null: *u8, port: u16): i32
-pub extern "C" fn kaede_sys_listen(fd: i32, backlog: i32): i32
-pub extern "C" fn kaede_sys_accept(listen_fd: i32): i32
-pub extern "C" fn kaede_sys_open_read(path: *u8, path_len: u64): i32
-pub extern "C" fn kaede_sys_read(fd: i32, buf: *u8, len: u64): i64
-pub extern "C" fn kaede_sys_write(fd: i32, buf: *u8, len: u64): i64
-pub extern "C" fn kaede_sys_is_regular_file(fd: i32): i32
-pub extern "C" fn kaede_sys_close(fd: i32): i32
-pub extern "C" fn kaede_sys_sleep_ms(ms: u64): i32
-pub extern "C" fn kaede_sys_errno(): i32
-pub extern "C" fn kaede_sys_somaxconn(): i32
+export extern "C" fun kaede_sys_socket_tcp4() -> i32
+export extern "C" fun kaede_sys_set_reuseaddr(fd: i32) -> i32
+export extern "C" fun kaede_sys_bind_ipv4(fd: i32, ip_or_null: *u8, port: u16) -> i32
+export extern "C" fun kaede_sys_listen(fd: i32, backlog: i32) -> i32
+export extern "C" fun kaede_sys_accept(listen_fd: i32) -> i32
+export extern "C" fun kaede_sys_open_read(path: *u8, path_len: u64) -> i32
+export extern "C" fun kaede_sys_read(fd: i32, buf: *u8, len: u64) -> i64
+export extern "C" fun kaede_sys_write(fd: i32, buf: *u8, len: u64) -> i64
+export extern "C" fun kaede_sys_is_regular_file(fd: i32) -> i32
+export extern "C" fun kaede_sys_close(fd: i32) -> i32
+export extern "C" fun kaede_sys_sleep_ms(ms: u64) -> i32
+export extern "C" fun kaede_sys_errno() -> i32
+export extern "C" fun kaede_sys_somaxconn() -> i32
 
-pub fn __sys_socket_tcp4(): i32 {
+export fun __sys_socket_tcp4() -> i32 {
     return kaede_sys_socket_tcp4()
 }
 
-pub fn __sys_set_reuseaddr(fd: i32): i32 {
+export fun __sys_set_reuseaddr(fd: i32) -> i32 {
     return kaede_sys_set_reuseaddr(fd)
 }
 
-pub fn __sys_bind_ipv4(fd: i32, ip_or_null: *u8, port: u16): i32 {
+export fun __sys_bind_ipv4(fd: i32, ip_or_null: *u8, port: u16) -> i32 {
     return kaede_sys_bind_ipv4(fd, ip_or_null, port)
 }
 
-pub fn __sys_listen(fd: i32, backlog: i32): i32 {
+export fun __sys_listen(fd: i32, backlog: i32) -> i32 {
     return kaede_sys_listen(fd, backlog)
 }
 
-pub fn __sys_accept(listen_fd: i32): i32 {
+export fun __sys_accept(listen_fd: i32) -> i32 {
     return kaede_sys_accept(listen_fd)
 }
 
-pub fn __sys_open_read(path: *u8, path_len: u64): i32 {
+export fun __sys_open_read(path: *u8, path_len: u64) -> i32 {
     return kaede_sys_open_read(path, path_len)
 }
 
-pub fn __sys_read(fd: i32, buf: *u8, len: u64): i64 {
+export fun __sys_read(fd: i32, buf: *u8, len: u64) -> i64 {
     return kaede_sys_read(fd, buf, len)
 }
 
-pub fn __sys_write(fd: i32, buf: *u8, len: u64): i64 {
+export fun __sys_write(fd: i32, buf: *u8, len: u64) -> i64 {
     return kaede_sys_write(fd, buf, len)
 }
 
-pub fn __sys_is_regular_file(fd: i32): i32 {
+export fun __sys_is_regular_file(fd: i32) -> i32 {
     return kaede_sys_is_regular_file(fd)
 }
 
-pub fn __sys_close(fd: i32): i32 {
+export fun __sys_close(fd: i32) -> i32 {
     return kaede_sys_close(fd)
 }
 
-pub fn __sys_sleep_ms(ms: u64): i32 {
+export fun __sys_sleep_ms(ms: u64) -> i32 {
     return kaede_sys_sleep_ms(ms)
 }
 
-pub fn __sys_errno(): i32 {
+export fun __sys_errno() -> i32 {
     return kaede_sys_errno()
 }
 
-pub fn __sys_somaxconn(): i32 {
+export fun __sys_somaxconn() -> i32 {
     return kaede_sys_somaxconn()
 }

--- a/library/src/std/http.kd
+++ b/library/src/std/http.kd
@@ -13,7 +13,7 @@ use std.ffi.http.__http_ws_accept
 
 // ====== Minimal HTTP request/response types ======
 
-pub enum Status {
+export enum Status {
     Ok, // 200
     NotFound, // 404
     BadRequest, // 400
@@ -21,7 +21,7 @@ pub enum Status {
     InternalServerError, // 500
 }
 
-pub enum WebSocketMessageKind {
+export enum WebSocketMessageKind {
     Text,
     Binary,
     Close,
@@ -34,7 +34,7 @@ struct PathParam {
     value: String,
 }
 
-pub struct Request {
+export struct Request {
     method: String,
     path: String,
     query: String,
@@ -44,12 +44,12 @@ pub struct Request {
     body: [u8],
 }
 
-pub struct WebSocketMessage {
+export struct WebSocketMessage {
     kind: WebSocketMessageKind,
     payload: Vector<u8>,
 }
 
-pub struct WebSocket {
+export struct WebSocket {
     conn: Fd,
     closed: bool,
 }
@@ -57,19 +57,19 @@ pub struct WebSocket {
 impl Request {
     // Returns the decoded value of the query parameter `name`
     // (e.g. ?name=alice%20bob -> query("name") -> Some("alice bob")).
-    pub fn query(self, name: str): Option<String> {
+    export fun query(self, name: str) -> Option<String> {
         return find_query_param_value(self.query, name)
     }
 
     // Returns the value of the path parameter `name` (e.g. "/users/:id" + "/users/42" -> param("id") -> Some("42")).
-    pub fn param(self, name: str): Option<String> {
+    export fun param(self, name: str) -> Option<String> {
         return find_path_param_value(self.params, name)
     }
 }
 
 impl WebSocket {
     // Reads the next WebSocket frame and maps it to a high-level message.
-    pub fn receive(mut self): Option<WebSocketMessage> {
+    export fun receive(mut self) -> Option<WebSocketMessage> {
         if self.closed {
             return Option::None
         }
@@ -108,7 +108,7 @@ impl WebSocket {
     // Sends a message using the opcode that matches its kind.
     // Returns false if the socket is already closed, the payload is invalid
     // for a control frame, or the frame write fails.
-    pub fn send(mut self, msg: WebSocketMessage): bool {
+    export fun send(mut self, msg: WebSocketMessage) -> bool {
         return match msg.kind {
             WebSocketMessageKind::Text => self.send_frame(1, msg.payload.as_slice()),
             WebSocketMessageKind::Binary => self.send_frame(2, msg.payload.as_slice()),
@@ -120,41 +120,41 @@ impl WebSocket {
 
     // Sends a text frame.
     // Returns false if the socket is already closed or the frame write fails.
-    pub fn send_text(mut self, text: str): bool {
+    export fun send_text(mut self, text: str) -> bool {
         let bytes = text.to_bytes()
         return self.send_frame(1, bytes.as_slice())
     }
 
     // Sends a binary frame.
     // Returns false if the socket is already closed or the frame write fails.
-    pub fn send_bytes(mut self, body: [u8]): bool {
+    export fun send_bytes(mut self, body: [u8]) -> bool {
         return self.send_frame(2, body)
     }
 
     // Sends a ping control frame.
     // Returns false if the socket is already closed, the payload exceeds 125 bytes,
     // or the frame write fails.
-    pub fn send_ping(mut self, body: [u8]): bool {
+    export fun send_ping(mut self, body: [u8]) -> bool {
         return self.send_control_frame(9, body)
     }
 
     // Sends a pong control frame.
     // Returns false if the socket is already closed, the payload exceeds 125 bytes,
     // or the frame write fails.
-    pub fn send_pong(mut self, body: [u8]): bool {
+    export fun send_pong(mut self, body: [u8]) -> bool {
         return self.send_control_frame(10, body)
     }
 
     // Sends a close control frame with an empty payload.
     // Returns false if the socket is already closed or the frame write fails.
-    pub fn close(mut self): bool {
+    export fun close(mut self) -> bool {
         return self.close_with_body(b"")
     }
 
     // Sends a close control frame with an explicit payload.
     // Returns false if the socket is already closed, the payload exceeds 125 bytes,
     // or the frame write fails. The socket is marked closed after this call.
-    pub fn close_with_body(mut self, body: [u8]): bool {
+    export fun close_with_body(mut self, body: [u8]) -> bool {
         if self.closed {
             return false
         }
@@ -168,7 +168,7 @@ impl WebSocket {
         return ok
     }
 
-    fn send_frame(mut self, opcode: u8, payload: [u8]): bool {
+    fun send_frame(mut self, opcode: u8, payload: [u8]) -> bool {
         if self.closed {
             return false
         }
@@ -181,7 +181,7 @@ impl WebSocket {
         return ok
     }
 
-    fn send_control_frame(mut self, opcode: u8, payload: [u8]): bool {
+    fun send_control_frame(mut self, opcode: u8, payload: [u8]) -> bool {
         if self.closed {
             return false
         }
@@ -204,7 +204,7 @@ struct ResponseHeader {
     value: String,
 }
 
-pub struct Response {
+export struct Response {
     conn: Fd,
     close_conn: bool,
     status: Status,
@@ -213,7 +213,7 @@ pub struct Response {
 }
 
 impl Response {
-    pub fn new(conn: Fd, close_conn: bool): mut Response {
+    export fun new(conn: Fd, close_conn: bool) -> mut Response {
         return Response {
             conn,
             close_conn,
@@ -223,12 +223,12 @@ impl Response {
         }
     }
 
-    pub fn status(mut self, code: Status): mut Response {
+    export fun status(mut self, code: Status) -> mut Response {
         self.status = code
         return self
     }
 
-    pub fn header(mut self, name: str, value: str): mut Response {
+    export fun header(mut self, name: str, value: str) -> mut Response {
         self.headers.push(ResponseHeader {
             name: String::from(name),
             value: String::from(value),
@@ -236,19 +236,19 @@ impl Response {
         return self
     }
 
-    pub fn content_type(mut self, value: str): mut Response {
+    export fun content_type(mut self, value: str) -> mut Response {
         return self.header("Content-Type", value)
     }
 
-    pub fn has_write_failed(self): bool {
+    export fun has_write_failed(self) -> bool {
         return self.write_failed
     }
 
-    fn mark_write_failed(mut self) {
+    fun mark_write_failed(mut self) {
         self.write_failed = true
     }
 
-    pub fn send_bytes(mut self, body: [u8]) {
+    export fun send_bytes(mut self, body: [u8]) {
         if !write_status_line(self.conn, self.status) {
             self.mark_write_failed()
             return
@@ -274,15 +274,15 @@ impl Response {
         }
     }
 
-    pub fn send_text(mut self, text: str) {
+    export fun send_text(mut self, text: str) {
         self.send_bytes(text.to_bytes().as_slice())
     }
 
-    pub fn send_string(mut self, text: str) {
+    export fun send_string(mut self, text: str) {
         self.send_text(text)
     }
 
-    pub fn send_file(mut self, body: [u8], content_type: str) {
+    export fun send_file(mut self, body: [u8], content_type: str) {
         self.content_type(content_type).send_bytes(body)
     }
 }
@@ -295,7 +295,7 @@ enum FrameReadResult {
 
 // Splits the request target (e.g. "/primes?n=1000") into path and query string.
 // Path is the part before '?'; query is the part after '?' or empty if no '?'.
-fn split_path_query(target: String): (String, String) {
+fun split_path_query(target: String) -> (String, String) {
     let mut i = 0
 
     let mut path = String::new()
@@ -330,7 +330,7 @@ fn split_path_query(target: String): (String, String) {
     return (path, query)
 }
 
-fn find_char_from(s: String, start: u64, target: char): u64 {
+fun find_char_from(s: String, start: u64, target: char) -> u64 {
     let mut i = start
     while i < s.len() {
         match s.at(i) {
@@ -347,7 +347,7 @@ fn find_char_from(s: String, start: u64, target: char): u64 {
 }
 
 // Finds a single byte in a byte slice.
-fn find_byte(buf: [u8], target: u8): i32 {
+fun find_byte(buf: [u8], target: u8) -> i32 {
     let mut i = 0
     while i < buf.len() {
         if buf[i] == target {
@@ -359,7 +359,7 @@ fn find_byte(buf: [u8], target: u8): i32 {
 }
 
 // Compares two byte slices for exact equality.
-fn bytes_eq(left: [u8], right: [u8]): bool {
+fun bytes_eq(left: [u8], right: [u8]) -> bool {
     if left.len() != right.len() {
         return false
     }
@@ -375,7 +375,7 @@ fn bytes_eq(left: [u8], right: [u8]): bool {
     return true
 }
 
-fn byte_to_lower(b: u8): u8 {
+fun byte_to_lower(b: u8) -> u8 {
     if b >= b'A' && b <= b'Z' {
         return b + 32
     }
@@ -383,7 +383,7 @@ fn byte_to_lower(b: u8): u8 {
 }
 
 // Compares two byte slices for ASCII-case-insensitive equality.
-fn bytes_eq_ci(left: [u8], right: [u8]): bool {
+fun bytes_eq_ci(left: [u8], right: [u8]) -> bool {
     if left.len() != right.len() {
         return false
     }
@@ -400,7 +400,7 @@ fn bytes_eq_ci(left: [u8], right: [u8]): bool {
 }
 
 // Trims leading and trailing spaces used in HTTP header values.
-fn trim_http_whitespace(value: [u8]): [u8] {
+fun trim_http_whitespace(value: [u8]) -> [u8] {
     let mut start = 0
     let mut end = value.len()
 
@@ -416,7 +416,7 @@ fn trim_http_whitespace(value: [u8]): [u8] {
 }
 
 // Checks whether an HTTP header line starts with the requested header name (case-insensitive).
-fn line_matches_header_name(line: [u8], name: [u8]): bool {
+fun line_matches_header_name(line: [u8], name: [u8]) -> bool {
     if line.len() < name.len() + 1 {
         return false
     }
@@ -429,7 +429,7 @@ fn line_matches_header_name(line: [u8], name: [u8]): bool {
 }
 
 // Returns the raw value of a named HTTP header.
-fn header_value(header: [u8], name: [u8]): Option<[u8]> {
+fun header_value(header: [u8], name: [u8]) -> Option<[u8]> {
     let mut line_start = 0
 
     loop {
@@ -464,7 +464,7 @@ fn header_value(header: [u8], name: [u8]): Option<[u8]> {
 }
 
 // Checks whether a comma-separated header value contains a given token.
-fn value_has_token(value: [u8], token: [u8]): bool {
+fun value_has_token(value: [u8], token: [u8]) -> bool {
     let mut i = 0
 
     while i < value.len() {
@@ -491,7 +491,7 @@ fn value_has_token(value: [u8], token: [u8]): bool {
 }
 
 // Checks whether the Connection header requests an Upgrade.
-fn has_connection_upgrade_token(header: [u8]): bool {
+fun has_connection_upgrade_token(header: [u8]) -> bool {
     let connection = header_value(header, b"Connection")
     return match connection {
         Option::Some(value) => value_has_token(value, b"Upgrade"),
@@ -500,7 +500,7 @@ fn has_connection_upgrade_token(header: [u8]): bool {
 }
 
 // Checks whether the Connection header contains "close" (case-insensitive).
-fn has_connection_close(header: [u8], version: str): bool {
+fun has_connection_close(header: [u8], version: str) -> bool {
     let connection = header_value(header, b"Connection")
     match connection {
         Option::Some(value) => {
@@ -522,7 +522,7 @@ fn has_connection_close(header: [u8], version: str): bool {
 }
 
 // Detects whether a request looks like a WebSocket upgrade attempt.
-fn is_websocket_upgrade_candidate(header: [u8]): bool {
+fun is_websocket_upgrade_candidate(header: [u8]) -> bool {
     if has_connection_upgrade_token(header) {
         return true
     }
@@ -548,7 +548,7 @@ fn is_websocket_upgrade_candidate(header: [u8]): bool {
 }
 
 // Validates the upgrade request and returns the Sec-WebSocket-Key.
-fn websocket_upgrade_key(method: str, version: str, header: [u8]): Option<[u8]> {
+fun websocket_upgrade_key(method: str, version: str, header: [u8]) -> Option<[u8]> {
     if method != "GET" {
         return Option::None
     }
@@ -590,7 +590,7 @@ fn websocket_upgrade_key(method: str, version: str, header: [u8]): Option<[u8]> 
 
 // Parses query string "key1=val1&key2=val2" and returns the value for the given name.
 // We scan each '&'-separated segment, then split the segment by '='.
-fn find_query_param_value(query: String, name: str): Option<String> {
+fun find_query_param_value(query: String, name: str) -> Option<String> {
     let mut seg_start = 0
     while seg_start <= query.len() {
         let seg_end = find_char_from(query, seg_start, '&')
@@ -612,7 +612,7 @@ fn find_query_param_value(query: String, name: str): Option<String> {
     return Option::None
 }
 
-fn decode_query_component(component: String): String {
+fun decode_query_component(component: String) -> String {
     let bytes = component.as_str().to_bytes()
     let mut out = Vector<u8>::new()
     let mut i = 0
@@ -643,7 +643,7 @@ fn decode_query_component(component: String): String {
     return String::from_bytes(out.as_slice())
 }
 
-fn hex_nibble(ch: char): i32 {
+fun hex_nibble(ch: char) -> i32 {
     if ch >= '0' && ch <= '9' {
         return (ch - '0') as i32
     }
@@ -657,7 +657,7 @@ fn hex_nibble(ch: char): i32 {
     return -1
 }
 
-fn find_path_param_value(params_vec: Vector<PathParam>, name: str): Option<String> {
+fun find_path_param_value(params_vec: Vector<PathParam>, name: str) -> Option<String> {
     let mut i = 0
     while i < params_vec.len() {
         let p = params_vec.at(i).unwrap()
@@ -669,7 +669,7 @@ fn find_path_param_value(params_vec: Vector<PathParam>, name: str): Option<Strin
     return Option::None
 }
 
-pub fn parse_content_length(header: [u8]): i32 {
+export fun parse_content_length(header: [u8]) -> i32 {
     let value = match header_value(header, b"Content-Length") {
         Option::Some(v) => v,
         Option::None => return 0,
@@ -688,7 +688,7 @@ pub fn parse_content_length(header: [u8]): i32 {
     return val
 }
 
-fn write_content_length(conn: Fd, len: u64): bool {
+fun write_content_length(conn: Fd, len: u64) -> bool {
     let prefix = b"Content-Length: "
     if std.sys.write(conn, prefix).is_none() {
         return false
@@ -725,7 +725,7 @@ fn write_content_length(conn: Fd, len: u64): bool {
     return std.sys.write(conn, b"\r\n").is_some()
 }
 
-pub fn write_status_line(conn: Fd, status: Status): bool {
+export fun write_status_line(conn: Fd, status: Status) -> bool {
     match status {
         Status::Ok => return std.sys.write(conn, b"HTTP/1.1 200 OK\r\n").is_some(),
         Status::NotFound => return std.sys.write(conn, b"HTTP/1.1 404 Not Found\r\n").is_some(),
@@ -737,7 +737,7 @@ pub fn write_status_line(conn: Fd, status: Status): bool {
     return false
 }
 
-fn write_response_headers(conn: Fd, headers: Vector<ResponseHeader>): bool {
+fun write_response_headers(conn: Fd, headers: Vector<ResponseHeader>) -> bool {
     let mut i = 0
     while i < headers.len() {
         let header = headers.at(i).unwrap()
@@ -759,7 +759,7 @@ fn write_response_headers(conn: Fd, headers: Vector<ResponseHeader>): bool {
     return true
 }
 
-pub fn write_text_response(conn: Fd, close_conn: bool, status: Status, body: [u8]): bool {
+export fun write_text_response(conn: Fd, close_conn: bool, status: Status, body: [u8]) -> bool {
     if !write_status_line(conn, status) {
         return false
     }
@@ -775,11 +775,11 @@ pub fn write_text_response(conn: Fd, close_conn: bool, status: Status, body: [u8
     return std.sys.write(conn, body).is_some()
 }
 
-pub fn write_bytes_response(conn: Fd, close_conn: bool, status: Status, body: [u8]): bool {
+export fun write_bytes_response(conn: Fd, close_conn: bool, status: Status, body: [u8]) -> bool {
     return write_text_response(conn, close_conn, status, body)
 }
 
-fn write_websocket_upgrade_response(conn: Fd, accept_value: [u8]): bool {
+fun write_websocket_upgrade_response(conn: Fd, accept_value: [u8]) -> bool {
     if std.sys.write(conn, b"HTTP/1.1 101 Switching Protocols\r\n").is_none() {
         return false
     }
@@ -799,7 +799,7 @@ fn write_websocket_upgrade_response(conn: Fd, accept_value: [u8]): bool {
 }
 
 // Writes a WebSocket control frame and enforces its payload size limit.
-fn write_ws_control_frame(conn: Fd, opcode: u8, payload: [u8]): bool {
+fun write_ws_control_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
     if payload.len() > 125 {
         return false
     }
@@ -808,7 +808,7 @@ fn write_ws_control_frame(conn: Fd, opcode: u8, payload: [u8]): bool {
 }
 
 // Encodes and writes a single server-side WebSocket frame.
-fn write_ws_frame(conn: Fd, opcode: u8, payload: [u8]): bool {
+fun write_ws_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
     let mut header = [0; 10]
     header[0] = opcode + 128
 
@@ -845,7 +845,7 @@ fn write_ws_frame(conn: Fd, opcode: u8, payload: [u8]): bool {
 }
 
 // Reads an exact number of bytes and reports whether it succeeded.
-fn read_exact_bytes(fd: Fd, buf: mut [u8], len: u64): bool {
+fun read_exact_bytes(fd: Fd, buf: mut [u8], len: u64) -> bool {
     return match std.sys.read_exact(fd, buf, len) {
         Option::Some(n) => n == len,
         Option::None => false,
@@ -853,7 +853,7 @@ fn read_exact_bytes(fd: Fd, buf: mut [u8], len: u64): bool {
 }
 
 // Reads a 16-bit extended WebSocket payload length.
-fn read_ws_len16(conn: Fd): Option<u64> {
+fun read_ws_len16(conn: Fd) -> Option<u64> {
     let mut buf = [0; 2]
     if !read_exact_bytes(conn, buf, 2) {
         return Option::None
@@ -863,7 +863,7 @@ fn read_ws_len16(conn: Fd): Option<u64> {
 }
 
 // Reads a 64-bit extended WebSocket payload length.
-fn read_ws_len64(conn: Fd): Option<u64> {
+fun read_ws_len64(conn: Fd) -> Option<u64> {
     let mut buf = [0; 8]
     if !read_exact_bytes(conn, buf, 8) {
         return Option::None
@@ -883,7 +883,7 @@ fn read_ws_len64(conn: Fd): Option<u64> {
 }
 
 // Reads and unmasks a WebSocket payload body.
-fn read_ws_payload(conn: Fd, payload_len: u64, mask_key: [u8]): Option<Vector<u8>> {
+fun read_ws_payload(conn: Fd, payload_len: u64, mask_key: [u8]) -> Option<Vector<u8>> {
     let mut out = Vector<u8>::new()
     let mut chunk = [0; 256]
     let mut remaining = payload_len
@@ -914,7 +914,7 @@ fn read_ws_payload(conn: Fd, payload_len: u64, mask_key: [u8]): Option<Vector<u8
 
 // Discards a bounded amount of frame body bytes so the server can send a close
 // frame before tearing the connection down on protocol errors.
-fn discard_ws_frame_body(conn: Fd, len: u64): bool {
+fun discard_ws_frame_body(conn: Fd, len: u64) -> bool {
     let mut chunk = [0; 256]
     let mut remaining = len
 
@@ -930,7 +930,7 @@ fn discard_ws_frame_body(conn: Fd, len: u64): bool {
 }
 
 // Reads one client WebSocket frame and validates the minimal protocol rules.
-fn read_ws_frame(conn: Fd): FrameReadResult {
+fun read_ws_frame(conn: Fd) -> FrameReadResult {
     let mut first_bytes = [0; 2]
     let n = match std.sys.read_exact(conn, first_bytes, 2) {
         Option::Some(value) => value,
@@ -1006,9 +1006,9 @@ fn read_ws_frame(conn: Fd): FrameReadResult {
 
 // ====== Routing ======
 
-pub type Handler = fn(mut Request, mut Response)
+export type Handler = fun(mut Request, mut Response)
 // Handler type used by WebSocket routes after the upgrade succeeds.
-pub type WebSocketHandler = fn(mut Request, mut WebSocket)
+export type WebSocketHandler = fun(mut Request, mut WebSocket)
 
 enum RouteKind {
     Http(Handler),
@@ -1043,14 +1043,14 @@ struct StaticDirRoute {
     fs_dir: String,
 }
 
-pub struct App {
+export struct App {
     routes: Vector<Route>,
     static_files: Vector<StaticFileRoute>,
     static_dirs: Vector<StaticDirRoute>,
 }
 
 impl App {
-    pub fn new(): mut App {
+    export fun new() -> mut App {
         return App {
             routes: Vector<Route>::new(),
             static_files: Vector<StaticFileRoute>::new(),
@@ -1058,33 +1058,33 @@ impl App {
         }
     }
 
-    pub fn get(mut self, path: str, handler: Handler) {
+    export fun get(mut self, path: str, handler: Handler) {
         self.add_http_route("GET", path, handler)
     }
 
-    pub fn post(mut self, path: str, handler: Handler) {
+    export fun post(mut self, path: str, handler: Handler) {
         self.add_http_route("POST", path, handler)
     }
 
-    pub fn ws(mut self, path: str, handler: WebSocketHandler) {
+    export fun ws(mut self, path: str, handler: WebSocketHandler) {
         self.add_ws_route("GET", path, handler)
     }
 
-    pub fn static_file(mut self, url_path: str, fs_path: str) {
+    export fun static_file(mut self, url_path: str, fs_path: str) {
         self.static_files.push(StaticFileRoute {
             url_path: String::from(url_path),
             fs_path: String::from(fs_path),
         })
     }
 
-    pub fn static_dir(mut self, url_prefix: str, fs_dir: str) {
+    export fun static_dir(mut self, url_prefix: str, fs_dir: str) {
         self.static_dirs.push(StaticDirRoute {
             url_prefix: normalize_static_prefix(url_prefix),
             fs_dir: String::from(fs_dir),
         })
     }
 
-    pub fn dispatch(self, req: mut Request, res: mut Response): bool {
+    export fun dispatch(self, req: mut Request, res: mut Response) -> bool {
         let http_match = self.find_http_route(req.method.as_str(), req.path.as_str())
         match http_match {
             Option::Some(found) => {
@@ -1103,20 +1103,20 @@ impl App {
         return self.dispatch_static(req.path, res)
     }
 
-    pub fn listen(self, ip: str = "0.0.0.0", port: u16) {
+    export fun listen(self, ip: str = "0.0.0.0", port: u16) {
         serve_tcp4(self, ip, port)
     }
 
-    fn add_http_route(mut self, method: str, path: str, handler: Handler) {
+    fun add_http_route(mut self, method: str, path: str, handler: Handler) {
         self.add_route(method, path, RouteKind::Http(handler))
     }
 
     // Registers a GET route that upgrades to WebSocket.
-    fn add_ws_route(mut self, method: str, path: str, handler: WebSocketHandler) {
+    fun add_ws_route(mut self, method: str, path: str, handler: WebSocketHandler) {
         self.add_route(method, path, RouteKind::Ws(handler))
     }
 
-    fn add_route(mut self, method: str, path: str, kind: RouteKind) {
+    fun add_route(mut self, method: str, path: str, kind: RouteKind) {
         let route_path = String::from(path)
         let has_params = has_path_params(route_path.as_str())
         let route = Route {
@@ -1128,7 +1128,7 @@ impl App {
         self.routes.push(route)
     }
 
-    fn find_http_route(self, method: str, path: str): Option<HttpRouteMatch> {
+    fun find_http_route(self, method: str, path: str) -> Option<HttpRouteMatch> {
         {
             let mut i = 0
             while i < self.routes.len() {
@@ -1172,7 +1172,7 @@ impl App {
     }
 
     // Finds the WebSocket handler that matches an incoming request path.
-    fn find_ws_route(self, method: str, path: str): Option<WsRouteMatch> {
+    fun find_ws_route(self, method: str, path: str) -> Option<WsRouteMatch> {
         {
             let mut i = 0
             while i < self.routes.len() {
@@ -1216,7 +1216,7 @@ impl App {
     }
 
     // Resolves a GET request against explicit static files first, then static directories.
-    fn dispatch_static(self, path: String, res: mut Response): bool {
+    fun dispatch_static(self, path: String, res: mut Response) -> bool {
         let file_match = self.find_static_file(path.as_str())
         match file_match {
             Option::Some(found) => {
@@ -1239,7 +1239,7 @@ impl App {
     }
 
     // Finds an exact static file mapping such as "/" -> "frontend/post.html".
-    fn find_static_file(self, path: str): Option<StaticFileRoute> {
+    fun find_static_file(self, path: str) -> Option<StaticFileRoute> {
         let mut i = 0
         while i < self.static_files.len() {
             let route = self.static_files.at(i).unwrap()
@@ -1253,7 +1253,7 @@ impl App {
     }
 
     // Maps a URL under a static directory prefix to a safe filesystem path.
-    fn find_static_dir_target(self, path: str): Option<String> {
+    fun find_static_dir_target(self, path: str) -> Option<String> {
         let mut i = 0
         while i < self.static_dirs.len() {
             let route = self.static_dirs.at(i).unwrap()
@@ -1278,7 +1278,7 @@ impl App {
     }
 }
 
-fn is_path_param_segment(segment: String): bool {
+fun is_path_param_segment(segment: String) -> bool {
     if segment.len() == 0 {
         return false
     }
@@ -1289,7 +1289,7 @@ fn is_path_param_segment(segment: String): bool {
     }
 }
 
-fn split_path_segments(path: String): Vector<String> {
+fun split_path_segments(path: String) -> Vector<String> {
     let mut segments = Vector<String>::new()
     let mut seg_start = 0
     while seg_start <= path.len() {
@@ -1304,7 +1304,7 @@ fn split_path_segments(path: String): Vector<String> {
 }
 
 // Returns true if the path has at least one ":name" segment.
-fn has_path_params(path: str): bool {
+fun has_path_params(path: str) -> bool {
     let path_segments = split_path_segments(String::from(path))
 
     let mut i = 0
@@ -1320,7 +1320,7 @@ fn has_path_params(path: str): bool {
 }
 
 // Matches route_path against path and fills `params` with extracted ":name" values.
-fn match_route_path(route_path: String, path: String, params: mut Vector<PathParam>): bool {
+fun match_route_path(route_path: String, path: String, params: mut Vector<PathParam>) -> bool {
     let route_segments = split_path_segments(route_path)
     let req_segments = split_path_segments(path)
     if route_segments.len() != req_segments.len() {
@@ -1349,7 +1349,7 @@ fn match_route_path(route_path: String, path: String, params: mut Vector<PathPar
 }
 
 // Normalizes a static directory prefix so route matching has one canonical form.
-fn normalize_static_prefix(prefix: str): String {
+fun normalize_static_prefix(prefix: str) -> String {
     if prefix.len() == 0 {
         return String::from("/")
     }
@@ -1367,7 +1367,7 @@ fn normalize_static_prefix(prefix: str): String {
 }
 
 // Removes the matched static prefix from a request path and returns the relative tail.
-fn strip_static_prefix(path: str, prefix: str): Option<String> {
+fun strip_static_prefix(path: str, prefix: str) -> Option<String> {
     if prefix == "/" {
         if path.len() <= 1 || path[0] != '/' {
             return Option::None
@@ -1392,7 +1392,7 @@ fn strip_static_prefix(path: str, prefix: str): Option<String> {
 }
 
 // Rejects traversal-like paths and returns a normalized relative path for static serving.
-fn sanitize_static_relative_path(relative: String): Option<String> {
+fun sanitize_static_relative_path(relative: String) -> Option<String> {
     if relative.len() == 0 {
         return Option::None
     }
@@ -1431,7 +1431,7 @@ fn sanitize_static_relative_path(relative: String): Option<String> {
 }
 
 // Joins a static directory root and a sanitized relative path into one filesystem path.
-fn join_static_fs_path(dir: String, relative: String): String {
+fun join_static_fs_path(dir: String, relative: String) -> String {
     if dir.len() == 0 {
         return relative
     }
@@ -1445,7 +1445,7 @@ fn join_static_fs_path(dir: String, relative: String): String {
 }
 
 // Opens a static file, validates it, reads it, and sends it with basic response headers.
-fn serve_static_path(res: mut Response, fs_path: String) {
+fun serve_static_path(res: mut Response, fs_path: String) {
     if fs_path.len() == 0 {
         res.status(Status::NotFound).send_bytes(b"")
         return
@@ -1481,7 +1481,7 @@ fn serve_static_path(res: mut Response, fs_path: String) {
 }
 
 // Guesses a content type from the file extension for common static assets.
-fn guess_content_type(path: str): str {
+fun guess_content_type(path: str) -> str {
     if path.ends_with(".html") {
         return "text/html; charset=utf-8"
     }
@@ -1510,7 +1510,7 @@ fn guess_content_type(path: str): str {
 // ====== Connection handling / server ======
 
 // Handles one TCP connection as either HTTP or WebSocket depending on the request.
-fn handle_conn(conn: Fd, app: App) {
+fun handle_conn(conn: Fd, app: App) {
     loop {
         let mut buf = [0; 8192]
 
@@ -1633,7 +1633,7 @@ fn handle_conn(conn: Fd, app: App) {
 }
 
 // Starts the TCP server and dispatches each accepted connection.
-pub fn serve_tcp4(app: App, ip: str, port: u16) {
+export fun serve_tcp4(app: App, ip: str, port: u16) {
     let backlog = std.sys.somaxconn()
     let fd = std.sys.socket_tcp4()
     std.sys.bind_ipv4(fd, ip, port)

--- a/library/src/std/io.kd
+++ b/library/src/std/io.kd
@@ -2,20 +2,20 @@ import std.ffi.io
 
 use std.ffi.io.write
 
-pub fn print(msg: str): i32 {
+export fun print(msg: str) -> i32 {
     return write(1, msg)
 }
 
-pub fn println(msg: str): i32 {
+export fun println(msg: str) -> i32 {
     print(msg)
     return write(1, "\n")
 }
 
-pub fn eprint(msg: str): i32 {
+export fun eprint(msg: str) -> i32 {
     return write(2, msg)
 }
 
-pub fn eprintln(msg: str): i32 {
+export fun eprintln(msg: str) -> i32 {
     eprint(msg)
     return write(2, "\n")
 }

--- a/library/src/std/option.kd
+++ b/library/src/std/option.kd
@@ -1,24 +1,24 @@
-pub enum Option<T> {
+export enum Option<T> {
     Some(T),
     None,
 }
 
 impl<T> Option<T> {
-    pub fn is_some(self): bool {
+    export fun is_some(self) -> bool {
         return match self {
             Option::Some(_) => true,
             Option::None => false,
         }
     }
 
-    pub fn is_none(self): bool {
+    export fun is_none(self) -> bool {
         return match self {
             Option::Some(_) => false,
             Option::None => true,
         }
     }
 
-    pub fn unwrap(self): T {
+    export fun unwrap(self) -> T {
         return match self {
             Option::Some(value) => value,
             Option::None => panic("called `Option::unwrap()` on a `None` value"),

--- a/library/src/std/result.kd
+++ b/library/src/std/result.kd
@@ -1,31 +1,31 @@
-pub enum Result<T, E> {
+export enum Result<T, E> {
     Ok(T),
     Err(E),
 }
 
 impl<T, E> Result<T, E> {
-    pub fn is_ok(self): bool {
+    export fun is_ok(self) -> bool {
         return match self {
             Result::Ok(_) => true,
             Result::Err(_) => false,
         }
     }
 
-    pub fn is_err(self): bool {
+    export fun is_err(self) -> bool {
         return match self {
             Result::Ok(_) => false,
             Result::Err(_) => true,
         }
     }
 
-    pub fn unwrap(self): T {
+    export fun unwrap(self) -> T {
         return match self {
             Result::Ok(value) => value,
             Result::Err(_) => panic("called `Result::unwrap()` on an `Err` value"),
         }
     }
 
-    pub fn unwrap_err(self): E {
+    export fun unwrap_err(self) -> E {
         return match self {
             Result::Ok(_) => panic("called `Result::unwrap_err()` on an `Ok` value"),
             Result::Err(err) => err,

--- a/library/src/std/string.kd
+++ b/library/src/std/string.kd
@@ -4,40 +4,40 @@ import std.option
 use std.collections.Vector
 use std.option.Option
 
-extern "C" fn kaede_utf8_char_at(s: *u8, len: u64, index: u64): char
-extern "C" fn kaede_utf8_char_count(s: *u8, len: u64): u64
-extern "C" fn kaede_utf8_byte_index_of_char(s: *u8, len: u64, index: u64): u64
+extern "C" fun kaede_utf8_char_at(s: *u8, len: u64, index: u64) -> char
+extern "C" fun kaede_utf8_char_count(s: *u8, len: u64) -> u64
+extern "C" fun kaede_utf8_byte_index_of_char(s: *u8, len: u64, index: u64) -> u64
 
-pub struct String {
+export struct String {
     bytes: Vector<u8>,
 }
 
 impl String {
-    pub fn new(): mut String {
+    export fun new() -> mut String {
         return String { bytes: Vector<u8>::new() }
     }
 
-    pub fn from(s: str): mut String {
+    export fun from(s: str) -> mut String {
         return String { bytes: s.to_bytes() }
     }
 
-    pub fn from_bytes(bytes: [u8]): String {
+    export fun from_bytes(bytes: [u8]) -> String {
         return String { bytes: Vector<u8>::from_slice(bytes) }
     }
 
-    pub fn as_ptr(self): *u8 {
+    export fun as_ptr(self) -> *u8 {
         return self.bytes.as_ptr()
     }
 
-    pub fn len(self): u64 {
+    export fun len(self) -> u64 {
         return kaede_utf8_char_count(self.as_ptr(), self.bytes.len())
     }
 
-    pub fn as_str(self): str {
+    export fun as_str(self) -> str {
         return __str(self.as_ptr(), self.bytes.len())
     }
 
-    pub fn at(self, idx: u64): Option<char> {
+    export fun at(self, idx: u64) -> Option<char> {
         if idx >= self.len() {
             return Option::None
         }
@@ -45,7 +45,7 @@ impl String {
         return Option::Some(kaede_utf8_char_at(self.as_ptr(), self.bytes.len(), idx))
     }
 
-    pub fn push(mut self, ch: char) {
+    export fun push(mut self, ch: char) {
         let code = ch as u32
 
         if code > 0x10FFFF || (code >= 0xD800 && code <= 0xDFFF) {
@@ -76,11 +76,11 @@ impl String {
         self.bytes.push((0x80 + (code & 0x3F)) as u8)
     }
 
-    pub fn clone(self): String {
+    export fun clone(self) -> String {
         return String { bytes: Vector<u8>::from_slice(self.bytes.as_slice()) }
     }
 
-    pub fn push_str(mut self, s: str) {
+    export fun push_str(mut self, s: str) {
         let bytes = s.to_bytes()
         let slice = bytes.as_slice()
         let mut i = 0
@@ -90,14 +90,14 @@ impl String {
         }
     }
 
-    pub fn push_line(mut self, s: str) {
+    export fun push_line(mut self, s: str) {
         self.push_str(s)
         self.push('\n')
     }
 
     // Returns substring from start (inclusive) to end (exclusive). Like [start:end] slice syntax.
     // Returns empty string if start >= end or start >= len.
-    pub fn slice(self, start: u64, end: u64): String {
+    export fun slice(self, start: u64, end: u64) -> String {
         let len = self.len()
         let safe_start = if start > len { len } else { start }
         let safe_end = if end > len { len } else { end }
@@ -111,7 +111,7 @@ impl String {
     }
 }
 
-fn parse_u64_from_str(s: str): Option<u64> {
+fun parse_u64_from_str(s: str) -> Option<u64> {
     let chars_len = kaede_utf8_char_count(s.as_ptr(), s.len())
     if chars_len == 0 {
         return Option::None
@@ -141,7 +141,7 @@ fn parse_u64_from_str(s: str): Option<u64> {
     return Option::Some(val)
 }
 
-fn parse_i64_from_str(s: str): Option<i64> {
+fun parse_i64_from_str(s: str) -> Option<i64> {
     let chars_len = kaede_utf8_char_count(s.as_ptr(), s.len())
     if chars_len == 0 {
         return Option::None
@@ -190,7 +190,7 @@ fn parse_i64_from_str(s: str): Option<i64> {
     return Option::Some(val as i64)
 }
 
-fn u64_to_string(n: u64): String {
+fun u64_to_string(n: u64) -> String {
     let mut x = n
     if x == 0 {
         let mut out = String::new()
@@ -217,7 +217,7 @@ fn u64_to_string(n: u64): String {
     return out
 }
 
-fn i64_to_string(n: i64): String {
+fun i64_to_string(n: i64) -> String {
     if n < 0 {
         let mut out = String::new()
         out.push('-')
@@ -237,16 +237,16 @@ fn i64_to_string(n: i64): String {
 
 impl str {
     // Converts a string slice to a byte vector.
-    pub fn to_bytes(self): Vector<u8> {
+    export fun to_bytes(self) -> Vector<u8> {
         return Vector<u8>::from_slice(__slice_from_raw_parts(self.as_ptr(), self.len()))
     }
 
-    pub fn chars_len(self): u64 {
+    export fun chars_len(self) -> u64 {
         return kaede_utf8_char_count(self.as_ptr(), self.len())
     }
 
     // Returns true when `self` begins with `prefix`.
-    pub fn starts_with(self, prefix: str): bool {
+    export fun starts_with(self, prefix: str) -> bool {
         let bytes = self.to_bytes()
         let prefix_bytes = prefix.to_bytes()
         if prefix_bytes.len() > bytes.len() {
@@ -267,7 +267,7 @@ impl str {
     }
 
     // Returns true when `self` ends with `suffix`.
-    pub fn ends_with(self, suffix: str): bool {
+    export fun ends_with(self, suffix: str) -> bool {
         let bytes = self.to_bytes()
         let suffix_bytes = suffix.to_bytes()
         if suffix_bytes.len() > bytes.len() {
@@ -288,23 +288,23 @@ impl str {
         return true
     }
 
-    pub fn parse_u64(self): std.option.Option<u64> {
+    export fun parse_u64(self) -> std.option.Option<u64> {
         return parse_u64_from_str(self)
     }
 
-    pub fn parse_i64(self): std.option.Option<i64> {
+    export fun parse_i64(self) -> std.option.Option<i64> {
         return parse_i64_from_str(self)
     }
 }
 
 impl u64 {
-    pub fn to_string(self): String {
+    export fun to_string(self) -> String {
         return u64_to_string(self)
     }
 }
 
 impl i64 {
-    pub fn to_string(self): String {
+    export fun to_string(self) -> String {
         return i64_to_string(self)
     }
 }

--- a/library/src/std/sync.kd
+++ b/library/src/std/sync.kd
@@ -6,76 +6,76 @@ use std.ffi.sync.*
 use std.ffi.mem.__mem_alloc
 use std.option.Option
 
-pub struct Mutex {
+export struct Mutex {
     ptr: *u8,
 }
 
 impl Mutex {
-    pub fn new(): mut Mutex {
+    export fun new() -> mut Mutex {
         return Mutex { ptr: kaede_mutex_new() }
     }
 
-    pub fn lock(mut self) {
+    export fun lock(mut self) {
         kaede_mutex_lock(self.ptr)
     }
 
-    pub fn unlock(mut self) {
+    export fun unlock(mut self) {
         kaede_mutex_unlock(self.ptr)
     }
 }
 
-pub struct WaitGroup {
+export struct WaitGroup {
     ptr: *u8,
 }
 
 impl WaitGroup {
-    pub fn new(): mut WaitGroup {
+    export fun new() -> mut WaitGroup {
         return WaitGroup { ptr: kaede_wg_new() }
     }
 
-    pub fn add(mut self, delta: i32) {
+    export fun add(mut self, delta: i32) {
         kaede_wg_add(self.ptr, delta)
     }
 
-    pub fn done(mut self) {
+    export fun done(mut self) {
         kaede_wg_done(self.ptr)
     }
 
-    pub fn wait(self) {
+    export fun wait(self) {
         kaede_wg_wait(self.ptr)
     }
 }
 
-pub struct Channel<T> {
+export struct Channel<T> {
     ptr: *u8,
 }
 
 impl<T> Channel<T> {
-    pub fn new(): Channel<T> {
+    export fun new() -> Channel<T> {
         return Channel<T> {
             ptr: kaede_chan_new(__type_size<T>(), 0),
         }
     }
 
-    pub fn with_capacity(capacity: u64): Channel<T> {
+    export fun with_capacity(capacity: u64) -> Channel<T> {
         return Channel<T> {
             ptr: kaede_chan_new(__type_size<T>(), capacity),
         }
     }
 
-    pub fn send(self, value: T) {
+    export fun send(self, value: T) {
         let slot = [value]
         if kaede_chan_send(self.ptr, slot.as_ptr() as *u8) != 0 {
             panic("send on closed channel")
         }
     }
 
-    pub fn try_send(self, value: T): bool {
+    export fun try_send(self, value: T) -> bool {
         let slot = [value]
         return kaede_chan_try_send(self.ptr, slot.as_ptr() as *u8) == 1
     }
 
-    pub fn recv(self): Option<T> {
+    export fun recv(self) -> Option<T> {
         let slot = __mem_alloc(__type_size<T>()) as *T
         let status = kaede_chan_recv(self.ptr, slot as *u8)
         if status == 0 {
@@ -84,7 +84,7 @@ impl<T> Channel<T> {
         return Option::None
     }
 
-    pub fn try_recv(self): Option<T> {
+    export fun try_recv(self) -> Option<T> {
         let slot = __mem_alloc(__type_size<T>()) as *T
         if kaede_chan_try_recv(self.ptr, slot as *u8) == 1 {
             return Option::Some(slot[0])
@@ -92,11 +92,11 @@ impl<T> Channel<T> {
         return Option::None
     }
 
-    pub fn close(self) {
+    export fun close(self) {
         kaede_chan_close(self.ptr)
     }
 
-    pub fn is_closed(self): bool {
+    export fun is_closed(self) -> bool {
         return kaede_chan_is_closed(self.ptr) == 1
     }
 }

--- a/library/src/std/sys.kd
+++ b/library/src/std/sys.kd
@@ -9,21 +9,21 @@ use std.string.String
 
 use std.ffi.sys.*
 
-pub struct Fd {
+export struct Fd {
     raw: i32,
 }
 
 impl Fd {
-    pub fn new(fd: i32): Fd {
+    export fun new(fd: i32) -> Fd {
         return Fd { raw: fd }
     }
 
-    pub fn raw(self): i32 {
+    export fun raw(self) -> i32 {
         return self.raw
     }
 }
 
-pub fn socket_tcp4(): Fd {
+export fun socket_tcp4() -> Fd {
     let fd = __sys_socket_tcp4()
     if fd < 0 {
         panic("socket_tcp4 failed")
@@ -31,36 +31,36 @@ pub fn socket_tcp4(): Fd {
     return Fd::new(fd)
 }
 
-pub fn set_reuseaddr(fd: Fd) {
+export fun set_reuseaddr(fd: Fd) {
     let r = __sys_set_reuseaddr(fd.raw)
     if r < 0 {
         panic("set_reuseaddr failed")
     }
 }
 
-pub fn bind_ipv4(fd: Fd, ip: str, port: u16) {
+export fun bind_ipv4(fd: Fd, ip: str, port: u16) {
     let r = __sys_bind_ipv4(fd.raw, ip.as_ptr(), port)
     if r < 0 {
         panic("bind_ipv4 failed")
     }
 }
 
-pub fn listen(fd: Fd, backlog: i32) {
+export fun listen(fd: Fd, backlog: i32) {
     let r = __sys_listen(fd.raw, backlog)
     if r < 0 {
         panic("listen failed")
     }
 }
 
-pub fn somaxconn(): i32 {
+export fun somaxconn() -> i32 {
     return __sys_somaxconn()
 }
 
-pub fn errno(): i32 {
+export fun errno() -> i32 {
     return __sys_errno()
 }
 
-pub fn accept(fd: Fd): Fd {
+export fun accept(fd: Fd) -> Fd {
     let c = __sys_accept(fd.raw)
     if c < 0 {
         panic("accept failed")
@@ -68,18 +68,18 @@ pub fn accept(fd: Fd): Fd {
     return Fd::new(c)
 }
 
-pub fn close(fd: Fd) {
+export fun close(fd: Fd) {
     let r = __sys_close(fd.raw)
     if r < 0 {
         panic("close failed")
     }
 }
 
-pub fn close_quiet(fd: Fd): bool {
+export fun close_quiet(fd: Fd) -> bool {
     return __sys_close(fd.raw) == 0
 }
 
-pub fn sleep_ms(ms: u64) {
+export fun sleep_ms(ms: u64) {
     let r = __sys_sleep_ms(ms)
     if r < 0 {
         panic("sleep_ms failed")
@@ -88,7 +88,7 @@ pub fn sleep_ms(ms: u64) {
 
 // ===== I/O =====
 
-pub fn open_read(path: str): Option<Fd> {
+export fun open_read(path: str) -> Option<Fd> {
     let fd = __sys_open_read(path.as_ptr(), path.len())
     if fd < 0 {
         return Option::None
@@ -97,11 +97,11 @@ pub fn open_read(path: str): Option<Fd> {
     return Option::Some(Fd::new(fd))
 }
 
-pub fn is_regular_file(fd: Fd): bool {
+export fun is_regular_file(fd: Fd) -> bool {
     return __sys_is_regular_file(fd.raw) == 1
 }
 
-pub fn read(fd: Fd, buf: mut [u8]): Option<u64> {
+export fun read(fd: Fd, buf: mut [u8]) -> Option<u64> {
     let n = __sys_read(fd.raw, buf.as_ptr(), buf.len())
     if n < 0 {
         return Option::None
@@ -110,7 +110,7 @@ pub fn read(fd: Fd, buf: mut [u8]): Option<u64> {
 }
 
 // Read exactly `len` bytes unless EOF is hit; returns bytes read.
-pub fn read_exact(fd: Fd, buf: mut [u8], len: u64): Option<u64> {
+export fun read_exact(fd: Fd, buf: mut [u8], len: u64) -> Option<u64> {
     let mut read_total = 0
     while read_total < len {
         let mut slice = buf[read_total:buf.len()]
@@ -126,11 +126,11 @@ pub fn read_exact(fd: Fd, buf: mut [u8], len: u64): Option<u64> {
     return Option::Some(read_total)
 }
 
-pub fn write(fd: Fd, buf: [u8]): Option<u64> {
+export fun write(fd: Fd, buf: [u8]) -> Option<u64> {
     return write_all(fd, buf)
 }
 
-fn write_all(fd: Fd, buf: [u8]): Option<u64> {
+fun write_all(fd: Fd, buf: [u8]) -> Option<u64> {
     let mut off = 0
     let total = buf.len()
 
@@ -156,7 +156,7 @@ fn write_all(fd: Fd, buf: [u8]): Option<u64> {
     return Option::Some(total)
 }
 
-pub fn read_all(fd: Fd, max_bytes: u64): Option<Vector<u8>> {
+export fun read_all(fd: Fd, max_bytes: u64) -> Option<Vector<u8>> {
     let mut out = Vector<u8>::new()
     let mut buf = [0; 4096]
 
@@ -184,7 +184,7 @@ pub fn read_all(fd: Fd, max_bytes: u64): Option<Vector<u8>> {
     return Option::Some(out)
 }
 
-pub fn read_until(fd: Fd, buf: mut [u8], delim: [u8]): Option<u64> {
+export fun read_until(fd: Fd, buf: mut [u8], delim: [u8]) -> Option<u64> {
     let mut filled = 0
 
     loop {
@@ -215,7 +215,7 @@ pub fn read_until(fd: Fd, buf: mut [u8], delim: [u8]): Option<u64> {
     __unreachable()
 }
 
-pub fn find_subslice(haystack: [u8], needle: [u8]): i32 {
+export fun find_subslice(haystack: [u8], needle: [u8]) -> i32 {
     let hlen = haystack.len()
     let nlen = needle.len()
 
@@ -247,7 +247,7 @@ pub fn find_subslice(haystack: [u8], needle: [u8]): i32 {
     return -1
 }
 
-pub fn parse_request_line(header: [u8]): (String, String, String) {
+export fun parse_request_line(header: [u8]) -> (String, String, String) {
     let i = find_subslice(header, b"\r\n")
     if i < 0 {
         panic("parse_request_line: missing CRLF")
@@ -257,7 +257,7 @@ pub fn parse_request_line(header: [u8]): (String, String, String) {
     return split3_spaces(line)
 }
 
-fn split3_spaces(line: [u8]): (String, String, String) {
+fun split3_spaces(line: [u8]) -> (String, String, String) {
     let sp1 = find_byte(line, b' ')
     if sp1 < 0 {
         panic("split3_spaces: missing first space")
@@ -281,7 +281,7 @@ fn split3_spaces(line: [u8]): (String, String, String) {
     return (method, target, ver)
 }
 
-fn find_byte(buf: [u8], b: u8): i32 {
+fun find_byte(buf: [u8], b: u8) -> i32 {
     let mut i = 0
     while i < buf.len() {
         if buf[i] == b {

--- a/website/docs/getting-started/first-program.md
+++ b/website/docs/getting-started/first-program.md
@@ -16,7 +16,7 @@ cd hello_kaede
 Kaede creates a project with a `src/` directory and a starter `main.kd` file:
 
 ```rust
-fn main() {
+fun main() {
     println("hello, world!")
 }
 ```

--- a/website/docs/language/concurrency.md
+++ b/website/docs/language/concurrency.md
@@ -13,11 +13,11 @@ Kaede includes built-in primitives for spawning tasks, passing values across cha
 Use `spawn` to start work in another task:
 
 ```rust
-fn producer(ch: Channel<i32>) {
+fun producer(ch: Channel<i32>) {
     ch.send(42)
 }
 
-fn main(): i32 {
+fun main() -> i32 {
     ch := Channel<i32>::new()
     spawn producer(ch)
     return 0

--- a/website/docs/language/control-flow.md
+++ b/website/docs/language/control-flow.md
@@ -80,7 +80,7 @@ while i < pending.len() {
 Functions use explicit `return` in the current codebase:
 
 ```rust
-fn foo(): i32 {
+fun foo() -> i32 {
     return 123
 }
 ```
@@ -91,7 +91,7 @@ Functions returning `Result<T, E>` can use postfix `?` for early returns:
 import std.result
 use std.result.Result
 
-fn read_value(): Result<i32, str> {
+fun read_value() -> Result<i32, str> {
     value := parse()?
     return Result::Ok(value)
 }

--- a/website/docs/language/generics.md
+++ b/website/docs/language/generics.md
@@ -11,7 +11,7 @@ Kaede supports generic functions, structs, enums, and `impl` blocks.
 Type parameters are written in angle brackets:
 
 ```rust
-fn identity<T>(value: T): T {
+fun identity<T>(value: T) -> T {
     return value
 }
 
@@ -25,7 +25,7 @@ struct Box<T> {
 Generic functions can declare one or more type parameters:
 
 ```rust
-fn first<T, U>(a: T, b: U): T {
+fun first<T, U>(a: T, b: U) -> T {
     return a
 }
 ```
@@ -93,11 +93,11 @@ struct Box<T> {
 }
 
 impl<T> Box<T> {
-    fn new(value: T): Box<T> {
+    fun new(value: T) -> Box<T> {
         return Box<T> { value: value }
     }
 
-    fn get(self): T {
+    fun get(self) -> T {
         return self.value
     }
 }
@@ -117,7 +117,7 @@ Kaede can infer generic type arguments in several common cases.
 Function calls:
 
 ```rust
-fn identity<T>(value: T): T {
+fun identity<T>(value: T) -> T {
     return value
 }
 

--- a/website/docs/language/overview.md
+++ b/website/docs/language/overview.md
@@ -46,14 +46,14 @@ In practice, current Kaede code tends to use:
 
 ## Functions and return types
 
-Functions declare return types with `: Type`.
+Functions declare return types with `-> Type`.
 
 ```rust
-fn greet() {
+fun greet() {
     println("hello, world!")
 }
 
-fn add(a: i32, b: i32): i32 {
+fun add(a: i32, b: i32) -> i32 {
     return a + b
 }
 ```
@@ -87,11 +87,11 @@ struct Counter {
 }
 
 impl Counter {
-    fn new(start: u64): mut Counter {
+    fun new(start: u64) -> mut Counter {
         return Counter { value: start }
     }
 
-    fn next(mut self): u64 {
+    fun next(mut self) -> u64 {
         id := self.value
         self.value = id + 1
         return id

--- a/website/docs/language/rust-interop.md
+++ b/website/docs/language/rust-interop.md
@@ -15,7 +15,7 @@ Kaede imports Rust code with `import rust::<crate>`:
 ```rust
 import rust::rust_interop
 
-fn main(): i32 {
+fun main() -> i32 {
     rust::rust_interop::greetings()
     return rust::rust_interop::add(10, 20)
 }
@@ -48,7 +48,7 @@ Generated `src/main.kd`:
 ```rust
 import rust::myproject
 
-fn main(): i32 {
+fun main() -> i32 {
     return rust::myproject::add(10, 20)
 }
 ```

--- a/website/docs/language/types.md
+++ b/website/docs/language/types.md
@@ -43,7 +43,7 @@ match <-ch {
 import std.result
 use std.result.Result
 
-fn parse_id(): Result<i32, str> {
+fun parse_id() -> Result<i32, str> {
     return Result::Ok(42)
 }
 ```
@@ -76,7 +76,7 @@ Comment {
 Enums can carry values:
 
 ```rust
-pub enum Token {
+export enum Token {
     Num(i32),
     Add,
     Sub,
@@ -100,7 +100,7 @@ Methods live in `impl` blocks:
 
 ```rust
 impl Counter {
-    fn next(mut self): u64 {
+    fun next(mut self) -> u64 {
         id := self.value
         self.value = id + 1
         return id


### PR DESCRIPTION
## Summary
- migrate Kaede function declarations to export fun ... -> T
- migrate function types to fun(...) -> T and reject legacy pub/fn syntax
- update the standard library, examples, tests, and language docs to the new syntax

## Verification
- cargo fmt --all
- cargo clippy -- -D warnings
- cargo test --release --no-fail-fast

Closes #218