### PR TITLE
feat(semantic): add interface IR and symbol table representation

### DIFF
--- a/compiler/codegen/src/top.rs
+++ b/compiler/codegen/src/top.rs
@@ -28,6 +28,8 @@ impl<'ctx> CodeGenerator<'ctx> {
             TopLevel::Struct(node) => self.build_struct(&node),
 
             TopLevel::Enum(node) => self.build_enum(&node),
+
+            TopLevel::Interface(_) => {}
         };
         Ok(())
     }

--- a/compiler/ir/src/top.rs
+++ b/compiler/ir/src/top.rs
@@ -7,7 +7,7 @@ use crate::{
     expr,
     qualified_symbol::QualifiedSymbol,
     stmt::Block,
-    ty::{GenericInstanceInfo, Ty},
+    ty::{GenericInstanceInfo, Mutability, Ty},
 };
 
 #[derive(Debug, Clone)]
@@ -91,10 +91,25 @@ pub struct Impl {
     pub methods: Vec<Rc<Fn>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InterfaceMethod {
+    pub name: Symbol,
+    pub self_: Option<Mutability>,
+    pub params: Vec<Param>,
+    pub return_ty: Rc<Ty>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Interface {
+    pub name: QualifiedSymbol,
+    pub methods: Vec<InterfaceMethod>,
+}
+
 #[derive(Debug, Clone)]
 pub enum TopLevel {
     Fn(Rc<Fn>),
     Struct(Rc<Struct>),
     Enum(Rc<Enum>),
     Impl(Rc<Impl>),
+    Interface(Rc<Interface>),
 }

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -304,7 +304,6 @@ fn semantic_error_span(err: &SemanticError) -> Option<Span> {
         | SemanticError::FormatPlaceholderCountMismatch { span, .. }
         | SemanticError::TryRequiresResult { span, .. }
         | SemanticError::TryOutsideResultFunction { span, .. }
-        | SemanticError::InterfaceNotYetSupported { span }
         | SemanticError::GenericBoundNotYetSupported { span } => Some(*span),
         SemanticError::MainNotFound
         | SemanticError::LLVMError { .. }

--- a/compiler/monomorphize/src/lib.rs
+++ b/compiler/monomorphize/src/lib.rs
@@ -255,7 +255,7 @@ impl Monomorphizer {
                     }
                 }
             }
-            TopLevel::Struct(_) | TopLevel::Enum(_) => {}
+            TopLevel::Struct(_) | TopLevel::Enum(_) | TopLevel::Interface(_) => {}
         }
         Ok(())
     }

--- a/compiler/semantic/src/error.rs
+++ b/compiler/semantic/src/error.rs
@@ -227,9 +227,6 @@ pub enum SemanticError {
     #[error("{}:{}:{} `?` can only be used in functions returning `Result<T, E>`, got `{}`", span.file, span.start.line, span.start.column, actual)]
     TryOutsideResultFunction { actual: String, span: Span },
 
-    #[error("{}:{}:{} `interface` is not yet supported by the compiler", span.file, span.start.line, span.start.column)]
-    InterfaceNotYetSupported { span: Span },
-
     #[error("{}:{}:{} generic bounds are not yet supported by the compiler", span.file, span.start.line, span.start.column)]
     GenericBoundNotYetSupported { span: Span },
 }

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -195,6 +195,7 @@ impl SemanticAnalyzer {
                 ast::top::TopLevelKind::Struct(_)
                     | ast::top::TopLevelKind::Enum(_)
                     | ast::top::TopLevelKind::TypeAlias(_)
+                    | ast::top::TopLevelKind::Interface(_)
             )
         });
 
@@ -744,6 +745,7 @@ impl SemanticAnalyzer {
                         }
                     }
                 }
+                ir::top::TopLevel::Interface(_) => {}
             }
         }
     }
@@ -1261,7 +1263,9 @@ impl SemanticAnalyzer {
                         }
                     }
                 }
-                ir::top::TopLevel::Struct(_) | ir::top::TopLevel::Enum(_) => {}
+                ir::top::TopLevel::Struct(_)
+                | ir::top::TopLevel::Enum(_)
+                | ir::top::TopLevel::Interface(_) => {}
             }
 
             self.generated_generics[i] = top_level;

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -51,9 +51,7 @@ impl SemanticAnalyzer {
             TopLevelKind::Import(node) => self.analyze_import(node),
             TopLevelKind::Use(node) => self.analyze_use(node),
             TopLevelKind::TypeAlias(node) => self.analyze_type_alias(node),
-            TopLevelKind::Interface(node) => {
-                Err(SemanticError::InterfaceNotYetSupported { span: node.span }.into())
-            }
+            TopLevelKind::Interface(node) => self.analyze_interface(node),
         }
     }
 
