### PR TITLE
feat(parser): add interface syntax and generic bound scaffolding

### DIFF
--- a/compiler/ast/src/top.rs
+++ b/compiler/ast/src/top.rs
@@ -56,9 +56,30 @@ impl From<bool> for Visibility {
 }
 
 #[derive(Debug, Clone)]
+pub struct GenericParam {
+    pub name: Ident,
+    /// Optional interface bound (e.g. `T: Reader`).
+    pub bound: Option<Ident>,
+}
+
+#[derive(Debug, Clone)]
 pub struct GenericParams {
-    pub names: Vec<Ident>,
+    pub params: Vec<GenericParam>,
     pub span: Span,
+}
+
+impl GenericParams {
+    pub fn len(&self) -> usize {
+        self.params.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.params.is_empty()
+    }
+
+    pub fn names(&self) -> impl Iterator<Item = Ident> + '_ {
+        self.params.iter().map(|p| p.name)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -178,6 +199,23 @@ pub struct Use {
 }
 
 #[derive(Debug, Clone)]
+pub struct InterfaceMethod {
+    pub name: Ident,
+    pub self_: Option<Mutability>,
+    pub params: Params,
+    pub return_ty: Rc<Ty>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub struct Interface {
+    pub vis: Visibility,
+    pub name: Ident,
+    pub methods: Vec<InterfaceMethod>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
 pub struct TypeAlias {
     pub vis: Visibility,
     pub name: Ident,
@@ -201,4 +239,5 @@ pub enum TopLevelKind {
     Extern(Extern),
     Use(Use),
     TypeAlias(TypeAlias),
+    Interface(Interface),
 }

--- a/compiler/lex/src/lib.rs
+++ b/compiler/lex/src/lib.rs
@@ -169,6 +169,7 @@ impl Cursor<'_> {
                     "while" => self.create_token(TokenKind::While),
                     "mut" => self.create_token(TokenKind::Mut),
                     "struct" => self.create_token(TokenKind::Struct),
+                    "interface" => self.create_token(TokenKind::Interface),
                     "true" => self.create_token(TokenKind::True),
                     "false" => self.create_token(TokenKind::False),
                     "import" => self.create_token(TokenKind::Import),

--- a/compiler/lex/src/token.rs
+++ b/compiler/lex/src/token.rs
@@ -126,6 +126,8 @@ pub enum TokenKind {
     While,
     /// "struct"
     Struct,
+    /// "interface"
+    Interface,
     /// "import"
     Import,
     /// "export"
@@ -233,6 +235,7 @@ impl std::fmt::Display for TokenKind {
                 Break => "'break'",
                 While => "'while'",
                 Struct => "'struct'",
+                Interface => "'interface'",
                 Import => "'import'",
                 Export => "'export'",
                 OldPub => "'pub'",

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -303,7 +303,9 @@ fn semantic_error_span(err: &SemanticError) -> Option<Span> {
         | SemanticError::InvalidFormatTemplate { span, .. }
         | SemanticError::FormatPlaceholderCountMismatch { span, .. }
         | SemanticError::TryRequiresResult { span, .. }
-        | SemanticError::TryOutsideResultFunction { span, .. } => Some(*span),
+        | SemanticError::TryOutsideResultFunction { span, .. }
+        | SemanticError::InterfaceNotYetSupported { span }
+        | SemanticError::GenericBoundNotYetSupported { span } => Some(*span),
         SemanticError::MainNotFound
         | SemanticError::LLVMError { .. }
         | SemanticError::FailedToLookupTarget { .. }

--- a/compiler/parse/src/top.rs
+++ b/compiler/parse/src/top.rs
@@ -2,9 +2,9 @@ use std::{collections::VecDeque, rc::Rc};
 
 use kaede_ast::{
     top::{
-        Enum, EnumVariant, Extern, Fn, FnDecl, GenericParams, Impl, Import, ImportKind, Param,
-        Params, Path, PathSegment, Struct, StructField, TopLevel, TopLevelKind, TypeAlias, Use,
-        VariadicKind, Visibility,
+        Enum, EnumVariant, Extern, Fn, FnDecl, GenericParam, GenericParams, Impl, Import,
+        ImportKind, Interface, InterfaceMethod, Param, Params, Path, PathSegment, Struct,
+        StructField, TopLevel, TopLevelKind, TypeAlias, Use, VariadicKind, Visibility,
     },
     ModuleItem,
 };
@@ -84,6 +84,11 @@ impl Parser {
                 (kind.span, TopLevelKind::TypeAlias(kind))
             }
 
+            TokenKind::Interface => {
+                let kind = self.interface(vis)?;
+                (kind.span, TopLevelKind::Interface(kind))
+            }
+
             _ => {
                 return Err(ParseError::ExpectedError {
                     expected: "top-level declaration".to_string(),
@@ -119,6 +124,7 @@ impl Parser {
                 | TokenKind::Extern
                 | TokenKind::Use
                 | TokenKind::Type
+                | TokenKind::Interface
         )
     }
 
@@ -157,10 +163,16 @@ impl Parser {
 
         let start = self.consume(&TokenKind::Lt)?.start;
 
-        let mut names = Vec::new();
+        let mut params = Vec::new();
 
         loop {
-            names.push(self.ident()?);
+            let name = self.ident()?;
+            let bound = if self.consume_b(&TokenKind::Colon) {
+                Some(self.ident()?)
+            } else {
+                None
+            };
+            params.push(GenericParam { name, bound });
 
             if !self.consume_b(&TokenKind::Comma) {
                 break;
@@ -169,7 +181,7 @@ impl Parser {
 
         Ok(if let Ok(span) = self.consume(&TokenKind::Gt) {
             Some(GenericParams {
-                names,
+                params,
                 span: self.new_span(start, span.finish),
             })
         } else {
@@ -190,7 +202,7 @@ impl Parser {
 
         if let Some(params) = &generic_params {
             self.generic_param_names_stack
-                .push(params.names.iter().map(|i| i.symbol()).collect());
+                .push(params.params.iter().map(|p| p.name.symbol()).collect());
         }
 
         let ty = self.ty()?;
@@ -357,7 +369,7 @@ impl Parser {
         // Push generic param names to determine if types is generic types.
         if let Some(params) = &generic_params {
             self.generic_param_names_stack
-                .push(params.names.iter().map(|i| i.symbol()).collect());
+                .push(params.params.iter().map(|p| p.name.symbol()).collect());
         }
 
         let params_start = self.consume(&TokenKind::OpenParen)?.start;
@@ -503,7 +515,7 @@ impl Parser {
         // Push generic param names to determine if types is generic types.
         if let Some(params) = &generic_params {
             self.generic_param_names_stack
-                .push(params.names.iter().map(|i| i.symbol()).collect());
+                .push(params.params.iter().map(|p| p.name.symbol()).collect());
         }
 
         self.consume(&TokenKind::OpenBrace)?;
@@ -579,7 +591,7 @@ impl Parser {
         // Push generic param names to determine if types is generic types.
         if let Some(params) = &generic_params {
             self.generic_param_names_stack
-                .push(params.names.iter().map(|i| i.symbol()).collect());
+                .push(params.params.iter().map(|p| p.name.symbol()).collect());
         }
 
         self.consume(&TokenKind::OpenBrace)?;
@@ -637,5 +649,91 @@ impl Parser {
         }
 
         Ok(fields)
+    }
+
+    fn interface(&mut self, vis: Visibility) -> ParseResult<Interface> {
+        let start = self.consume(&TokenKind::Interface).unwrap().start;
+
+        let name = self.ident()?;
+
+        self.consume(&TokenKind::OpenBrace)?;
+
+        let mut methods = Vec::new();
+
+        loop {
+            if self.check(&TokenKind::CloseBrace) {
+                break;
+            }
+
+            methods.push(self.interface_method()?);
+
+            if !self.check(&TokenKind::CloseBrace) {
+                self.consume_semi()?;
+            }
+        }
+
+        let finish = self.consume(&TokenKind::CloseBrace)?.finish;
+
+        Ok(Interface {
+            vis,
+            name,
+            methods,
+            span: self.new_span(start, finish),
+        })
+    }
+
+    fn interface_method(&mut self) -> ParseResult<InterfaceMethod> {
+        let start = self.consume(&TokenKind::Fun)?.start;
+
+        let name = self.ident()?;
+
+        let params_start = self.consume(&TokenKind::OpenParen)?.start;
+
+        let mutability = self.consume_b(&TokenKind::Mut).into();
+        let has_self = self.consume_b(&TokenKind::Self_);
+        if !has_self && mutability == Mutability::Mut {
+            return Err(ParseError::ExpectedError {
+                expected: "'self'".to_string(),
+                but: self.first().kind.to_string(),
+                span: self.first().span,
+            }
+            .into());
+        }
+
+        let first_param = if has_self {
+            let _ = self.consume(&TokenKind::Comma);
+            None
+        } else if self.check(&TokenKind::CloseParen) {
+            None
+        } else {
+            let param = self.fn_param()?;
+            let _ = self.consume(&TokenKind::Comma);
+            Some(param)
+        };
+
+        let params = {
+            let mut params = self.fn_params(params_start)?;
+            if let Some(first_param) = first_param {
+                params.v.push_front(first_param);
+            }
+            params
+        };
+
+        let (return_ty, finish) = if self.consume_b(&TokenKind::Arrow) {
+            let ret_ty = Rc::new(self.ty()?);
+            let finish = ret_ty.span.finish;
+            (ret_ty, finish)
+        } else {
+            let unit_span = self.new_span(params.span.finish, params.span.finish);
+            (Rc::new(Ty::new_unit(unit_span)), params.span.finish)
+        };
+
+        Ok(InterfaceMethod {
+            name,
+            self_: if has_self { Some(mutability) } else { None },
+            params,
+            return_ty,
+            span: self.new_span(start, finish),
+        })
     }
 }

--- a/compiler/parse/tests/interface_decl.rs
+++ b/compiler/parse/tests/interface_decl.rs
@@ -1,0 +1,135 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use kaede_ast::{top::TopLevelKind, ModuleItem};
+use kaede_ast_type::Mutability;
+use kaede_parse::Parser;
+use kaede_span::file::FilePath;
+use kaede_symbol::Symbol;
+
+fn file() -> FilePath {
+    FilePath::from(PathBuf::from("test.kd"))
+}
+
+#[test]
+fn parse_interface_with_methods() -> Result<()> {
+    let src = "\
+export interface Reader {
+    fun read(mut self, buf: i32) -> i32
+    fun peek(self) -> i32
+}
+";
+    let mut parser = Parser::new(src, file());
+    let compile_unit = parser.run()?;
+
+    let ModuleItem::Decl(top) = compile_unit.items.front().unwrap() else {
+        panic!("expected top-level declaration");
+    };
+
+    let TopLevelKind::Interface(interface) = &top.kind else {
+        panic!("expected interface top-level");
+    };
+
+    assert!(interface.vis.is_public());
+    assert_eq!(interface.name.symbol(), Symbol::from("Reader".to_string()));
+    assert_eq!(interface.methods.len(), 2);
+
+    let read = &interface.methods[0];
+    assert_eq!(read.name.symbol(), Symbol::from("read".to_string()));
+    assert_eq!(read.self_, Some(Mutability::Mut));
+    assert_eq!(read.params.v.len(), 1);
+
+    let peek = &interface.methods[1];
+    assert_eq!(peek.name.symbol(), Symbol::from("peek".to_string()));
+    assert_eq!(peek.self_, Some(Mutability::Not));
+    assert_eq!(peek.params.v.len(), 0);
+
+    Ok(())
+}
+
+#[test]
+fn parse_interface_without_export() -> Result<()> {
+    let src = "\
+interface Stringer {
+    fun to_string(self) -> i32
+}
+";
+    let mut parser = Parser::new(src, file());
+    let compile_unit = parser.run()?;
+
+    let ModuleItem::Decl(top) = compile_unit.items.front().unwrap() else {
+        panic!("expected top-level declaration");
+    };
+
+    let TopLevelKind::Interface(interface) = &top.kind else {
+        panic!("expected interface top-level");
+    };
+
+    assert!(interface.vis.is_private());
+    assert_eq!(interface.methods.len(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn parse_empty_interface() -> Result<()> {
+    let src = "interface Empty {}\n";
+    let mut parser = Parser::new(src, file());
+    let compile_unit = parser.run()?;
+
+    let ModuleItem::Decl(top) = compile_unit.items.front().unwrap() else {
+        panic!("expected top-level declaration");
+    };
+
+    let TopLevelKind::Interface(interface) = &top.kind else {
+        panic!("expected interface top-level");
+    };
+
+    assert_eq!(interface.methods.len(), 0);
+    Ok(())
+}
+
+#[test]
+fn parse_generic_bound() -> Result<()> {
+    let src = "\
+fun drain<T: Reader>(r: T) {}
+";
+    let mut parser = Parser::new(src, file());
+    let compile_unit = parser.run()?;
+
+    let ModuleItem::Decl(top) = compile_unit.items.front().unwrap() else {
+        panic!("expected top-level declaration");
+    };
+
+    let TopLevelKind::Fn(func) = &top.kind else {
+        panic!("expected function top-level");
+    };
+
+    let gp = func.decl.generic_params.as_ref().expect("generic params");
+    assert_eq!(gp.params.len(), 1);
+    let bound = gp.params[0].bound.as_ref().expect("bound");
+    assert_eq!(bound.symbol(), Symbol::from("Reader".to_string()));
+
+    Ok(())
+}
+
+#[test]
+fn parse_generic_without_bound() -> Result<()> {
+    let src = "fun id<T>(x: T) -> T { return x }\n";
+    let mut parser = Parser::new(src, file());
+    let compile_unit = parser.run()?;
+
+    let ModuleItem::Decl(top) = compile_unit.items.front().unwrap() else {
+        panic!("expected top-level declaration");
+    };
+
+    let TopLevelKind::Fn(func) = &top.kind else {
+        panic!("expected function top-level");
+    };
+
+    let gp = func.decl.generic_params.as_ref().expect("generic params");
+    assert_eq!(gp.params.len(), 1);
+    assert!(gp.params[0].bound.is_none());
+
+    Ok(())
+}

--- a/compiler/semantic/src/error.rs
+++ b/compiler/semantic/src/error.rs
@@ -226,4 +226,10 @@ pub enum SemanticError {
 
     #[error("{}:{}:{} `?` can only be used in functions returning `Result<T, E>`, got `{}`", span.file, span.start.line, span.start.column, actual)]
     TryOutsideResultFunction { actual: String, span: Span },
+
+    #[error("{}:{}:{} `interface` is not yet supported by the compiler", span.file, span.start.line, span.start.column)]
+    InterfaceNotYetSupported { span: Span },
+
+    #[error("{}:{}:{} generic bounds are not yet supported by the compiler", span.file, span.start.line, span.start.column)]
+    GenericBoundNotYetSupported { span: Span },
 }

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -1372,7 +1372,7 @@ impl SemanticAnalyzer {
                 .decl
                 .generic_params
                 .as_ref()
-                .map_or(0, |params| params.names.len());
+                .map_or(0, |params| params.len());
             if inferred_args.len() < param_len {
                 inferred_args.extend(
                     (0..(param_len - inferred_args.len())).map(|_| self.infer_context.fresh()),

--- a/compiler/semantic/src/symbol_table.rs
+++ b/compiler/semantic/src/symbol_table.rs
@@ -14,9 +14,9 @@ impl SemanticAnalyzer {
         f: impl FnOnce(&mut Self) -> anyhow::Result<T>,
     ) -> anyhow::Result<T> {
         // Check the length of the generic arguments
-        if generic_params.names.len() != generic_args.len() {
+        if generic_params.len() != generic_args.len() {
             return Err(SemanticError::GenericArgumentLengthMismatch {
-                expected: generic_params.names.len(),
+                expected: generic_params.len(),
                 actual: generic_args.len(),
                 span: generic_params.span,
             }
@@ -27,8 +27,7 @@ impl SemanticAnalyzer {
 
         generic_argument_table.map.extend(
             generic_params
-                .names
-                .iter()
+                .names()
                 .zip(generic_args.iter())
                 .map(|(ident, ty)| (ident.symbol(), ty.clone())),
         );

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -40,6 +40,8 @@ impl SemanticAnalyzer {
     ) -> anyhow::Result<TopLevelAnalysisResult> {
         use ast::top::TopLevelKind;
 
+        check_no_generic_bounds(&top_level.kind)?;
+
         match top_level.kind {
             TopLevelKind::Fn(node) => self.analyze_fn(node),
             TopLevelKind::Struct(node) => self.analyze_struct(node),
@@ -49,6 +51,9 @@ impl SemanticAnalyzer {
             TopLevelKind::Import(node) => self.analyze_import(node),
             TopLevelKind::Use(node) => self.analyze_use(node),
             TopLevelKind::TypeAlias(node) => self.analyze_type_alias(node),
+            TopLevelKind::Interface(node) => {
+                Err(SemanticError::InterfaceNotYetSupported { span: node.span }.into())
+            }
         }
     }
 
@@ -916,4 +921,28 @@ impl SemanticAnalyzer {
 
         Ok(TopLevelAnalysisResult::Imported(vec![]))
     }
+}
+
+fn check_no_generic_bounds(kind: &ast::top::TopLevelKind) -> anyhow::Result<()> {
+    use ast::top::TopLevelKind;
+
+    let generic_params = match kind {
+        TopLevelKind::Fn(node) => node.decl.generic_params.as_ref(),
+        TopLevelKind::Struct(node) => node.generic_params.as_ref(),
+        TopLevelKind::Enum(node) => node.generic_params.as_ref(),
+        TopLevelKind::Impl(node) => node.generic_params.as_ref(),
+        TopLevelKind::Extern(node) => node.fn_decl.generic_params.as_ref(),
+        TopLevelKind::Import(_)
+        | TopLevelKind::Use(_)
+        | TopLevelKind::TypeAlias(_)
+        | TopLevelKind::Interface(_) => None,
+    };
+
+    if let Some(params) = generic_params {
+        if params.params.iter().any(|p| p.bound.is_some()) {
+            return Err(SemanticError::GenericBoundNotYetSupported { span: params.span }.into());
+        }
+    }
+
+    Ok(())
 }

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -126,9 +126,9 @@ impl SemanticAnalyzer {
         args: &[Rc<ir_type::Ty>],
         span: Span,
     ) -> anyhow::Result<()> {
-        if params.names.len() != args.len() {
+        if params.len() != args.len() {
             return Err(SemanticError::GenericArgumentLengthMismatch {
-                expected: params.names.len(),
+                expected: params.len(),
                 actual: args.len(),
                 span,
             }
@@ -364,9 +364,9 @@ impl SemanticAnalyzer {
                     let generic_params = impl_info.impl_.generic_params.as_ref().unwrap().clone();
 
                     // Check if the length of the generic arguments is the same as the number of generic parameters
-                    if generic_params.names.len() != generic_args.len() {
+                    if generic_params.len() != generic_args.len() {
                         return Err(SemanticError::GenericArgumentLengthMismatch {
-                            expected: generic_params.names.len(),
+                            expected: generic_params.len(),
                             actual: generic_args.len(),
                             span: generic_params.span,
                         }

--- a/compiler/symbol_table/src/lib.rs
+++ b/compiler/symbol_table/src/lib.rs
@@ -104,8 +104,8 @@ impl GenericInfo {
 
     pub fn get_generic_argument_length(&self) -> usize {
         match &self.kind {
-            GenericKind::Struct(info) => info.ast.generic_params.as_ref().unwrap().names.len(),
-            GenericKind::Enum(info) => info.ast.generic_params.as_ref().unwrap().names.len(),
+            GenericKind::Struct(info) => info.ast.generic_params.as_ref().unwrap().len(),
+            GenericKind::Enum(info) => info.ast.generic_params.as_ref().unwrap().len(),
             GenericKind::Slice(_) => 1,
             _ => unreachable!(),
         }


### PR DESCRIPTION
## Summary
- Adds the `interface` keyword, AST nodes, and parser support for interface declarations.
- Extends generic parameters to accept a single bound via `T: Bound` syntax.
- Wires semantic analysis to emit dedicated `InterfaceNotYetSupported` / `GenericBoundNotYetSupported` errors so downstream stages can land incrementally.

This is the first iteration of #219. Later iterations will add the type representation, conformance checks, IR/codegen for fat pointers and itables, boxing, and stdlib adoption.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --release --no-fail-fast`
- [x] New parser tests in `compiler/parse/tests/interface_decl.rs` cover public / private / empty interfaces and bound/unbound generics.
- [x] Manual smoke test: compiling a source file containing `interface` or `T: Bound` produces the new semantic error with the correct span.