### PR TITLE
refactor: simplify stringer PR (format helper + drop redundant tests)

### DIFF
--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -707,20 +707,6 @@ fn fundamental_to_string_for_i32() -> anyhow::Result<()> {
 }
 
 #[test]
-fn fundamental_to_string_for_i64_baseline() -> anyhow::Result<()> {
-    let program = r#"fun main() -> i32 {
-        let n: i64 = 12345
-        if n.to_string().as_str() == "12345" {
-            return 1
-        }
-        return 0
-    }"#;
-
-    assert_eq!(exec(program)?, 1);
-    Ok(())
-}
-
-#[test]
 fn fundamental_to_string_for_u32() -> anyhow::Result<()> {
     let program = r#"fun main() -> i32 {
         let n: u32 = 999
@@ -817,26 +803,6 @@ fn interpolated_string_calls_user_to_string() -> anyhow::Result<()> {
 
     assert_eq!(exec(program)?, 1);
     Ok(())
-}
-
-#[test]
-fn builtin_format_rejects_type_without_to_string() {
-    let program = r#"
-    struct Pair {
-        a: i32,
-        b: i32,
-    }
-
-    fun main() -> i32 {
-        let p = Pair { a: 1, b: 2 }
-        let _ = __format("{}", p)
-        return 0
-    }"#;
-
-    assert!(matches!(
-        extract_semantic_error(exec(program).unwrap_err()),
-        SemanticError::NoMethod { .. }
-    ));
 }
 
 #[test]

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -1709,42 +1709,29 @@ impl SemanticAnalyzer {
         Ok(parts)
     }
 
-    /// Convert a non-`str` format argument to `str` by rewriting it to
-    /// `<arg>.to_string().as_str()` at the AST level and re-analyzing.
-    /// A missing `to_string` surfaces as a `NoMethod` error on the concrete type.
     fn format_arg_via_to_string(
         &mut self,
         arg: &ast::expr::Expr,
     ) -> anyhow::Result<ir::expr::Expr> {
         let span = arg.span;
-        let empty_args = ast::expr::Args {
-            args: std::collections::VecDeque::new(),
-            span,
-        };
-        let make_call = |receiver: ast::expr::Expr, method: &str| ast::expr::Expr {
-            kind: ast::expr::ExprKind::Binary(ast::expr::Binary::new(
-                receiver.into(),
-                ast::expr::BinaryKind::Access,
-                ast::expr::Expr {
-                    kind: ast::expr::ExprKind::FnCall(ast::expr::FnCall {
-                        callee: Box::new(Self::ast_ident_expr(
-                            Symbol::from(method.to_owned()),
-                            span,
-                        )),
-                        generic_args: None,
-                        args: empty_args.clone(),
+        let call = |receiver: ast::expr::Expr, method: &str| {
+            let fn_call = ast::expr::Expr {
+                kind: ast::expr::ExprKind::FnCall(ast::expr::FnCall {
+                    callee: Box::new(Self::ast_ident_expr(Symbol::from(method.to_owned()), span)),
+                    generic_args: None,
+                    args: ast::expr::Args {
+                        args: std::collections::VecDeque::new(),
                         span,
-                    }),
+                    },
                     span,
-                }
-                .into(),
-            )),
-            span,
+                }),
+                span,
+            };
+            Self::ast_access_expr(receiver, fn_call, span)
         };
 
-        let to_string_call = make_call(arg.clone(), "to_string");
-        let as_str_call = make_call(to_string_call, "as_str");
-        self.analyze_expr(&as_str_call)
+        let desugared = call(call(arg.clone(), "to_string"), "as_str");
+        self.analyze_expr(&desugared)
     }
 
     fn analyze_builtin_fn_call(


### PR DESCRIPTION
## Summary
- Reuse existing `ast_access_expr` helper in `format_arg_via_to_string`; drop nested closure, redundant `empty_args.clone()`, and the WHAT-style docstring
- Drop `fundamental_to_string_for_i64_baseline` (covered transitively via other delegating impls) and `builtin_format_rejects_type_without_to_string` (already covered at the semantic tier)

## Test plan
- [x] `cargo fmt`
- [x] `cargo test -p kaede_codegen` (all stringer/format tests pass)
- [x] `cargo test -p kaede_semantic`
- [x] `cargo clippy --all -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)