### PR TITLE
feat: add Option try operator support

### DIFF
--- a/compiler/driver/tests/cli.rs
+++ b/compiler/driver/tests/cli.rs
@@ -137,3 +137,40 @@ fun main() -> i32 {
 
     Ok(())
 }
+
+#[test]
+fn direct_compile_rejects_try_outside_option_function() -> anyhow::Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let app = temp_dir.child("app.kd");
+    let exe = temp_dir.child("a.out");
+
+    app.write_str(
+        r#"import std.option
+use std.option.Option
+
+fun fail() -> i32 {
+    value := Option::Some(1)?;
+    return value
+}
+
+fun main() -> i32 {
+    return fail()
+}"#,
+    )?;
+
+    Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+        .args([
+            app.path().to_str().unwrap(),
+            "-o",
+            exe.path().to_str().unwrap(),
+            "--root-dir",
+            temp_dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`?` can only be used in functions returning `Option<T>`",
+        ));
+
+    Ok(())
+}

--- a/compiler/driver/tests/run.rs
+++ b/compiler/driver/tests/run.rs
@@ -201,3 +201,38 @@ fun main() -> i32 {
 
     Ok(())
 }
+
+#[test]
+fn run_executes_option_try_program() -> anyhow::Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+
+    create_project(
+        &temp_dir,
+        r#"import std.option
+use std.option.Option
+
+fun inner() -> Option<i32> {
+    return Option::Some(42)
+}
+
+fun outer() -> Option<i32> {
+    value := inner()?;
+    return Option::Some(value)
+}
+
+fun main() -> i32 {
+    return match outer() {
+        Option::Some(value) => value,
+        Option::None => 1,
+    }
+}"#,
+    )?;
+
+    Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+        .current_dir(temp_dir.path())
+        .arg("run")
+        .assert()
+        .code(predicate::eq(42));
+
+    Ok(())
+}

