### PR TITLE
feat: treat interface as a user-defined type

### DIFF
--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -378,6 +378,15 @@ impl<'ctx> CodeGenerator<'ctx> {
                     UserDefinedTypeKind::Struct(sty) => sty.name.clone(),
                     UserDefinedTypeKind::Enum(ety) => ety.name.clone(),
                     UserDefinedTypeKind::Placeholder(qsym) => qsym.clone(),
+                    UserDefinedTypeKind::Interface(_) => {
+                        // Fat-pointer layout: { data: *i8, itable: *i8 }.
+                        // Method dispatch through the itable is wired up in a later step.
+                        let ptr_ty = self.context().ptr_type(AddressSpace::default());
+                        return self
+                            .context()
+                            .struct_type(&[ptr_ty.into(), ptr_ty.into()], false)
+                            .into();
+                    }
                 };
 
                 match self

--- a/compiler/ir/src/ty.rs
+++ b/compiler/ir/src/ty.rs
@@ -14,7 +14,7 @@ use kaede_symbol::Symbol;
 use crate::{
     module_path::ModulePath,
     qualified_symbol::QualifiedSymbol,
-    top::{Enum, Struct},
+    top::{Enum, Interface, Struct},
 };
 
 /// Duplicate the type, change the mutability, and return the duplicated type
@@ -712,6 +712,7 @@ impl Eq for PointerType {}
 pub enum UserDefinedTypeKind {
     Struct(Rc<Struct>),
     Enum(Rc<Enum>),
+    Interface(Rc<Interface>),
     // For circular dependency
     Placeholder(QualifiedSymbol),
 }
@@ -744,6 +745,7 @@ impl UserDefinedType {
         match &self.kind {
             UserDefinedTypeKind::Struct(s) => s.name.module_path().clone(),
             UserDefinedTypeKind::Enum(e) => e.name.module_path().clone(),
+            UserDefinedTypeKind::Interface(i) => i.name.module_path().clone(),
             UserDefinedTypeKind::Placeholder(qsym) => qsym.module_path().clone(),
         }
     }
@@ -752,6 +754,7 @@ impl UserDefinedType {
         match &self.kind {
             UserDefinedTypeKind::Struct(s) => s.name.symbol(),
             UserDefinedTypeKind::Enum(e) => e.name.symbol(),
+            UserDefinedTypeKind::Interface(i) => i.name.symbol(),
             UserDefinedTypeKind::Placeholder(qsym) => qsym.symbol(),
         }
     }
@@ -760,8 +763,13 @@ impl UserDefinedType {
         match &self.kind {
             UserDefinedTypeKind::Struct(s) => s.name.clone(),
             UserDefinedTypeKind::Enum(e) => e.name.clone(),
+            UserDefinedTypeKind::Interface(i) => i.name.clone(),
             UserDefinedTypeKind::Placeholder(qsym) => qsym.clone(),
         }
+    }
+
+    pub fn is_interface(&self) -> bool {
+        matches!(self.kind, UserDefinedTypeKind::Interface(_))
     }
 }
 

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -673,6 +673,9 @@ impl SemanticAnalyzer {
 
             SymbolTableValueKind::Struct(st) => ir_type::UserDefinedTypeKind::Struct(st.clone()),
             SymbolTableValueKind::Enum(en) => ir_type::UserDefinedTypeKind::Enum(en.clone()),
+            SymbolTableValueKind::Interface(iface) => {
+                ir_type::UserDefinedTypeKind::Interface(iface.clone())
+            }
             SymbolTableValueKind::Placeholder(placeholder) => {
                 ir_type::UserDefinedTypeKind::Placeholder(placeholder.clone())
             }

--- a/compiler/semantic/tests/top.rs
+++ b/compiler/semantic/tests/top.rs
@@ -795,3 +795,30 @@ fun helper() {
 
     Ok(())
 }
+
+#[test]
+fn interface_usable_as_parameter_and_field_type() -> anyhow::Result<()> {
+    let unit = semantic_analyze_as_non_entry(
+        "\
+interface Reader {
+    fun read(self) -> i32
+}
+
+struct Pipeline {
+    source: Reader,
+}
+
+fun take(r: Reader) -> i32 {
+    return 0
+}
+",
+    )?;
+
+    let has_fn = unit.top_levels.iter().any(|tl| match tl {
+        TopLevel::Fn(fn_) => fn_.decl.name.symbol() == Symbol::from("take".to_string()),
+        _ => false,
+    });
+    assert!(has_fn, "`take` function should be present in IR");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add `Interface(Rc<Interface>)` variant to `UserDefinedTypeKind` so interfaces flow through the IR alongside structs/enums.
- Plumb the new variant through `UserDefinedType` helpers, the semantic layer's type analysis, and the LLVM codegen (emitting the placeholder fat-pointer `{ *i8, *i8 }` layout).
- Add a semantic test covering interfaces used as parameter and field types.

## Test plan
- [x] `cargo test` (all workspace tests pass)
- [x] `cargo clippy` (no new warnings)

Part of #219. Unblocks the interface-value / dynamic-dispatch tasks (#10–#12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)