### PR TITLE
feat: add Stringer interface and auto-call to_string in __format

### DIFF
--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -693,6 +693,153 @@ fn builtin_format() -> anyhow::Result<()> {
 }
 
 #[test]
+fn fundamental_to_string_for_i32() -> anyhow::Result<()> {
+    let program = r#"fun main() -> i32 {
+        let n: i32 = 123
+        if n.to_string().as_str() == "123" {
+            return 1
+        }
+        return 0
+    }"#;
+
+    assert_eq!(exec(program)?, 1);
+    Ok(())
+}
+
+#[test]
+fn fundamental_to_string_for_i64_baseline() -> anyhow::Result<()> {
+    let program = r#"fun main() -> i32 {
+        let n: i64 = 12345
+        if n.to_string().as_str() == "12345" {
+            return 1
+        }
+        return 0
+    }"#;
+
+    assert_eq!(exec(program)?, 1);
+    Ok(())
+}
+
+#[test]
+fn fundamental_to_string_for_u32() -> anyhow::Result<()> {
+    let program = r#"fun main() -> i32 {
+        let n: u32 = 999
+        if n.to_string().as_str() == "999" {
+            return 1
+        }
+        return 0
+    }"#;
+
+    assert_eq!(exec(program)?, 1);
+    Ok(())
+}
+
+#[test]
+fn fundamental_to_string_for_bool() -> anyhow::Result<()> {
+    let program = r#"fun main() -> i32 {
+        if true.to_string().as_str() == "true" {
+            return 1
+        }
+        return 0
+    }"#;
+
+    assert_eq!(exec(program)?, 1);
+    Ok(())
+}
+
+#[test]
+fn builtin_format_auto_calls_stringer_to_string() -> anyhow::Result<()> {
+    let program = r#"fun main() -> i32 {
+        if __format("{}+{}={}", 2 as i32, 3 as i32, 5 as i32) == "2+3=5" {
+            return 1
+        }
+        return 0
+    }"#;
+
+    assert_eq!(exec(program)?, 1);
+    Ok(())
+}
+
+#[test]
+fn builtin_format_auto_calls_stringer_for_bool_and_char() -> anyhow::Result<()> {
+    let program = r#"fun main() -> i32 {
+        if __format("{} {} {}", true, false, 'k') == "true false k" {
+            return 1
+        }
+        return 0
+    }"#;
+
+    assert_eq!(exec(program)?, 1);
+    Ok(())
+}
+
+#[test]
+fn interpolated_string_auto_calls_to_string() -> anyhow::Result<()> {
+    let program = r#"fun main() -> i32 {
+        let n: i32 = 42
+        let b = true
+        if $"n={n} b={b}" == "n=42 b=true" {
+            return 1
+        }
+        return 0
+    }"#;
+
+    assert_eq!(exec(program)?, 1);
+    Ok(())
+}
+
+#[test]
+fn interpolated_string_calls_user_to_string() -> anyhow::Result<()> {
+    let program = r#"
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    impl Point {
+        fun to_string(self) -> String {
+            let mut out = String::from("(")
+            out.push_str(self.x.to_string().as_str())
+            out.push_str(", ")
+            out.push_str(self.y.to_string().as_str())
+            out.push_str(")")
+            return out
+        }
+    }
+
+    fun main() -> i32 {
+        let p = Point { x: 3, y: 7 }
+        if $"p={p}" == "p=(3, 7)" {
+            return 1
+        }
+        return 0
+    }"#;
+
+    assert_eq!(exec(program)?, 1);
+    Ok(())
+}
+
+#[test]
+fn builtin_format_rejects_type_without_to_string() {
+    let program = r#"
+    struct Pair {
+        a: i32,
+        b: i32,
+    }
+
+    fun main() -> i32 {
+        let p = Pair { a: 1, b: 2 }
+        let _ = __format("{}", p)
+        return 0
+    }"#;
+
+    assert!(matches!(
+        extract_semantic_error(exec(program).unwrap_err()),
+        SemanticError::NoMethod { .. }
+    ));
+}
+
+#[test]
 fn builtin_format_requires_literal_template() {
     let program = r#"fun main() -> i32 {
         let t = "{}"

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -299,7 +299,6 @@ fn semantic_error_span(err: &SemanticError) -> Option<Span> {
         | SemanticError::TopLevelStatementsOnlyAllowedInEntryUnit { span }
         | SemanticError::MainOnlyAllowedInEntryUnit { span }
         | SemanticError::FormatTemplateMustBeStringLiteral { span }
-        | SemanticError::FormatArgumentMustBeStr { span, .. }
         | SemanticError::InvalidFormatTemplate { span, .. }
         | SemanticError::FormatPlaceholderCountMismatch { span, .. }
         | SemanticError::TryRequiresResult { span, .. }

--- a/compiler/semantic/src/error.rs
+++ b/compiler/semantic/src/error.rs
@@ -204,13 +204,6 @@ pub enum SemanticError {
     #[error("{}:{}:{} `format` template must be a string literal", span.file, span.start.line, span.start.column)]
     FormatTemplateMustBeStringLiteral { span: Span },
 
-    #[error("{}:{}:{} `format` argument #{} must be `str`, got `{}`", span.file, span.start.line, span.start.column, index, ty)]
-    FormatArgumentMustBeStr {
-        index: usize,
-        ty: String,
-        span: Span,
-    },
-
     #[error("{}:{}:{} invalid `format` template: {}", span.file, span.start.line, span.start.column, reason)]
     InvalidFormatTemplate { reason: String, span: Span },
 

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -1709,6 +1709,44 @@ impl SemanticAnalyzer {
         Ok(parts)
     }
 
+    /// Convert a non-`str` format argument to `str` by rewriting it to
+    /// `<arg>.to_string().as_str()` at the AST level and re-analyzing.
+    /// A missing `to_string` surfaces as a `NoMethod` error on the concrete type.
+    fn format_arg_via_to_string(
+        &mut self,
+        arg: &ast::expr::Expr,
+    ) -> anyhow::Result<ir::expr::Expr> {
+        let span = arg.span;
+        let empty_args = ast::expr::Args {
+            args: std::collections::VecDeque::new(),
+            span,
+        };
+        let make_call = |receiver: ast::expr::Expr, method: &str| ast::expr::Expr {
+            kind: ast::expr::ExprKind::Binary(ast::expr::Binary::new(
+                receiver.into(),
+                ast::expr::BinaryKind::Access,
+                ast::expr::Expr {
+                    kind: ast::expr::ExprKind::FnCall(ast::expr::FnCall {
+                        callee: Box::new(Self::ast_ident_expr(
+                            Symbol::from(method.to_owned()),
+                            span,
+                        )),
+                        generic_args: None,
+                        args: empty_args.clone(),
+                        span,
+                    }),
+                    span,
+                }
+                .into(),
+            )),
+            span,
+        };
+
+        let to_string_call = make_call(arg.clone(), "to_string");
+        let as_str_call = make_call(to_string_call, "as_str");
+        self.analyze_expr(&as_str_call)
+    }
+
     fn analyze_builtin_fn_call(
         &mut self,
         node: &ast::expr::FnCall,
@@ -1800,17 +1838,14 @@ impl SemanticAnalyzer {
                     let mut args = Vec::with_capacity(node.args.args.len());
                     args.push(self.analyze_expr(&first.value)?);
 
-                    for (i, arg) in node.args.args.iter().skip(1).enumerate() {
+                    for arg in node.args.args.iter().skip(1) {
                         let analyzed = self.analyze_expr(&arg.value)?;
-                        if !analyzed.ty.is_str() {
-                            return Err(SemanticError::FormatArgumentMustBeStr {
-                                index: i + 1,
-                                ty: analyzed.ty.kind.to_string(),
-                                span: arg.value.span,
-                            }
-                            .into());
-                        }
-                        args.push(analyzed);
+                        let str_arg = if analyzed.ty.is_str() {
+                            analyzed
+                        } else {
+                            self.format_arg_via_to_string(&arg.value)?
+                        };
+                        args.push(str_arg);
                     }
 
                     let actual = node.args.args.len() - 1;

--- a/compiler/semantic/tests/expr.rs
+++ b/compiler/semantic/tests/expr.rs
@@ -58,9 +58,11 @@ fn builtin_format_requires_literal_template() -> anyhow::Result<()> {
 }
 
 #[test]
-fn builtin_format_requires_str_args() -> anyhow::Result<()> {
-    let err = semantic_analyze_expect_error("fun f() { __format(\"n = {}\", 42) }")?;
-    assert!(err.to_string().contains("argument #1 must be `str`"));
+fn builtin_format_rejects_type_without_to_string() -> anyhow::Result<()> {
+    let err = semantic_analyze_expect_error(
+        "struct P { a: i32 }\nfun f() { let p = P { a: 1 }\n__format(\"{}\", p) }",
+    )?;
+    assert!(err.to_string().contains("no method named `to_string`"));
     Ok(())
 }
 

--- a/compiler/semantic/tests/top.rs
+++ b/compiler/semantic/tests/top.rs
@@ -635,18 +635,19 @@ interface Reader {
 ",
     )?;
 
-    let interfaces: Vec<_> = unit
+    let iface = unit
         .top_levels
         .iter()
-        .filter_map(|tl| match tl {
-            TopLevel::Interface(iface) => Some(iface),
+        .find_map(|tl| match tl {
+            TopLevel::Interface(iface)
+                if iface.name.symbol() == Symbol::from("Reader".to_string()) =>
+            {
+                Some(iface)
+            }
             _ => None,
         })
-        .collect();
+        .expect("Reader interface must be emitted");
 
-    assert_eq!(interfaces.len(), 1);
-    let iface = interfaces[0];
-    assert_eq!(iface.name.symbol(), Symbol::from("Reader".to_string()));
     assert_eq!(iface.methods.len(), 2);
     assert_eq!(iface.methods[0].name, Symbol::from("read".to_string()));
     assert_eq!(iface.methods[1].name, Symbol::from("peek".to_string()));

--- a/library/src/std/string.kd
+++ b/library/src/std/string.kd
@@ -297,6 +297,10 @@ impl str {
     }
 }
 
+export interface Stringer {
+    fun to_string(self) -> String
+}
+
 impl u64 {
     export fun to_string(self) -> String {
         return u64_to_string(self)
@@ -306,5 +310,58 @@ impl u64 {
 impl i64 {
     export fun to_string(self) -> String {
         return i64_to_string(self)
+    }
+}
+
+impl u8 {
+    export fun to_string(self) -> String {
+        return u64_to_string(self as u64)
+    }
+}
+
+impl u16 {
+    export fun to_string(self) -> String {
+        return u64_to_string(self as u64)
+    }
+}
+
+impl u32 {
+    export fun to_string(self) -> String {
+        return u64_to_string(self as u64)
+    }
+}
+
+impl i8 {
+    export fun to_string(self) -> String {
+        return i64_to_string(self as i64)
+    }
+}
+
+impl i16 {
+    export fun to_string(self) -> String {
+        return i64_to_string(self as i64)
+    }
+}
+
+impl i32 {
+    export fun to_string(self) -> String {
+        return i64_to_string(self as i64)
+    }
+}
+
+impl bool {
+    export fun to_string(self) -> String {
+        if self {
+            return String::from("true")
+        }
+        return String::from("false")
+    }
+}
+
+impl char {
+    export fun to_string(self) -> String {
+        let mut s = String::new()
+        s.push(self)
+        return s
     }
 }


### PR DESCRIPTION
## Summary

- Adds `std.string.Stringer` interface (`fun to_string(self) -> String`) plus `to_string` impls for every fundamental type (`i8/i16/i32/u8/u16/u32/bool/char`; `i64/u64` already existed).
- `__format` (and `$"..."` interpolation, which desugars to `__format`) now auto-converts any non-`str` argument by rewriting it to `<arg>.to_string().as_str()` at the AST level and re-analyzing, so the concrete `to_string` is resolved at compile time.
- No codegen changes: because dispatch is resolved statically, we don't need interface boxing for this feature. The `Stringer` interface is still exported for user-generic code (`fun print(s: Stringer)` etc.); `__format` just doesn't go through it.
- Types lacking `to_string` surface the existing `NoMethod` error. The old `FormatArgumentMustBeStr` variant is removed.

## Test plan

- [x] `cargo test --workspace` passes locally
- [x] `fundamental_to_string_for_{i32,i64_baseline,u32,bool}` — each checks exact string equality via `str == str`
- [x] `builtin_format_auto_calls_stringer_{to_string,for_bool_and_char}` — exact-match assertions on `__format` output
- [x] `interpolated_string_auto_calls_to_string` — `$"n={n} b={b}"` produces `"n=42 b=true"`
- [x] `interpolated_string_calls_user_to_string` — user-defined `impl Point { fun to_string }` is picked up by interpolation
- [x] `builtin_format_rejects_type_without_to_string` — structs without `to_string` error with `NoMethod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)