### PR TITLE
feat(ir): add fat-pointer interface IR nodes

### DIFF
--- a/compiler/codegen/src/expr.rs
+++ b/compiler/codegen/src/expr.rs
@@ -188,6 +188,13 @@ impl<'ctx> CodeGenerator<'ctx> {
             ExprKind::Closure(closure) => self.build_closure(closure, &node.ty)?,
 
             ExprKind::Spawn(spawn) => self.build_spawn(spawn)?,
+
+            ExprKind::InterfaceBox(_) => {
+                anyhow::bail!("internal error: interface boxing codegen not yet implemented")
+            }
+            ExprKind::InterfaceMethodCall(_) => {
+                anyhow::bail!("internal error: interface method call codegen not yet implemented")
+            }
         })
     }
 

--- a/compiler/ir/src/expr.rs
+++ b/compiler/ir/src/expr.rs
@@ -5,7 +5,7 @@ use kaede_symbol::Symbol;
 
 use crate::{
     stmt::Block,
-    top::{Enum, FnDecl, Struct},
+    top::{Enum, FnDecl, Interface, InterfaceMethod, Struct},
     ty::{Ty, UserDefinedType},
 };
 
@@ -314,6 +314,37 @@ pub struct FnPointer {
     pub span: Span,
 }
 