--- a/compiler/lex/src/semi.rs
+++ b/compiler/lex/src/semi.rs
@@ -54,6 +54,7 @@ fn is_semi_insertable(token: &TokenKind) -> bool {
             | CloseParen
             | CloseBrace
             | CloseBracket
+            | Question
             | Return
             | True
             | False

--- a/compiler/lex/src/tests.rs
+++ b/compiler/lex/src/tests.rs
@@ -101,7 +101,7 @@ fn left_arrow() {
 
 #[test]
 fn question() {
-    lex_test("foo?", vec![Ident("foo".to_string()), Question, Eoi]);
+    lex_test("foo?", vec![Ident("foo".to_string()), Question, Semi, Eoi]);
 }
 
 #[test]

--- a/compiler/lex/src/tests.rs
+++ b/compiler/lex/src/tests.rs
@@ -133,6 +133,24 @@ fn auto_insert_semi() {
     );
 
     lex_test("return", vec![Return, Semi, Eoi]);
+    lex_test(
+        "value := inner()?\nif true {}",
+        vec![
+            Ident("value".to_string()),
+            ColonEq,
+            Ident("inner".to_string()),
+            OpenParen,
+            CloseParen,
+            Question,
+            Semi,
+            If,
+            True,
+            OpenBrace,
+            CloseBrace,
+            Semi,
+            Eoi,
+        ],
+    );
 }
 
 #[test]

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -304,6 +304,8 @@ fn semantic_error_span(err: &SemanticError) -> Option<Span> {
         | SemanticError::FormatPlaceholderCountMismatch { span, .. }
         | SemanticError::TryRequiresResult { span, .. }
         | SemanticError::TryOutsideResultFunction { span, .. }
+        | SemanticError::TryRequiresOption { span, .. }
+        | SemanticError::TryOutsideOptionFunction { span, .. }
         | SemanticError::GenericBoundMustBeInterface { span, .. }
         | SemanticError::GenericBoundNotSatisfied { span, .. } => Some(*span),
         SemanticError::MainNotFound

--- a/compiler/semantic/src/error.rs
+++ b/compiler/semantic/src/error.rs
@@ -227,6 +227,12 @@ pub enum SemanticError {
     #[error("{}:{}:{} `?` can only be used in functions returning `Result<T, E>`, got `{}`", span.file, span.start.line, span.start.column, actual)]
     TryOutsideResultFunction { actual: String, span: Span },
 
+    #[error("{}:{}:{} `?` requires `Option<T>`, got `{}`", span.file, span.start.line, span.start.column, actual)]
+    TryRequiresOption { actual: String, span: Span },
+
+    #[error("{}:{}:{} `?` can only be used in functions returning `Option<T>`, got `{}`", span.file, span.start.line, span.start.column, actual)]
+    TryOutsideOptionFunction { actual: String, span: Span },
+
     #[error("{}:{}:{} generic bound `{}` must reference an interface", span.file, span.start.line, span.start.column, name)]
     GenericBoundMustBeInterface { name: Symbol, span: Span },
 

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -29,15 +29,21 @@ struct DecomposedEnumVariantPattern<'p> {
     param: Option<&'p ast::expr::Args>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TryCarrier {
+    Result,
+    Option,
+}
+
 impl SemanticAnalyzer {
-    fn is_std_result_ty(ty: &Rc<ir_type::Ty>) -> bool {
+    fn std_try_carrier(ty: &Rc<ir_type::Ty>) -> Option<TryCarrier> {
         let base_ty = match ty.kind.as_ref() {
             ir_type::TyKind::Reference(rty) => rty.get_base_type(),
             _ => ty.clone(),
         };
 
         let ir_type::TyKind::UserDefined(udt) = base_ty.kind.as_ref() else {
-            return false;
+            return None;
         };
 
         let qualified_symbol = udt
@@ -48,8 +54,50 @@ impl SemanticAnalyzer {
         let module_path = qualified_symbol.module_path().clone();
         let modules = module_path.get_module_names_from_root();
 
-        matches!(modules, [std, result] if std.as_str() == "std" && result.as_str() == "result")
-            && qualified_symbol.symbol().as_str() == "Result"
+        match modules {
+            [std, module] if std.as_str() == "std" && module.as_str() == "result" => {
+                (qualified_symbol.symbol().as_str() == "Result").then_some(TryCarrier::Result)
+            }
+            [std, module] if std.as_str() == "std" && module.as_str() == "option" => {
+                (qualified_symbol.symbol().as_str() == "Option").then_some(TryCarrier::Option)
+            }
+            _ => None,
+        }
+    }
+
+    fn try_carrier_module_and_name(kind: TryCarrier) -> (&'static str, &'static str) {
+        match kind {
+            TryCarrier::Result => ("result", "Result"),
+            TryCarrier::Option => ("option", "Option"),
+        }
+    }
+
+    fn try_success_variant(kind: TryCarrier) -> &'static str {
+        match kind {
+            TryCarrier::Result => "Ok",
+            TryCarrier::Option => "Some",
+        }
+    }
+
+    fn try_failure_variant(kind: TryCarrier) -> &'static str {
+        match kind {
+            TryCarrier::Result => "Err",
+            TryCarrier::Option => "None",
+        }
+    }
+
+    fn try_requires_error(kind: TryCarrier, actual: String, span: Span) -> SemanticError {
+        match kind {
+            TryCarrier::Result => SemanticError::TryRequiresResult { actual, span },
+            TryCarrier::Option => SemanticError::TryRequiresOption { actual, span },
+        }
+    }
+
+    fn try_outside_function_error(kind: TryCarrier, actual: String, span: Span) -> SemanticError {
+        match kind {
+            TryCarrier::Result => SemanticError::TryOutsideResultFunction { actual, span },
+            TryCarrier::Option => SemanticError::TryOutsideOptionFunction { actual, span },
+        }
     }
 
     fn ast_ident_expr(symbol: Symbol, span: Span) -> ast::expr::Expr {
@@ -87,13 +135,15 @@ impl SemanticAnalyzer {
 
     fn ast_variant_expr(
         &self,
+        kind: TryCarrier,
         variant_name: Symbol,
         arg: Option<ast::expr::Expr>,
         span: Span,
     ) -> ast::expr::Expr {
-        let result_path = Self::ast_access_expr(
+        let (module_name, enum_name) = Self::try_carrier_module_and_name(kind);
+        let carrier_path = Self::ast_access_expr(
             Self::ast_ident_expr(Symbol::from("std".to_owned()), span),
-            Self::ast_ident_expr(Symbol::from("result".to_owned()), span),
+            Self::ast_ident_expr(Symbol::from(module_name.to_owned()), span),
             span,
         );
 
@@ -118,9 +168,9 @@ impl SemanticAnalyzer {
         };
 
         Self::ast_access_expr(
-            result_path,
+            carrier_path,
             Self::ast_scope_resolution_expr(
-                Self::ast_ident_expr(Symbol::from("Result".to_owned()), span),
+                Self::ast_ident_expr(Symbol::from(enum_name.to_owned()), span),
                 variant_expr,
                 span,
             ),
@@ -2363,39 +2413,54 @@ impl SemanticAnalyzer {
     }
 
     fn analyze_try(&mut self, node: &ast::expr::Try) -> anyhow::Result<ir::expr::Expr> {
-        let current_fn = self.context.get_current_function().ok_or_else(|| {
-            SemanticError::TryOutsideResultFunction {
-                actual: Rc::new(ir_type::Ty::new_unit()).kind.to_string(),
-                span: node.span,
-            }
-        })?;
-
-        if !Self::is_std_result_ty(&current_fn.return_ty) {
-            return Err(SemanticError::TryOutsideResultFunction {
-                actual: current_fn.return_ty.kind.to_string(),
-                span: node.span,
-            }
-            .into());
-        }
-
         let operand = self.analyze_expr(&node.operand)?;
-        if !Self::is_std_result_ty(&operand.ty) {
-            return Err(SemanticError::TryRequiresResult {
-                actual: operand.ty.kind.to_string(),
-                span: node.span,
+        let operand_carrier = Self::std_try_carrier(&operand.ty);
+        let current_fn = self.context.get_current_function();
+        let current_return_ty = current_fn
+            .as_ref()
+            .map(|fn_| fn_.return_ty.clone())
+            .unwrap_or_else(|| Rc::new(ir_type::Ty::new_unit()));
+        let current_carrier = Self::std_try_carrier(&current_return_ty);
+
+        let try_carrier = match (current_carrier, operand_carrier) {
+            (Some(fn_kind), Some(operand_kind)) if fn_kind == operand_kind => fn_kind,
+            (Some(fn_kind), _) => {
+                return Err(Self::try_requires_error(
+                    fn_kind,
+                    operand.ty.kind.to_string(),
+                    node.span,
+                )
+                .into())
             }
-            .into());
-        }
+            (None, Some(operand_kind)) => {
+                return Err(Self::try_outside_function_error(
+                    operand_kind,
+                    current_return_ty.kind.to_string(),
+                    node.span,
+                )
+                .into())
+            }
+            (None, None) => {
+                return Err(SemanticError::TryOutsideResultFunction {
+                    actual: current_return_ty.kind.to_string(),
+                    span: node.span,
+                }
+                .into())
+            }
+        };
 
         let ok_name = self.fresh_temp_symbol("__try_ok");
         let err_name = self.fresh_temp_symbol("__try_err");
+        let ok_variant = Symbol::from(Self::try_success_variant(try_carrier).to_owned());
+        let err_variant = Symbol::from(Self::try_failure_variant(try_carrier).to_owned());
 
         let synthesized_match = ast::expr::Match {
             value: node.operand.clone(),
             arms: vec![
                 ast::expr::MatchArm {
                     pattern: Box::new(self.ast_variant_expr(
-                        Symbol::from("Ok".to_owned()),
+                        try_carrier,
+                        ok_variant,
                         Some(Self::ast_ident_expr(ok_name, node.span)),
                         node.span,
                     )),
@@ -2403,18 +2468,26 @@ impl SemanticAnalyzer {
                     is_catch_all: false,
                 },
                 ast::expr::MatchArm {
-                    pattern: Box::new(self.ast_variant_expr(
-                        Symbol::from("Err".to_owned()),
-                        Some(Self::ast_ident_expr(err_name, node.span)),
-                        node.span,
-                    )),
+                    pattern: Box::new(
+                        self.ast_variant_expr(
+                            try_carrier,
+                            err_variant,
+                            (try_carrier == TryCarrier::Result)
+                                .then(|| Self::ast_ident_expr(err_name, node.span)),
+                            node.span,
+                        ),
+                    ),
                     code: Rc::new(ast::expr::Expr {
                         kind: ast::expr::ExprKind::Return(ast::expr::Return {
-                            val: Some(Box::new(self.ast_variant_expr(
-                                Symbol::from("Err".to_owned()),
-                                Some(Self::ast_ident_expr(err_name, node.span)),
-                                node.span,
-                            ))),
+                            val: Some(Box::new(
+                                self.ast_variant_expr(
+                                    try_carrier,
+                                    err_variant,
+                                    (try_carrier == TryCarrier::Result)
+                                        .then(|| Self::ast_ident_expr(err_name, node.span)),
+                                    node.span,
+                                ),
+                            )),
                             span: node.span,
                         }),
                         span: node.span,

--- a/compiler/semantic/tests/expr.rs
+++ b/compiler/semantic/tests/expr.rs
@@ -147,6 +147,56 @@ fun f() -> i32 {
 }
 
 #[test]
+fn option_try_is_accepted() -> anyhow::Result<()> {
+    semantic_analyze(
+        r#"import std.option
+use std.option.Option
+
+fun inner() -> Option<i32> {
+    return Option::Some(42)
+}
+
+fun outer() -> Option<i32> {
+    value := inner()?;
+    return Option::Some(value)
+}"#,
+    )?;
+    Ok(())
+}
+
+#[test]
+fn option_try_requires_option_operand() -> anyhow::Result<()> {
+    let err = semantic_analyze_expect_error(
+        r#"import std.option
+use std.option.Option
+
+fun fail() -> Option<i32> {
+    value := 1?;
+    return Option::Some(value)
+}"#,
+    )?;
+    assert!(err.to_string().contains("`?` requires `Option<T>`"));
+    Ok(())
+}
+
+#[test]
+fn option_try_requires_option_function() -> anyhow::Result<()> {
+    let err = semantic_analyze_expect_error(
+        r#"import std.option
+use std.option.Option
+
+fun fail() -> i32 {
+    value := Option::Some(1)?;
+    return value
+}"#,
+    )?;
+    assert!(err
+        .to_string()
+        .contains("`?` can only be used in functions returning `Option<T>`"));
+    Ok(())
+}
+
+#[test]
 fn channel_recv_requires_channel() -> anyhow::Result<()> {
     let err = semantic_analyze_expect_error("fun f() { <-1 }")?;
     assert!(err.to_string().contains("channel receive requires"));

--- a/library/src/std/http.kd
+++ b/library/src/std/http.kd
@@ -557,7 +557,7 @@ fun websocket_upgrade_key(method: str, version: str, header: [u8]) -> Option<[u8
         return Option::None
     }
 
-    let upgrade = header_value(header, b"Upgrade")?
+    upgrade := header_value(header, b"Upgrade")?
     if !bytes_eq_ci(upgrade, b"websocket") {
         return Option::None
     }
@@ -566,12 +566,12 @@ fun websocket_upgrade_key(method: str, version: str, header: [u8]) -> Option<[u8
         return Option::None
     }
 
-    let version_header = header_value(header, b"Sec-WebSocket-Version")?
+    version_header := header_value(header, b"Sec-WebSocket-Version")?
     if !bytes_eq(version_header, b"13") {
         return Option::None
     }
 
-    let key = header_value(header, b"Sec-WebSocket-Key")?
+    key := header_value(header, b"Sec-WebSocket-Key")?
     if key.len() == 0 {
         return Option::None
     }

--- a/library/src/std/http.kd
+++ b/library/src/std/http.kd
@@ -557,10 +557,7 @@ fun websocket_upgrade_key(method: str, version: str, header: [u8]) -> Option<[u8
         return Option::None
     }
 
-    let upgrade = match header_value(header, b"Upgrade") {
-        Option::Some(value) => value,
-        Option::None => return Option::None,
-    }
+    let upgrade = header_value(header, b"Upgrade")?
     if !bytes_eq_ci(upgrade, b"websocket") {
         return Option::None
     }
@@ -569,18 +566,12 @@ fun websocket_upgrade_key(method: str, version: str, header: [u8]) -> Option<[u8
         return Option::None
     }
 
-    let version_header = match header_value(header, b"Sec-WebSocket-Version") {
-        Option::Some(value) => value,
-        Option::None => return Option::None,
-    }
+    let version_header = header_value(header, b"Sec-WebSocket-Version")?
     if !bytes_eq(version_header, b"13") {
         return Option::None
     }
 
-    let key = match header_value(header, b"Sec-WebSocket-Key") {
-        Option::Some(value) => value,
-        Option::None => return Option::None,
-    }
+    let key = header_value(header, b"Sec-WebSocket-Key")?
     if key.len() == 0 {
         return Option::None
     }


### PR DESCRIPTION
## Summary
- add postfix `?` support for `Option<T>` in semantic analysis alongside existing `Result` support
- report `Option`-specific diagnostics in semantic errors and LSP diagnostics
- add semantic/driver regression tests and simplify std HTTP option propagation with `?`

## Testing
- cargo fmt --all
- cargo clippy -- -D warnings
- cargo test -p kaede_semantic --test expr option_try -- --nocapture
- cargo test -p kaede_compiler_driver --test run run_executes_option_try_program -- --nocapture
- cargo test -p kaede_compiler_driver --test cli direct_compile_rejects_try_outside_option_function -- --nocapture
- cargo test --release --no-fail-fast *(HTTP/netpoll integration targets fail in this sandbox with `Operation not permitted (os error 1)`)*

Closes #223