### PR TITLE
feat(semantic): resolve and enforce interface generic bounds

### DIFF
--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -304,7 +304,8 @@ fn semantic_error_span(err: &SemanticError) -> Option<Span> {
         | SemanticError::FormatPlaceholderCountMismatch { span, .. }
         | SemanticError::TryRequiresResult { span, .. }
         | SemanticError::TryOutsideResultFunction { span, .. }
-        | SemanticError::GenericBoundMustBeInterface { span, .. } => Some(*span),
+        | SemanticError::GenericBoundMustBeInterface { span, .. }
+        | SemanticError::GenericBoundNotSatisfied { span, .. } => Some(*span),
         SemanticError::MainNotFound
         | SemanticError::LLVMError { .. }
         | SemanticError::FailedToLookupTarget { .. }

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -304,7 +304,7 @@ fn semantic_error_span(err: &SemanticError) -> Option<Span> {
         | SemanticError::FormatPlaceholderCountMismatch { span, .. }
         | SemanticError::TryRequiresResult { span, .. }
         | SemanticError::TryOutsideResultFunction { span, .. }
-        | SemanticError::GenericBoundNotYetSupported { span } => Some(*span),
+        | SemanticError::GenericBoundMustBeInterface { span, .. } => Some(*span),
         SemanticError::MainNotFound
         | SemanticError::LLVMError { .. }
         | SemanticError::FailedToLookupTarget { .. }

--- a/compiler/semantic/src/error.rs
+++ b/compiler/semantic/src/error.rs
@@ -227,6 +227,6 @@ pub enum SemanticError {
     #[error("{}:{}:{} `?` can only be used in functions returning `Result<T, E>`, got `{}`", span.file, span.start.line, span.start.column, actual)]
     TryOutsideResultFunction { actual: String, span: Span },
 
-    #[error("{}:{}:{} generic bounds are not yet supported by the compiler", span.file, span.start.line, span.start.column)]
-    GenericBoundNotYetSupported { span: Span },
+    #[error("{}:{}:{} generic bound `{}` must reference an interface", span.file, span.start.line, span.start.column, name)]
+    GenericBoundMustBeInterface { name: Symbol, span: Span },
 }

--- a/compiler/semantic/src/error.rs
+++ b/compiler/semantic/src/error.rs
@@ -229,4 +229,12 @@ pub enum SemanticError {
 
     #[error("{}:{}:{} generic bound `{}` must reference an interface", span.file, span.start.line, span.start.column, name)]
     GenericBoundMustBeInterface { name: Symbol, span: Span },
+
+    #[error("{}:{}:{} type `{}` does not satisfy interface `{}`: missing or incompatible method `{}`", span.file, span.start.line, span.start.column, actual, interface, method_name)]
+    GenericBoundNotSatisfied {
+        actual: String,
+        interface: Symbol,
+        method_name: Symbol,
+        span: Span,
+    },
 }

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -1249,6 +1249,12 @@ impl SemanticAnalyzer {
             }
         }
 
+        self.verify_resolved_generic_bounds(
+            info.resolved_generic_params.as_ref(),
+            generic_args,
+            generic_params.span,
+        )?;
+
         // Generic functions must always be generated regardless of the analyze command, so it is overwritten
         let fn_ = self.with_analyze_command(AnalyzeCommand::NoCommand, |analyzer| {
             // Generate the generic function

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -10,7 +10,8 @@ use crate::{
 };
 use kaede_symbol_table::{
     GenericEnumInfo, GenericFuncInfo, GenericImplInfo, GenericInfo, GenericKind, GenericStructInfo,
-    SymbolTable, SymbolTableValue, SymbolTableValueKind, VariableInfo,
+    ResolvedGenericParam, ResolvedGenericParams, SymbolTable, SymbolTableValue,
+    SymbolTableValueKind, VariableInfo,
 };
 
 use kaede_ast::{self as ast};
@@ -39,8 +40,6 @@ impl SemanticAnalyzer {
         top_level: ast::top::TopLevel,
     ) -> anyhow::Result<TopLevelAnalysisResult> {
         use ast::top::TopLevelKind;
-
-        check_no_generic_bounds(&top_level.kind)?;
 
         match top_level.kind {
             TopLevelKind::Fn(node) => self.analyze_fn(node),
@@ -455,6 +454,8 @@ impl SemanticAnalyzer {
         let span = node.span;
 
         if let Some(_generic_params) = node.generic_params.as_ref() {
+            let resolved_generic_params =
+                self.resolve_generic_params(node.generic_params.as_ref())?;
             let base_ty = if let ast_type::TyKind::Reference(rty) = node.ty.kind.as_ref() {
                 rty.get_base_type()
             } else {
@@ -474,10 +475,18 @@ impl SemanticAnalyzer {
                         SymbolTableValueKind::Generic(ref mut generic_info) => {
                             match &mut generic_info.kind {
                                 GenericKind::Struct(info) => {
-                                    info.impl_info = Some(GenericImplInfo::new(node, span));
+                                    info.impl_info = Some(GenericImplInfo::new(
+                                        node,
+                                        resolved_generic_params,
+                                        span,
+                                    ));
                                 }
                                 GenericKind::Enum(info) => {
-                                    info.impl_info = Some(GenericImplInfo::new(node, span));
+                                    info.impl_info = Some(GenericImplInfo::new(
+                                        node,
+                                        resolved_generic_params,
+                                        span,
+                                    ));
                                 }
                                 _ => todo!("Error"),
                             }
@@ -503,7 +512,11 @@ impl SemanticAnalyzer {
                         SymbolTableValueKind::Generic(ref mut generic_info) => {
                             match &mut generic_info.kind {
                                 GenericKind::Slice(info) => {
-                                    info.impl_info = Some(GenericImplInfo::new(node, span));
+                                    info.impl_info = Some(GenericImplInfo::new(
+                                        node,
+                                        resolved_generic_params,
+                                        span,
+                                    ));
                                 }
                                 _ => todo!("Error"),
                             }
@@ -612,11 +625,16 @@ impl SemanticAnalyzer {
             }
 
             let span = node.span;
+            let resolved_generic_params =
+                self.resolve_generic_params(node.decl.generic_params.as_ref())?;
 
             let symbol_table_value = SymbolTableValue::new(
                 SymbolTableValueKind::Generic(
                     GenericInfo::new(
-                        GenericKind::Func(GenericFuncInfo { ast: node }),
+                        GenericKind::Func(GenericFuncInfo {
+                            ast: node,
+                            resolved_generic_params,
+                        }),
                         self.current_module_path().clone(),
                     )
                     .into(),
@@ -780,10 +798,12 @@ impl SemanticAnalyzer {
 
         // For generic
         if node.generic_params.is_some() {
+            let resolved_generic_params =
+                self.resolve_generic_params(node.generic_params.as_ref())?;
             let symbol_table_value = SymbolTableValue::new(
                 SymbolTableValueKind::Generic(
                     GenericInfo::new(
-                        GenericKind::Struct(GenericStructInfo::new(node)),
+                        GenericKind::Struct(GenericStructInfo::new(node, resolved_generic_params)),
                         self.current_module_path().clone(),
                     )
                     .into(),
@@ -843,10 +863,12 @@ impl SemanticAnalyzer {
 
         // For generic
         if node.generic_params.is_some() {
+            let resolved_generic_params =
+                self.resolve_generic_params(node.generic_params.as_ref())?;
             let symbol_table_value = SymbolTableValue::new(
                 SymbolTableValueKind::Generic(
                     GenericInfo::new(
-                        GenericKind::Enum(GenericEnumInfo::new(node)),
+                        GenericKind::Enum(GenericEnumInfo::new(node, resolved_generic_params)),
                         self.current_module_path().clone(),
                     )
                     .into(),
@@ -970,28 +992,53 @@ impl SemanticAnalyzer {
 
         Ok(TopLevelAnalysisResult::Imported(vec![]))
     }
-}
+    fn resolve_generic_params(
+        &self,
+        params: Option<&ast::top::GenericParams>,
+    ) -> anyhow::Result<Option<ResolvedGenericParams>> {
+        let Some(params) = params else {
+            return Ok(None);
+        };
 
-fn check_no_generic_bounds(kind: &ast::top::TopLevelKind) -> anyhow::Result<()> {
-    use ast::top::TopLevelKind;
+        let resolved_params = params
+            .params
+            .iter()
+            .map(|param| -> anyhow::Result<ResolvedGenericParam> {
+                let bound = match param.bound {
+                    Some(bound) => Some(self.resolve_generic_bound(bound)?),
+                    None => None,
+                };
 
-    let generic_params = match kind {
-        TopLevelKind::Fn(node) => node.decl.generic_params.as_ref(),
-        TopLevelKind::Struct(node) => node.generic_params.as_ref(),
-        TopLevelKind::Enum(node) => node.generic_params.as_ref(),
-        TopLevelKind::Impl(node) => node.generic_params.as_ref(),
-        TopLevelKind::Extern(node) => node.fn_decl.generic_params.as_ref(),
-        TopLevelKind::Import(_)
-        | TopLevelKind::Use(_)
-        | TopLevelKind::TypeAlias(_)
-        | TopLevelKind::Interface(_) => None,
-    };
+                Ok(ResolvedGenericParam {
+                    name: param.name.symbol(),
+                    bound,
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
-    if let Some(params) = generic_params {
-        if params.params.iter().any(|p| p.bound.is_some()) {
-            return Err(SemanticError::GenericBoundNotYetSupported { span: params.span }.into());
-        }
+        Ok(Some(ResolvedGenericParams {
+            params: resolved_params,
+            span: params.span,
+        }))
     }
 
-    Ok(())
+    fn resolve_generic_bound(&self, bound: Ident) -> anyhow::Result<QualifiedSymbol> {
+        let symbol = self
+            .lookup_symbol(bound.symbol())
+            .ok_or(SemanticError::Undeclared {
+                name: bound.symbol(),
+                span: bound.span(),
+            })?;
+
+        let borrowed = symbol.borrow();
+
+        match &borrowed.kind {
+            SymbolTableValueKind::Interface(interface) => Ok(interface.name.clone()),
+            _ => Err(SemanticError::GenericBoundMustBeInterface {
+                name: bound.symbol(),
+                span: bound.span(),
+            }
+            .into()),
+        }
+    }
 }

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -9,7 +9,7 @@ use kaede_symbol::{Ident, Symbol};
 
 use crate::context::AnalyzeCommand;
 use crate::{error::SemanticError, SemanticAnalyzer, TopLevelAnalysisResult};
-use kaede_symbol_table::{GenericKind, SymbolTableValueKind};
+use kaede_symbol_table::{GenericKind, ResolvedGenericParams, SymbolTableValueKind};
 
 struct GenericTypeOps<T> {
     get_generic_params: fn(&T) -> &ast::top::GenericParams,
@@ -20,6 +20,154 @@ struct GenericTypeOps<T> {
 }
 
 impl SemanticAnalyzer {
+    pub(crate) fn verify_resolved_generic_bounds(
+        &self,
+        resolved_params: Option<&ResolvedGenericParams>,
+        generic_args: &[Rc<ir_type::Ty>],
+        span: Span,
+    ) -> anyhow::Result<()> {
+        let Some(resolved_params) = resolved_params else {
+            return Ok(());
+        };
+
+        if resolved_params.len() != generic_args.len() {
+            return Err(SemanticError::GenericArgumentLengthMismatch {
+                expected: resolved_params.len(),
+                actual: generic_args.len(),
+                span,
+            }
+            .into());
+        }
+
+        for (param, arg) in resolved_params.params.iter().zip(generic_args.iter()) {
+            let Some(interface) = &param.bound else {
+                continue;
+            };
+
+            if matches!(arg.kind.as_ref(), ir_type::TyKind::Var(_)) {
+                continue;
+            }
+
+            self.verify_type_satisfies_interface(arg, interface, span)?;
+        }
+
+        Ok(())
+    }
+
+    fn verify_type_satisfies_interface(
+        &self,
+        actual_ty: &Rc<ir_type::Ty>,
+        interface_name: &QualifiedSymbol,
+        span: Span,
+    ) -> anyhow::Result<()> {
+        let interface_symbol = self.lookup_qualified_symbol(interface_name.clone()).ok_or(
+            SemanticError::Undeclared {
+                name: interface_name.symbol(),
+                span,
+            },
+        )?;
+
+        let interface = {
+            let borrowed = interface_symbol.borrow();
+            match &borrowed.kind {
+                SymbolTableValueKind::Interface(interface) => interface.clone(),
+                _ => unreachable!(),
+            }
+        };
+
+        for method in &interface.methods {
+            let Some(actual_method) = self.lookup_method_for_interface(actual_ty, method) else {
+                return Err(SemanticError::GenericBoundNotSatisfied {
+                    actual: actual_ty.kind.to_string(),
+                    interface: interface.name.symbol(),
+                    method_name: method.name,
+                    span,
+                }
+                .into());
+            };
+
+            if !self.interface_method_matches_decl(method, &actual_method) {
+                return Err(SemanticError::GenericBoundNotSatisfied {
+                    actual: actual_ty.kind.to_string(),
+                    interface: interface.name.symbol(),
+                    method_name: method.name,
+                    span,
+                }
+                .into());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn lookup_method_for_interface(
+        &self,
+        actual_ty: &Rc<ir_type::Ty>,
+        method: &ir::top::InterfaceMethod,
+    ) -> Option<Rc<ir::top::FnDecl>> {
+        let (module_path, parent_name) = self.method_lookup_target(actual_ty)?;
+        let method_key = self.create_method_key(parent_name, method.name, method.self_.is_none());
+        let symbol = self.lookup_qualified_symbol(QualifiedSymbol::new(module_path, method_key))?;
+        let borrowed = symbol.borrow();
+
+        match &borrowed.kind {
+            SymbolTableValueKind::Function(fn_decl) => Some(fn_decl.clone()),
+            _ => None,
+        }
+    }
+
+    fn method_lookup_target(
+        &self,
+        ty: &Rc<ir_type::Ty>,
+    ) -> Option<(kaede_ir::module_path::ModulePath, Symbol)> {
+        match ty.kind.as_ref() {
+            ir_type::TyKind::Reference(rty) => self.method_lookup_target(&rty.get_base_type()),
+            ir_type::TyKind::UserDefined(udt) => Some((udt.module_path(), udt.name())),
+            ir_type::TyKind::Fundamental(fty) => Some((
+                kaede_ir::module_path::ModulePath::new(vec![]),
+                fty.kind.to_string().into(),
+            )),
+            ir_type::TyKind::Slice(elem_ty) => Some((
+                self.module_path().clone(),
+                self.slice_method_parent_name(elem_ty),
+            )),
+            _ => None,
+        }
+    }
+
+    fn interface_method_matches_decl(
+        &self,
+        interface_method: &ir::top::InterfaceMethod,
+        actual_method: &Rc<ir::top::FnDecl>,
+    ) -> bool {
+        let actual_params = &actual_method.params;
+        let expected_is_instance = interface_method.self_.is_some();
+        let actual_is_instance = actual_params
+            .first()
+            .is_some_and(|param| param.name.as_str() == "self");
+
+        if expected_is_instance != actual_is_instance {
+            return false;
+        }
+
+        let actual_params_without_self = if actual_is_instance {
+            let self_param = &actual_params[0];
+            if self_param.ty.mutability != interface_method.self_.unwrap() {
+                return false;
+            }
+            &actual_params[1..]
+        } else {
+            &actual_params[..]
+        };
+
+        actual_params_without_self.len() == interface_method.params.len()
+            && actual_params_without_self
+                .iter()
+                .zip(interface_method.params.iter())
+                .all(|(actual, expected)| ir_type::is_same_type(&actual.ty, &expected.ty))
+            && ir_type::is_same_type(&actual_method.return_ty, &interface_method.return_ty)
+    }
+
     pub fn analyze_type(&mut self, ty: &ast_type::Ty) -> anyhow::Result<Rc<ir_type::Ty>> {
         match ty.kind.as_ref() {
             ast_type::TyKind::Fundamental(fty) => Ok(self
@@ -306,6 +454,12 @@ impl SemanticAnalyzer {
             _ => unreachable!(),
         };
 
+        self.verify_resolved_generic_bounds(
+            generic_info.resolved_generic_params(),
+            &generic_args,
+            name.span(),
+        )?;
+
         let module_path = generic_info.module_path.clone();
 
         self.with_module(module_path.clone(), |analyzer| {
@@ -362,6 +516,7 @@ impl SemanticAnalyzer {
                     impl_info.generateds.push(generic_args.clone());
 
                     let generic_params = impl_info.impl_.generic_params.as_ref().unwrap().clone();
+                    let resolved_generic_params = impl_info.resolved_generic_params.clone();
 
                     // Check if the length of the generic arguments is the same as the number of generic parameters
                     if generic_params.len() != generic_args.len() {
@@ -372,6 +527,12 @@ impl SemanticAnalyzer {
                         }
                         .into());
                     }
+
+                    analyzer.verify_resolved_generic_bounds(
+                        resolved_generic_params.as_ref(),
+                        &generic_args,
+                        generic_params.span,
+                    )?;
 
                     let mut impl_ = impl_info.impl_.clone();
                     impl_.generic_params = None;
@@ -709,8 +870,14 @@ impl SemanticAnalyzer {
         }
 
         let generic_params = impl_info.impl_.generic_params.as_ref().unwrap().clone();
+        let resolved_generic_params = impl_info.resolved_generic_params.clone();
 
         self.verify_generic_argument_length(&generic_params, &generic_args, generic_params.span)?;
+        self.verify_resolved_generic_bounds(
+            resolved_generic_params.as_ref(),
+            &generic_args,
+            generic_params.span,
+        )?;
 
         impl_info.generateds.push(generic_args.clone());
 

--- a/compiler/semantic/tests/top.rs
+++ b/compiler/semantic/tests/top.rs
@@ -653,3 +653,41 @@ interface Reader {
 
     Ok(())
 }
+
+#[test]
+fn generic_bounds_accept_interfaces() -> anyhow::Result<()> {
+    semantic_analyze_as_non_entry(
+        "\
+interface Reader {
+    fun read(self) -> i32
+}
+
+struct Box<T: Reader> {}
+
+fun drain<T: Reader>(x: T) -> i32 {
+    return 0
+}
+",
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn generic_bounds_reject_non_interfaces() -> anyhow::Result<()> {
+    let err = semantic_analyze_non_entry_expect_error(
+        "\
+struct Reader {}
+
+fun drain<T: Reader>(x: T) -> i32 {
+    return 0
+}
+",
+    )?;
+
+    assert!(err
+        .to_string()
+        .contains("generic bound `Reader` must reference an interface"));
+
+    Ok(())
+}

--- a/compiler/semantic/tests/top.rs
+++ b/compiler/semantic/tests/top.rs
@@ -691,3 +691,107 @@ fun drain<T: Reader>(x: T) -> i32 {
 
     Ok(())
 }
+
+#[test]
+fn generic_function_call_checks_bound_conformance() -> anyhow::Result<()> {
+    semantic_analyze(
+        "\
+interface Reader {
+    fun read(self) -> i32
+}
+
+struct File {}
+
+impl File {
+    fun read(self) -> i32 {
+        return 1
+    }
+}
+
+fun drain<T: Reader>(x: T) -> i32 {
+    return 0
+}
+
+fun main() -> i32 {
+    let file = File {}
+    return drain(file)
+}
+",
+    )?;
+
+    let err = semantic_analyze_expect_error(
+        "\
+interface Reader {
+    fun read(self) -> i32
+}
+
+struct NoRead {}
+
+fun drain<T: Reader>(x: T) -> i32 {
+    return 0
+}
+
+fun main() -> i32 {
+    let value = NoRead {}
+    return drain(value)
+}
+",
+    )?;
+
+    assert!(err
+        .to_string()
+        .contains("does not satisfy interface `Reader`"));
+
+    Ok(())
+}
+
+#[test]
+fn generic_type_instantiation_checks_bound_conformance() -> anyhow::Result<()> {
+    semantic_analyze_as_non_entry(
+        "\
+interface Reader {
+    fun read(self) -> i32
+}
+
+struct File {}
+
+impl File {
+    fun read(self) -> i32 {
+        return 1
+    }
+}
+
+struct Box<T: Reader> {
+    value: T,
+}
+
+fun helper() {
+    let _ok = Box<File> { value: File {} }
+}
+",
+    )?;
+
+    let err = semantic_analyze_non_entry_expect_error(
+        "\
+interface Reader {
+    fun read(self) -> i32
+}
+
+struct NoRead {}
+
+struct Box<T: Reader> {
+    value: T,
+}
+
+fun helper() {
+    let _bad = Box<NoRead> { value: NoRead {} }
+}
+",
+    )?;
+
+    assert!(err
+        .to_string()
+        .contains("does not satisfy interface `Reader`"));
+
+    Ok(())
+}

--- a/compiler/symbol_table/src/lib.rs
+++ b/compiler/symbol_table/src/lib.rs
@@ -16,31 +16,64 @@ use kaede_ir as ir;
 #[derive(Debug)]
 pub struct GenericImplInfo {
     pub impl_: ast::top::Impl,
+    pub resolved_generic_params: Option<ResolvedGenericParams>,
     pub span: Span,
     // Contains already generated generic arguments
     pub generateds: Vec<Vec<Rc<ir_type::Ty>>>,
 }
 
 impl GenericImplInfo {
-    pub fn new(impl_: ast::top::Impl, span: Span) -> Self {
+    pub fn new(
+        impl_: ast::top::Impl,
+        resolved_generic_params: Option<ResolvedGenericParams>,
+        span: Span,
+    ) -> Self {
         Self {
             impl_,
+            resolved_generic_params,
             span,
             generateds: Vec::new(),
         }
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct ResolvedGenericParam {
+    pub name: Symbol,
+    pub bound: Option<QualifiedSymbol>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedGenericParams {
+    pub params: Vec<ResolvedGenericParam>,
+    pub span: Span,
+}
+
+impl ResolvedGenericParams {
+    pub fn len(&self) -> usize {
+        self.params.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.params.is_empty()
+    }
+}
+
 #[derive(Debug)]
 pub struct GenericStructInfo {
     pub ast: ast::top::Struct,
+    pub resolved_generic_params: Option<ResolvedGenericParams>,
     pub impl_info: Option<GenericImplInfo>,
 }
 
 impl GenericStructInfo {
-    pub fn new(ast: ast::top::Struct) -> Self {
+    pub fn new(
+        ast: ast::top::Struct,
+        resolved_generic_params: Option<ResolvedGenericParams>,
+    ) -> Self {
         Self {
             ast,
+            resolved_generic_params,
             impl_info: None,
         }
     }
@@ -49,13 +82,18 @@ impl GenericStructInfo {
 #[derive(Debug)]
 pub struct GenericEnumInfo {
     pub ast: ast::top::Enum,
+    pub resolved_generic_params: Option<ResolvedGenericParams>,
     pub impl_info: Option<GenericImplInfo>,
 }
 
 impl GenericEnumInfo {
-    pub fn new(ast: ast::top::Enum) -> Self {
+    pub fn new(
+        ast: ast::top::Enum,
+        resolved_generic_params: Option<ResolvedGenericParams>,
+    ) -> Self {
         Self {
             ast,
+            resolved_generic_params,
             impl_info: None,
         }
     }
@@ -64,6 +102,7 @@ impl GenericEnumInfo {
 #[derive(Debug)]
 pub struct GenericFuncInfo {
     pub ast: ast::top::Fn,
+    pub resolved_generic_params: Option<ResolvedGenericParams>,
 }
 
 #[derive(Debug)]
@@ -100,6 +139,15 @@ pub struct GenericInfo {
 impl GenericInfo {
     pub fn new(kind: GenericKind, module_path: ModulePath) -> Self {
         Self { kind, module_path }
+    }
+
+    pub fn resolved_generic_params(&self) -> Option<&ResolvedGenericParams> {
+        match &self.kind {
+            GenericKind::Struct(info) => info.resolved_generic_params.as_ref(),
+            GenericKind::Enum(info) => info.resolved_generic_params.as_ref(),
+            GenericKind::Func(info) => info.resolved_generic_params.as_ref(),
+            GenericKind::Slice(_) => None,
+        }
     }
 
     pub fn get_generic_argument_length(&self) -> usize {


### PR DESCRIPTION
## Summary
- Resolve `T: Interface` bounds in semantic analysis: bound names are looked up, validated as interfaces, and stored on the IR generic-param representation via `ResolvedGenericParams`.
- Add method-set collection and conformance checking: instantiating a bounded generic with a concrete type verifies the type implements every interface method, with precise errors for missing/mismatched signatures.
- New `GenericBoundMustBeInterface` and `GenericBoundNotSatisfied` diagnostics (both surfaced through LSP span reporting).

The interface plan (#219). Interfaces are not yet usable as first-class types or dynamic dispatch targets — those land in follow-up PRs (#8, #10–#12).

## Test plan
- [x] `cargo test` (all suites green)
- [x] New semantic tests: `generic_bounds_accept_interfaces`, `generic_bounds_reject_non_interfaces`, `generic_function_call_checks_bound_conformance`, `generic_type_instantiation_checks_bound_conformance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)