@@ -267,6 +265,7 @@ impl SemanticAnalyzer {
                     ast::top::TopLevelKind::Struct(_)
                         | ast::top::TopLevelKind::Enum(_)
                         | ast::top::TopLevelKind::TypeAlias(_)
+                        | ast::top::TopLevelKind::Interface(_)
                 )
             });
 
@@ -901,6 +900,56 @@ impl SemanticAnalyzer {
         Ok(TopLevelAnalysisResult::TopLevel(ir::top::TopLevel::Enum(
             ir,
         )))
+    }
+
+    pub fn analyze_interface(
+        &mut self,
+        node: ast::top::Interface,
+    ) -> anyhow::Result<TopLevelAnalysisResult> {
+        let vis = node.vis;
+        let name = node.name.symbol();
+        let span = node.span;
+
+        let qualified_name = QualifiedSymbol::new(self.current_module_path().clone(), name);
+
+        let mut methods = Vec::with_capacity(node.methods.len());
+        for method in node.methods {
+            let params = method
+                .params
+                .v
+                .into_iter()
+                .map(|p| -> anyhow::Result<ir::top::Param> {
+                    Ok(ir::top::Param {
+                        name: p.name.symbol(),
+                        ty: self.analyze_type(&p.ty)?,
+                        default: None,
+                    })
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+
+            methods.push(ir::top::InterfaceMethod {
+                name: method.name.symbol(),
+                self_: method.self_.map(ir::ty::Mutability::from),
+                params,
+                return_ty: self.analyze_type(&method.return_ty)?,
+            });
+        }
+
+        let ir = Rc::new(ir::top::Interface {
+            name: qualified_name,
+            methods,
+        });
+
+        let symbol_table_value = SymbolTableValue::new(
+            SymbolTableValueKind::Interface(ir.clone()),
+            self.current_module_path().clone(),
+        );
+
+        self.insert_symbol_to_root_scope(name, symbol_table_value, vis, span)?;
+
+        Ok(TopLevelAnalysisResult::TopLevel(
+            ir::top::TopLevel::Interface(ir),
+        ))
     }
 
     pub fn analyze_type_alias(

--- a/compiler/semantic/tests/top.rs
+++ b/compiler/semantic/tests/top.rs
@@ -623,3 +623,33 @@ fn plain_functions_are_allowed_in_non_entry_units() -> anyhow::Result<()> {
     semantic_analyze_as_non_entry("fun helper() -> i32 { return 0 }")?;
     Ok(())
 }
+
+#[test]
+fn interface_declarations_are_accepted() -> anyhow::Result<()> {
+    let unit = semantic_analyze_as_non_entry(
+        "\
+interface Reader {
+    fun read(mut self, buf: i32) -> i32
+    fun peek(self) -> i32
+}
+",
+    )?;
+
+    let interfaces: Vec<_> = unit
+        .top_levels
+        .iter()
+        .filter_map(|tl| match tl {
+            TopLevel::Interface(iface) => Some(iface),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(interfaces.len(), 1);
+    let iface = interfaces[0];
+    assert_eq!(iface.name.symbol(), Symbol::from("Reader".to_string()));
+    assert_eq!(iface.methods.len(), 2);
+    assert_eq!(iface.methods[0].name, Symbol::from("read".to_string()));
+    assert_eq!(iface.methods[1].name, Symbol::from("peek".to_string()));
+
+    Ok(())
+}

--- a/compiler/symbol_table/src/lib.rs
+++ b/compiler/symbol_table/src/lib.rs
@@ -123,6 +123,7 @@ pub enum SymbolTableValueKind {
     Variable(VariableInfo),
     Struct(Rc<ir::top::Struct>),
     Enum(Rc<ir::top::Enum>),
+    Interface(Rc<ir::top::Interface>),
     TypeAlias(Rc<ir_type::Ty>),
     Generic(Box<GenericInfo>),
     Placeholder(QualifiedSymbol),


### PR DESCRIPTION
## Summary
- Replace the `InterfaceNotYetSupported` stub with real handling: semantic analysis lowers `interface` declarations into a new `ir::top::Interface` (method signatures only) and registers them in the symbol table alongside structs/enums.
- Extend `ir::top::TopLevel` with an `Interface` variant; codegen and monomorphization treat it as a no-op for now.
- Add `SymbolTableValueKind::Interface` so future steps can resolve interface names.

Step 2 of the Go-style interface plan (#219). Method-set conformance, generic-bound validation, and fat-pointer dispatch arrive in follow-up PRs.

## Test plan
- [x] `cargo build`
- [x] `cargo test` (all suites green)
- [x] `cargo clippy --all-targets` (no new warnings)
- [x] New `interface_declarations_are_accepted` semantic test verifies the IR is produced with the expected method signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)