+/// Per `(concrete_ty, interface)` pair: the concrete `FnDecl` that fills each
+/// interface method slot. `methods` is aligned with `interface.methods`.
+#[derive(Debug, Clone)]
+pub struct ITable {
+    pub interface: Rc<Interface>,
+    pub concrete_ty: Rc<Ty>,
+    pub methods: Vec<Rc<FnDecl>>,
+}
+
+/// Wrap a concrete value into a fat-pointer interface value
+/// (`{ data: *T, itable: *ITable }`).
+#[derive(Debug, Clone)]
+pub struct InterfaceBox {
+    pub value: Box<Expr>,
+    pub interface: Rc<Interface>,
+    pub itable: Rc<ITable>,
+    pub span: Span,
+}
+
+/// Dynamic dispatch through an interface fat pointer's itable.
+/// `method_index` indexes into `interface.methods`.
+#[derive(Debug, Clone)]
+pub struct InterfaceMethodCall {
+    pub receiver: Box<Expr>,
+    pub interface: Rc<Interface>,
+    pub method_index: usize,
+    pub method: InterfaceMethod,
+    pub args: Args,
+    pub span: Span,
+}
+
 #[derive(Debug, Clone)]
 pub enum ExprKind {
     Int(Int),
@@ -348,6 +379,8 @@ pub enum ExprKind {
     Break,
     Block(Block),
     BuiltinFnCall(BuiltinFnCall),
+    InterfaceBox(InterfaceBox),
+    InterfaceMethodCall(InterfaceMethodCall),
 }
 
 #[derive(Debug, Clone)]

--- a/compiler/monomorphize/src/lib.rs
+++ b/compiler/monomorphize/src/lib.rs
@@ -23,9 +23,7 @@ mod tests {
 
     use kaede_common::LangLinkage;
     use kaede_ir::{
-        expr::{
-            Args, Expr, ExprKind, GenericFnCall, ITable, InterfaceBox, InterfaceMethodCall,
-        },
+        expr::{Args, Expr, ExprKind, GenericFnCall, ITable, InterfaceBox, InterfaceMethodCall},
         module_path::ModulePath,
         qualified_symbol::QualifiedSymbol,
         stmt::{Block, Stmt},

--- a/compiler/monomorphize/src/lib.rs
+++ b/compiler/monomorphize/src/lib.rs
@@ -23,11 +23,13 @@ mod tests {
 
     use kaede_common::LangLinkage;
     use kaede_ir::{
-        expr::{Args, Expr, ExprKind, GenericFnCall},
+        expr::{
+            Args, Expr, ExprKind, GenericFnCall, ITable, InterfaceBox, InterfaceMethodCall,
+        },
         module_path::ModulePath,
         qualified_symbol::QualifiedSymbol,
         stmt::{Block, Stmt},
-        top::{Fn, FnDecl, Impl, TopLevel},
+        top::{Fn, FnDecl, Impl, Interface, InterfaceMethod, TopLevel},
         ty::Ty,
         CompileUnit,
     };
@@ -152,6 +154,11 @@ mod tests {
             ExprKind::StructLiteral(lit) => {
                 lit.values.iter().any(|(_, v)| contains_generic_call(v))
             }
+            ExprKind::InterfaceBox(boxed) => contains_generic_call(&boxed.value),
+            ExprKind::InterfaceMethodCall(call) => {
+                contains_generic_call(&call.receiver)
+                    || call.args.0.iter().any(contains_generic_call)
+            }
             ExprKind::Int(_)
             | ExprKind::StringLiteral(_)
             | ExprKind::ByteStringLiteral(_)
@@ -188,6 +195,108 @@ mod tests {
         let body = main_fn.body.as_ref().expect("expected body");
         let expr = body.last_expr.as_ref().expect("expected last expr");
         assert!(matches!(expr.kind, ExprKind::FnCall(_)));
+        assert!(!contains_generic_call(expr));
+    }
+
+    fn dummy_interface(name: &str) -> Rc<Interface> {
+        Rc::new(Interface {
+            name: QualifiedSymbol::new(ModulePath::new(vec![]), Symbol::from(name.to_owned())),
+            methods: vec![InterfaceMethod {
+                name: Symbol::from("m".to_owned()),
+                self_: None,
+                params: vec![],
+                return_ty: unit_ty(),
+            }],
+        })
+    }
+
+    #[test]
+    fn rewrites_generic_call_inside_interface_box() {
+        let iface = dummy_interface("Iface");
+        let itable = Rc::new(ITable {
+            interface: iface.clone(),
+            concrete_ty: unit_ty(),
+            methods: vec![fn_decl("Impl::m")],
+        });
+        let boxed = Expr {
+            kind: ExprKind::InterfaceBox(InterfaceBox {
+                value: Box::new(generic_call_expr("inner_i32")),
+                interface: iface,
+                itable,
+                span: Span::dummy(),
+            }),
+            ty: unit_ty(),
+            span: Span::dummy(),
+        };
+
+        let main_fn = Rc::new(Fn {
+            decl: (*fn_decl("main")).clone(),
+            body: Some(Block {
+                body: vec![],
+                last_expr: Some(Box::new(boxed)),
+                span: Span::dummy(),
+            }),
+        });
+
+        let mut unit = CompileUnit {
+            top_levels: vec![TopLevel::Fn(main_fn)],
+        };
+
+        Monomorphizer::new().run(&mut unit).unwrap();
+
+        let TopLevel::Fn(main_fn) = &unit.top_levels[0] else {
+            panic!("expected top-level fn");
+        };
+        let body = main_fn.body.as_ref().expect("expected body");
+        let expr = body.last_expr.as_ref().expect("expected last expr");
+        assert!(!contains_generic_call(expr));
+    }
+
+    #[test]
+    fn rewrites_generic_call_inside_interface_method_call() {
+        let iface = dummy_interface("Iface");
+        let receiver = Expr {
+            kind: ExprKind::Variable(kaede_ir::expr::Variable {
+                name: Symbol::from("r".to_owned()),
+                ty: unit_ty(),
+                span: Span::dummy(),
+            }),
+            ty: unit_ty(),
+            span: Span::dummy(),
+        };
+        let call = Expr {
+            kind: ExprKind::InterfaceMethodCall(InterfaceMethodCall {
+                receiver: Box::new(receiver),
+                interface: iface.clone(),
+                method_index: 0,
+                method: iface.methods[0].clone(),
+                args: Args(vec![generic_call_expr("arg_i32")], Span::dummy()),
+                span: Span::dummy(),
+            }),
+            ty: unit_ty(),
+            span: Span::dummy(),
+        };
+
+        let main_fn = Rc::new(Fn {
+            decl: (*fn_decl("main")).clone(),
+            body: Some(Block {
+                body: vec![],
+                last_expr: Some(Box::new(call)),
+                span: Span::dummy(),
+            }),
+        });
+
+        let mut unit = CompileUnit {
+            top_levels: vec![TopLevel::Fn(main_fn)],
+        };
+
+        Monomorphizer::new().run(&mut unit).unwrap();
+
+        let TopLevel::Fn(main_fn) = &unit.top_levels[0] else {
+            panic!("expected top-level fn");
+        };
+        let body = main_fn.body.as_ref().expect("expected body");
+        let expr = body.last_expr.as_ref().expect("expected last expr");
         assert!(!contains_generic_call(expr));
     }
 
@@ -409,6 +518,15 @@ impl Monomorphizer {
             ExprKind::StructLiteral(lit) => {
                 for (_, value) in &mut lit.values {
                     self.rewrite_expr(value)?;
+                }
+            }
+            ExprKind::InterfaceBox(boxed) => {
+                self.rewrite_expr(&mut boxed.value)?;
+            }
+            ExprKind::InterfaceMethodCall(call) => {
+                self.rewrite_expr(&mut call.receiver)?;
+                for arg in &mut call.args.0 {
+                    self.rewrite_expr(arg)?;
                 }
             }
             ExprKind::Int(_)

--- a/compiler/semantic/src/subst.rs
+++ b/compiler/semantic/src/subst.rs
@@ -243,6 +243,27 @@ impl<'a> GenericSubstituter<'a> {
                     self.apply_expr(arg);
                 }
             }
+            ir::expr::ExprKind::InterfaceBox(boxed) => {
+                self.apply_expr(&mut boxed.value);
+                let mut itable = (*boxed.itable).clone();
+                itable.concrete_ty = self.apply_ty(&itable.concrete_ty);
+                for method in &mut itable.methods {
+                    let mut decl = (**method).clone();
+                    self.apply_fn_decl(&mut decl);
+                    *method = Rc::new(decl);
+                }
+                boxed.itable = Rc::new(itable);
+            }
+            ir::expr::ExprKind::InterfaceMethodCall(call) => {
+                self.apply_expr(&mut call.receiver);
+                for arg in &mut call.args.0 {
+                    self.apply_expr(arg);
+                }
+                for param in &mut call.method.params {
+                    param.ty = self.apply_ty(&param.ty);
+                }
+                call.method.return_ty = self.apply_ty(&call.method.return_ty);
+            }
             ir::expr::ExprKind::Int(_)
             | ir::expr::ExprKind::StringLiteral(_)
             | ir::expr::ExprKind::ByteStringLiteral(_)

--- a/compiler/type_infer/src/lib.rs
+++ b/compiler/type_infer/src/lib.rs
@@ -484,6 +484,17 @@ impl TypeInferrer {
             Block(block) => self.infer_block(block),
             Return(ret) => self.infer_return(ret, expr.span),
             Break => Ok(Rc::new(Ty::new_never())),
+            InterfaceBox(boxed) => {
+                self.infer_expr(&boxed.value)?;
+                Ok(expr_ty.clone())
+            }
+            InterfaceMethodCall(call) => {
+                self.infer_expr(&call.receiver)?;
+                for arg in &call.args.0 {
+                    self.infer_expr(arg)?;
+                }
+                Ok(expr_ty.clone())
+            }
             Closure(closure) => {
                 for cap in &closure.captures {
                     self.infer_expr(cap)?;
@@ -1967,6 +1978,15 @@ impl TypeInferrer {
             Return(ret) => {
                 if let Some(expr) = ret {
                     self.apply_expr(expr)?;
+                }
+            }
+            InterfaceBox(boxed) => {
+                self.apply_expr(&mut boxed.value)?;
+            }
+            InterfaceMethodCall(call) => {
+                self.apply_expr(&mut call.receiver)?;
+                for arg in &mut call.args.0 {
+                    self.apply_expr(arg)?;
                 }
             }
         }


### PR DESCRIPTION
## Summary
Lays down IR-level support for Go-style interface values so later passes can box concrete values into fat pointers and dispatch methods dynamically through an itable.

- Add three IR types:
  - `ITable` — per `(concrete, interface)` pair, maps each interface method slot to the concrete `FnDecl`.
  - `InterfaceBox` — wraps a concrete value into a fat pointer `{ data, itable }`.
  - `InterfaceMethodCall` — dynamic dispatch through the itable by method index.
- Thread the new `ExprKind::InterfaceBox` / `ExprKind::InterfaceMethodCall` variants through monomorphize, semantic's generic substituter, and type_infer so passes traverse their children correctly.
- Codegen returns an explicit unimplemented error for the new variants — LLVM lowering will be added in a follow-up PR.
- Add monomorphize tests covering child traversal through both new nodes.

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets` (no new warnings; one pre-existing `items_after_test_module` warning is unchanged)

Part of the Go-style interface work tracked in #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)