### PR TITLE
feat(http): unify Response/WebSocket send via Payload interfaces

### DIFF
--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -218,7 +218,7 @@ impl<'ctx> CodeGenerator<'ctx> {
             &FnDecl {
                 lang_linkage: LangLinkage::Default,
                 link_once: false,
-                name: QualifiedSymbol::new(ModulePath::new(vec![]), self.cgcx.malloc_symbol),
+                name: QualifiedSymbol::new(ModulePath::root(), self.cgcx.malloc_symbol),
                 is_c_variadic: false,
                 return_ty,
                 params,

--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -5019,3 +5019,127 @@ fn interface_dispatch_selects_concrete_method_per_type() -> anyhow::Result<()> {
     assert_eq!(exec(program)?, 58);
     Ok(())
 }
+
+#[test]
+fn generic_method_with_interface_bound() -> anyhow::Result<()> {
+    let program = r#"
+        interface Counter {
+            fun count(self) -> i32
+        }
+
+        struct A { v: i32 }
+        impl A {
+            fun count(self) -> i32 { return self.v }
+        }
+
+        struct B { v: i32 }
+        impl B {
+            fun count(self) -> i32 { return self.v * 10 }
+        }
+
+        struct Sum { total: i32 }
+        impl Sum {
+            fun add<T: Counter>(mut self, x: T) {
+                self.total = self.total + x.count()
+            }
+        }
+
+        fun main() -> i32 {
+            let mut s = Sum { total: 0 }
+            s.add(A { v: 3 })
+            s.add(B { v: 4 })
+            return s.total
+        }
+    "#;
+
+    assert_eq!(exec(program)?, 43);
+    Ok(())
+}
+
+#[test]
+fn generic_method_dispatches_on_str_and_slice() -> anyhow::Result<()> {
+    let program = r#"
+        interface Payload {
+            fun as_bytes(self) -> [u8]
+        }
+
+        impl str {
+            fun as_bytes(self) -> [u8] {
+                return __slice_from_raw_parts(self.as_ptr(), self.len())
+            }
+        }
+
+        impl [u8] {
+            fun as_bytes(self) -> [u8] {
+                return self
+            }
+        }
+
+        struct Sink { total: i32 }
+        impl Sink {
+            fun push<T: Payload>(mut self, body: T) {
+                self.total = self.total + body.as_bytes().len() as i32
+            }
+        }
+
+        fun main() -> i32 {
+            let mut s = Sink { total: 0 }
+            s.push("abc")
+            s.push(b"wxyz")
+            return s.total
+        }
+    "#;
+
+    assert_eq!(exec(program)?, 7);
+    Ok(())
+}
+
+#[test]
+fn generic_method_unbounded_type_param() -> anyhow::Result<()> {
+    let program = r#"
+        struct Holder { v: i32 }
+
+        impl Holder {
+            fun echo<U>(self, other: U) -> U {
+                return other
+            }
+        }
+
+        fun main() -> i32 {
+            let h = Holder { v: 1 }
+            return h.echo(42)
+        }
+    "#;
+
+    assert_eq!(exec(program)?, 42);
+    Ok(())
+}
+
+#[test]
+fn generic_method_rejects_unsatisfied_bound() {
+    let program = r#"
+        interface Counter {
+            fun count(self) -> i32
+        }
+
+        struct A { v: i32 }
+
+        struct Sum { total: i32 }
+        impl Sum {
+            fun add<T: Counter>(mut self, x: T) {
+                self.total = self.total + x.count()
+            }
+        }
+
+        fun main() -> i32 {
+            let mut s = Sum { total: 0 }
+            s.add(A { v: 3 })
+            return s.total
+        }
+    "#;
+
+    assert!(matches!(
+        extract_semantic_error(exec(program).unwrap_err()),
+        SemanticError::GenericBoundNotSatisfied { .. }
+    ));
+}

--- a/compiler/driver/tests/http_runtime.rs
+++ b/compiler/driver/tests/http_runtime.rs
@@ -24,7 +24,7 @@ fn spawn_http_server() -> anyhow::Result<(assert_fs::TempDir, TestServer, u16, s
 let mut app = std.http.App::new()
 
 app.get("/hello", |req, res| {{
-    res.send_text("hello")
+    res.send("hello")
 }})
 
 app.get("/query", |req, res| {{
@@ -32,11 +32,11 @@ app.get("/query", |req, res| {{
         std.option.Option::Some(value) => value,
         std.option.Option::None => std.string.String::from("missing"),
     }}
-    res.send_text(author.as_str())
+    res.send(author.as_str())
 }})
 
 app.post("/echo", |req, res| {{
-    res.send_bytes(req.body)
+    res.send(req.body)
 }})
 
 app.listen(ip="127.0.0.1", port={port})

--- a/compiler/driver/tests/http_static.rs
+++ b/compiler/driver/tests/http_static.rs
@@ -32,7 +32,7 @@ fn std_http_serves_static_files_with_expected_routing_rules() -> anyhow::Result<
 let mut app = std.http.App::new()
 
 app.get("/hello", |req, res| {{
-    res.send_text("route wins")
+    res.send("route wins")
 }})
 
 app.static_file("/", "public/index.html")

--- a/compiler/ir/src/module_path.rs
+++ b/compiler/ir/src/module_path.rs
@@ -10,6 +10,13 @@ impl ModulePath {
         Self { modules_from_root }
     }
 
+    // The anonymous module at the top of the module tree — used for symbols that have no
+    // natural defining module (fundamental types, slice intrinsic methods, the main
+    // entry point).
+    pub fn root() -> Self {
+        Self::new(vec![])
+    }
+
     pub fn get_module_names_from_root(&self) -> &[Symbol] {
         &self.modules_from_root
     }

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -248,6 +248,7 @@ fn parse_error_span(err: &ParseError) -> Option<Span> {
 fn semantic_error_span(err: &SemanticError) -> Option<Span> {
     match err {
         SemanticError::Undeclared { span, .. }
+        | SemanticError::PrivateItemAccess { span, .. }
         | SemanticError::NotCallable { span, .. }
         | SemanticError::InvalidTypeForArithmeticOperation { span, .. }
         | SemanticError::GenericArgumentLengthMismatch { span, .. }

--- a/compiler/monomorphize/src/lib.rs
+++ b/compiler/monomorphize/src/lib.rs
@@ -44,7 +44,7 @@ mod tests {
         Rc::new(FnDecl {
             lang_linkage: LangLinkage::Default,
             link_once: false,
-            name: QualifiedSymbol::new(ModulePath::new(vec![]), Symbol::from(name.to_owned())),
+            name: QualifiedSymbol::new(ModulePath::root(), Symbol::from(name.to_owned())),
             params: vec![],
             is_c_variadic: false,
             return_ty: unit_ty(),
@@ -198,7 +198,7 @@ mod tests {
 
     fn dummy_interface(name: &str) -> Rc<Interface> {
         Rc::new(Interface {
-            name: QualifiedSymbol::new(ModulePath::new(vec![]), Symbol::from(name.to_owned())),
+            name: QualifiedSymbol::new(ModulePath::root(), Symbol::from(name.to_owned())),
             methods: vec![InterfaceMethod {
                 name: Symbol::from("m".to_owned()),
                 self_: None,

--- a/compiler/semantic/src/context.rs
+++ b/compiler/semantic/src/context.rs
@@ -106,6 +106,20 @@ impl SemanticAnalyzer {
         self.with_context(new_context, f)
     }
 
+    // Temporarily changes both the current and base module path, executes the provided closure.
+    // Used when re-analyzing code originally defined in another module (e.g. monomorphizing a
+    // generic function) so that name-lookup fallbacks target the defining module rather than the
+    // file currently being compiled.
+    pub fn with_defining_module<F, R>(&mut self, path: ModulePath, f: F) -> R
+    where
+        F: FnOnce(&mut Self) -> R,
+    {
+        let mut new_context = self.context.clone();
+        new_context.current_module_path = path.clone();
+        new_context.module_path = path;
+        self.with_context(new_context, f)
+    }
+
     pub fn with_root_module<F, R>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut Self) -> R,
@@ -325,9 +339,5 @@ impl ModuleContext {
                 .unwrap()
                 .bind(symbol, value)
         }
-    }
-
-    pub fn clear_private_symbol_table(&mut self) {
-        self.private_symbol_table.clear();
     }
 }

--- a/compiler/semantic/src/context.rs
+++ b/compiler/semantic/src/context.rs
@@ -33,7 +33,7 @@ pub struct AnalysisContext {
 impl AnalysisContext {
     pub fn new(module_path: ModulePath) -> Self {
         Self {
-            current_module_path: ModulePath::new(vec![]),
+            current_module_path: ModulePath::root(),
             module_path,
             fallback_lookup_module_path: None,
             is_inside_loop: false,

--- a/compiler/semantic/src/context.rs
+++ b/compiler/semantic/src/context.rs
@@ -123,7 +123,18 @@ impl SemanticAnalyzer {
     where
         F: FnOnce(&mut Self) -> R,
     {
-        self.with_module(ModulePath::new(vec![]), f)
+        self.with_module(ModulePath::root(), f)
+    }
+
+    // Register a decl in the root module while keeping `fallback` as a lookup fallback,
+    // so the body can still reach symbols declared alongside it in its original module.
+    // Used for built-in types (fundamentals, slices) whose methods live in the root module
+    // but whose bodies may reference helpers from wherever the `impl` block was written.
+    pub fn with_root_module_and_fallback<F, R>(&mut self, fallback: ModulePath, f: F) -> R
+    where
+        F: FnOnce(&mut Self) -> R,
+    {
+        self.with_lookup_fallback_module(fallback, |analyzer| analyzer.with_root_module(f))
     }
 
     // Temporarily changes the fallback module path used for symbol lookup.

--- a/compiler/semantic/src/context.rs
+++ b/compiler/semantic/src/context.rs
@@ -106,10 +106,9 @@ impl SemanticAnalyzer {
         self.with_context(new_context, f)
     }
 
-    // Temporarily changes both the current and base module path, executes the provided closure.
-    // Used when re-analyzing code originally defined in another module (e.g. monomorphizing a
-    // generic function) so that name-lookup fallbacks target the defining module rather than the
-    // file currently being compiled.
+    // Changes both `current_module_path` and `module_path`, so name-lookup fallbacks
+    // target the defining module rather than the caller (used when monomorphizing a
+    // generic whose body was written against another module's symbols).
     pub fn with_defining_module<F, R>(&mut self, path: ModulePath, f: F) -> R
     where
         F: FnOnce(&mut Self) -> R,

--- a/compiler/semantic/src/context.rs
+++ b/compiler/semantic/src/context.rs
@@ -286,6 +286,17 @@ impl ModuleContext {
         None
     }
 
+    // Public-only variant used when another module performs a qualified lookup into
+    // this one: private items must not be reachable across module boundaries.
+    pub fn lookup_public_symbol(&self, symbol: &Symbol) -> Option<Rc<RefCell<SymbolTableValue>>> {
+        for table in self.symbol_table_stack.iter().rev() {
+            if let Some(value) = table.lookup(symbol) {
+                return Some(value);
+            }
+        }
+        None
+    }
+
     pub fn lookup_generic_argument(&self, symbol: Symbol) -> Option<Rc<Ty>> {
         // Search from the top of the stack
         for table in self.generic_argument_table.iter().rev() {

--- a/compiler/semantic/src/error.rs
+++ b/compiler/semantic/src/error.rs
@@ -7,6 +7,13 @@ pub enum SemanticError {
     #[error("{}:{}:{} `{}` was not declared in this scope", span.file, span.start.line, span.start.column, .name)]
     Undeclared { name: Symbol, span: Span },
 
+    #[error("{}:{}:{} `{}` is private to module `{}`", span.file, span.start.line, span.start.column, .name, .module)]
+    PrivateItemAccess {
+        name: Symbol,
+        module: String,
+        span: Span,
+    },
+
     #[error("{}:{}:{} value of type `{}` is not callable", span.file, span.start.line, span.start.column, .ty)]
     NotCallable { ty: String, span: Span },
 

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -3577,7 +3577,7 @@ impl SemanticAnalyzer {
 
                     self.create_method_call_ir(
                         callee_symbol,
-                        ModulePath::new(vec![]),
+                        ModulePath::root(),
                         self.slice_method_parent_name(elem_ty),
                         call_node,
                         lhs,
@@ -3615,7 +3615,7 @@ impl SemanticAnalyzer {
                     // Arrays use slice methods (array is coerced to slice at codegen)
                     self.create_method_call_ir(
                         callee_symbol,
-                        ModulePath::new(vec![]),
+                        ModulePath::root(),
                         self.slice_method_parent_name(elem_ty),
                         call_node,
                         lhs,

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -1305,22 +1305,26 @@ impl SemanticAnalyzer {
             generic_params.span,
         )?;
 
-        // Generic functions must always be generated regardless of the analyze command, so it is overwritten
+        // Generic functions must always be generated regardless of the analyze command, so it is overwritten.
+        // Switch to the defining module so type names in the signature/body resolve against the
+        // module where the generic was declared, not the call site's module.
+        let defining_module = origin.module_path().clone();
         let fn_ = self.with_analyze_command(AnalyzeCommand::NoCommand, |analyzer| {
-            // Generate the generic function
-            analyzer.with_generic_arguments(generic_params, generic_args, |analyzer| {
-                let mut fn_ = info.ast.clone();
-                fn_.decl.name = Ident::new(generated_generic_key, Span::dummy());
-                // Because generic functions maybe generated multiple times (across multiple files),
-                // we need to set link_once to true to avoid errors
-                fn_.decl.link_once = true;
-                analyzer.with_pending_generic_instance(
-                    Some(ir_type::GenericInstanceInfo::new(
-                        origin.clone(),
-                        generic_args.to_vec(),
-                    )),
-                    |analyzer| analyzer.analyze_fn_internal(fn_),
-                )
+            analyzer.with_defining_module(defining_module, |analyzer| {
+                analyzer.with_generic_arguments(generic_params, generic_args, |analyzer| {
+                    let mut fn_ = info.ast.clone();
+                    fn_.decl.name = Ident::new(generated_generic_key, Span::dummy());
+                    // Because generic functions maybe generated multiple times (across multiple files),
+                    // we need to set link_once to true to avoid errors
+                    fn_.decl.link_once = true;
+                    analyzer.with_pending_generic_instance(
+                        Some(ir_type::GenericInstanceInfo::new(
+                            origin.clone(),
+                            generic_args.to_vec(),
+                        )),
+                        |analyzer| analyzer.analyze_fn_internal(fn_),
+                    )
+                })
             })
         })?;
 

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -1400,6 +1400,13 @@ impl SemanticAnalyzer {
         }
         provided_args.extend(analyzed_variadic.iter().cloned());
 
+        let param_len = func_info
+            .ast
+            .decl
+            .generic_params
+            .as_ref()
+            .map_or(0, |params| params.len());
+
         let generic_args = if let Some(generic_args) = node.generic_args.as_ref() {
             generic_args
                 .types
@@ -1409,6 +1416,8 @@ impl SemanticAnalyzer {
         } else {
             let mut inferred_args = provided_args
                 .iter()
+                .skip(if has_this { 1 } else { 0 })
+                .take(param_len)
                 .map(|arg| -> anyhow::Result<Rc<ir_type::Ty>> {
                     Ok(match arg.ty.kind.as_ref() {
                         ir_type::TyKind::Var(_) => match arg.kind {
@@ -1423,12 +1432,6 @@ impl SemanticAnalyzer {
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
-            let param_len = func_info
-                .ast
-                .decl
-                .generic_params
-                .as_ref()
-                .map_or(0, |params| params.len());
             if inferred_args.len() < param_len {
                 inferred_args.extend(
                     (0..(param_len - inferred_args.len())).map(|_| self.infer_context.fresh()),

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -3879,8 +3879,8 @@ impl SemanticAnalyzer {
     }
 
     // Slice/array method dispatch. The impl may live in a different module than the
-    // current one (autoload's `impl<T>[T]` registers under [autoload, slice], and
-    // monomorphization may produce a slice type whose impl was generated elsewhere).
+    // current one: autoload's monomorphized `impl<T>[T]` registers under the intrinsic
+    // module, while user-defined `impl [T] { ... }` registers under the caller's module.
     fn create_slice_method_call_ir(
         &mut self,
         method_name: Symbol,

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -1290,9 +1290,8 @@ impl SemanticAnalyzer {
         let generated_generic_key =
             self.create_generated_generic_key(info.ast.decl.name.symbol(), generic_args);
 
-        // If the generic function is already generated, return early.
         // Search the defining module first so cross-module call sites reuse the cached
-        // instantiation (which lives in the defining module, not the caller's module).
+        // instantiation, which lives in the defining module rather than the caller's.
         let cached = self
             .lookup_qualified_symbol(QualifiedSymbol::new(
                 origin.module_path().clone(),
@@ -1314,8 +1313,8 @@ impl SemanticAnalyzer {
         )?;
 
         // Generic functions must always be generated regardless of the analyze command, so it is overwritten.
-        // Switch to the defining module so type names in the signature/body resolve against the
-        // module where the generic was declared, not the call site's module.
+        // Switch to the defining module so names in the signature/body resolve against
+        // the module where the generic was declared, not the call site's.
         let defining_module = origin.module_path().clone();
         let fn_ = self.with_analyze_command(AnalyzeCommand::NoCommand, |analyzer| {
             analyzer.with_defining_module(defining_module, |analyzer| {
@@ -1412,13 +1411,6 @@ impl SemanticAnalyzer {
         }
         provided_args.extend(analyzed_variadic.iter().cloned());
 
-        let param_len = func_info
-            .ast
-            .decl
-            .generic_params
-            .as_ref()
-            .map_or(0, |params| params.len());
-
         let generic_args = if let Some(generic_args) = node.generic_args.as_ref() {
             generic_args
                 .types
@@ -1426,6 +1418,13 @@ impl SemanticAnalyzer {
                 .map(|arg| self.analyze_type(arg))
                 .collect::<anyhow::Result<Vec<_>>>()?
         } else {
+            let param_len = func_info
+                .ast
+                .decl
+                .generic_params
+                .as_ref()
+                .map_or(0, |params| params.len());
+
             let mut inferred_args = provided_args
                 .iter()
                 .skip(if has_this { 1 } else { 0 })
@@ -3063,9 +3062,7 @@ impl SemanticAnalyzer {
             };
 
             if analyzer.modules.contains_key(&module_path) {
-                analyzer.reject_private_cross_module_access(&module_path, &node.rhs)?;
-                let expr = analyzer
-                    .with_module(module_path, |analyzer| analyzer.analyze_expr(&node.rhs))?;
+                let expr = analyzer.analyze_cross_module_rhs(module_path, &node.rhs)?;
                 return Ok(Some(expr));
             }
 
@@ -3326,9 +3323,7 @@ impl SemanticAnalyzer {
                 node.lhs.span,
             ) {
                 if analyzer.modules.contains_key(&module_path) {
-                    analyzer.reject_private_cross_module_access(&module_path, &node.rhs)?;
-                    let expr = analyzer
-                        .with_module(module_path, |analyzer| analyzer.analyze_expr(&node.rhs))?;
+                    let expr = analyzer.analyze_cross_module_rhs(module_path, &node.rhs)?;
                     return Ok(Some(expr));
                 }
             }
@@ -3576,9 +3571,8 @@ impl SemanticAnalyzer {
                     let span = Span::new(lhs.span.start, call_node.span.finish, lhs.span.file);
                     let callee_symbol = self.callee_symbol(call_node)?;
 
-                    // Ensure slice methods exist for this element type. Substituting a generic
-                    // type parameter may produce a concrete slice type whose methods were never
-                    // registered at the call site.
+                    // Monomorphization may produce a slice type whose methods were never
+                    // registered at the call site; ensure they exist before dispatching.
                     self.generate_slice_impl(elem_ty.clone())?;
 
                     self.create_slice_method_call_ir(
@@ -3843,44 +3837,40 @@ impl SemanticAnalyzer {
         })
     }
 
-    // Privacy check for `module.symbol` / `module::symbol` user-facing accesses. The
-    // immediate symbol on the rhs must be reachable via the target module's *public*
-    // symbol table — private items must not leak across module boundaries.
-    fn reject_private_cross_module_access(
-        &self,
-        module_path: &ModulePath,
+    // Enter a foreign module to analyze the rhs of a `module.symbol` / `module::symbol`
+    // access, rejecting the access if the target symbol exists only in the module's
+    // private table — private items must not leak across module boundaries.
+    fn analyze_cross_module_rhs(
+        &mut self,
+        module_path: ModulePath,
         rhs: &ast::expr::Expr,
-    ) -> anyhow::Result<()> {
-        let (symbol, span) = match &rhs.kind {
-            ast::expr::ExprKind::Ident(ident) => (ident.symbol(), ident.span()),
-            ast::expr::ExprKind::FnCall(call) => match Self::callee_ident(call) {
-                Some(ident) => (ident.symbol(), ident.span()),
-                None => return Ok(()),
-            },
-            _ => return Ok(()),
-        };
-
-        let module = match self.modules.get(module_path) {
-            Some(m) => m,
-            None => return Ok(()),
-        };
-
-        if module.lookup_public_symbol(&symbol).is_some() {
-            return Ok(());
+    ) -> anyhow::Result<ir::expr::Expr> {
+        if let Some((symbol, span)) = Self::rhs_symbol(rhs) {
+            if let Some(module) = self.modules.get(&module_path) {
+                if module.lookup_public_symbol(&symbol).is_none()
+                    && module.lookup_symbol(&symbol).is_some()
+                {
+                    return Err(SemanticError::Undeclared { name: symbol, span }.into());
+                }
+            }
         }
 
-        if module.lookup_symbol(&symbol).is_some() {
-            return Err(SemanticError::Undeclared { name: symbol, span }.into());
-        }
-
-        Ok(())
+        self.with_module(module_path, |analyzer| analyzer.analyze_expr(rhs))
     }
 
-    // Slice/array method dispatch. The impl may have been registered from a different
-    // module than the current one (e.g. autoload's `impl<T>[T]` lives in [autoload, slice],
-    // and during cross-module monomorphization the caller's module differs from where the
-    // impl was generated). Try the current module first, then fall back to any module that
-    // has the key — slice keys are concrete-element-typed and unique per compile unit.
+    fn rhs_symbol(rhs: &ast::expr::Expr) -> Option<(Symbol, Span)> {
+        match &rhs.kind {
+            ast::expr::ExprKind::Ident(ident) => Some((ident.symbol(), ident.span())),
+            ast::expr::ExprKind::FnCall(call) => {
+                Self::callee_ident(call).map(|ident| (ident.symbol(), ident.span()))
+            }
+            _ => None,
+        }
+    }
+
+    // Slice/array method dispatch. The impl may live in a different module than the
+    // current one (autoload's `impl<T>[T]` registers under [autoload, slice], and
+    // monomorphization may produce a slice type whose impl was generated elsewhere).
     fn create_slice_method_call_ir(
         &mut self,
         method_name: Symbol,

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -3575,8 +3575,9 @@ impl SemanticAnalyzer {
                     // registered at the call site; ensure they exist before dispatching.
                     self.generate_slice_impl(elem_ty.clone())?;
 
-                    self.create_slice_method_call_ir(
+                    self.create_method_call_ir(
                         callee_symbol,
+                        ModulePath::new(vec![]),
                         self.slice_method_parent_name(elem_ty),
                         call_node,
                         lhs,
@@ -3612,8 +3613,9 @@ impl SemanticAnalyzer {
                     self.generate_slice_impl(elem_ty.clone())?;
 
                     // Arrays use slice methods (array is coerced to slice at codegen)
-                    self.create_slice_method_call_ir(
+                    self.create_method_call_ir(
                         callee_symbol,
+                        ModulePath::new(vec![]),
                         self.slice_method_parent_name(elem_ty),
                         call_node,
                         lhs,
@@ -3876,32 +3878,6 @@ impl SemanticAnalyzer {
             }
             _ => None,
         }
-    }
-
-    // Slice/array method dispatch. The impl may live in a different module than the
-    // current one: autoload's monomorphized `impl<T>[T]` registers under the intrinsic
-    // module, while user-defined `impl [T] { ... }` registers under the caller's module.
-    fn create_slice_method_call_ir(
-        &mut self,
-        method_name: Symbol,
-        parent_name: Symbol,
-        call_node: &ast::expr::FnCall,
-        this: ir::expr::Expr,
-        span: Span,
-    ) -> anyhow::Result<ir::expr::Expr> {
-        let method_key = self.create_method_key(parent_name, method_name, false);
-
-        let module_path = self
-            .lookup_qualified_symbol(QualifiedSymbol::new(self.module_path().clone(), method_key))
-            .map(|_| self.module_path().clone())
-            .or_else(|| {
-                self.modules
-                    .iter()
-                    .find_map(|(mp, module)| module.lookup_symbol(&method_key).map(|_| mp.clone()))
-            })
-            .unwrap_or_else(|| self.module_path().clone());
-
-        self.create_method_call_ir(method_name, module_path, parent_name, call_node, this, span)
     }
 
     fn create_method_call_ir(

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -1290,8 +1290,16 @@ impl SemanticAnalyzer {
         let generated_generic_key =
             self.create_generated_generic_key(info.ast.decl.name.symbol(), generic_args);
 
-        // If the generic function is already generated, return early
-        if let Some(symbol_value) = self.lookup_symbol(generated_generic_key) {
+        // If the generic function is already generated, return early.
+        // Search the defining module first so cross-module call sites reuse the cached
+        // instantiation (which lives in the defining module, not the caller's module).
+        let cached = self
+            .lookup_qualified_symbol(QualifiedSymbol::new(
+                origin.module_path().clone(),
+                generated_generic_key,
+            ))
+            .or_else(|| self.lookup_symbol(generated_generic_key));
+        if let Some(symbol_value) = cached {
             if let SymbolTableValueKind::Function(fn_) = &symbol_value.borrow().kind {
                 return Ok(fn_.clone());
             } else {
@@ -3055,6 +3063,7 @@ impl SemanticAnalyzer {
             };
 
             if analyzer.modules.contains_key(&module_path) {
+                analyzer.reject_private_cross_module_access(&module_path, &node.rhs)?;
                 let expr = analyzer
                     .with_module(module_path, |analyzer| analyzer.analyze_expr(&node.rhs))?;
                 return Ok(Some(expr));
@@ -3317,6 +3326,7 @@ impl SemanticAnalyzer {
                 node.lhs.span,
             ) {
                 if analyzer.modules.contains_key(&module_path) {
+                    analyzer.reject_private_cross_module_access(&module_path, &node.rhs)?;
                     let expr = analyzer
                         .with_module(module_path, |analyzer| analyzer.analyze_expr(&node.rhs))?;
                     return Ok(Some(expr));
@@ -3566,9 +3576,13 @@ impl SemanticAnalyzer {
                     let span = Span::new(lhs.span.start, call_node.span.finish, lhs.span.file);
                     let callee_symbol = self.callee_symbol(call_node)?;
 
-                    self.create_method_call_ir(
+                    // Ensure slice methods exist for this element type. Substituting a generic
+                    // type parameter may produce a concrete slice type whose methods were never
+                    // registered at the call site.
+                    self.generate_slice_impl(elem_ty.clone())?;
+
+                    self.create_slice_method_call_ir(
                         callee_symbol,
-                        self.module_path().clone(),
                         self.slice_method_parent_name(elem_ty),
                         call_node,
                         lhs,
@@ -3604,9 +3618,8 @@ impl SemanticAnalyzer {
                     self.generate_slice_impl(elem_ty.clone())?;
 
                     // Arrays use slice methods (array is coerced to slice at codegen)
-                    self.create_method_call_ir(
+                    self.create_slice_method_call_ir(
                         callee_symbol,
-                        self.module_path().clone(),
                         self.slice_method_parent_name(elem_ty),
                         call_node,
                         lhs,
@@ -3828,6 +3841,67 @@ impl SemanticAnalyzer {
                 span,
             }),
         })
+    }
+
+    // Privacy check for `module.symbol` / `module::symbol` user-facing accesses. The
+    // immediate symbol on the rhs must be reachable via the target module's *public*
+    // symbol table — private items must not leak across module boundaries.
+    fn reject_private_cross_module_access(
+        &self,
+        module_path: &ModulePath,
+        rhs: &ast::expr::Expr,
+    ) -> anyhow::Result<()> {
+        let (symbol, span) = match &rhs.kind {
+            ast::expr::ExprKind::Ident(ident) => (ident.symbol(), ident.span()),
+            ast::expr::ExprKind::FnCall(call) => match Self::callee_ident(call) {
+                Some(ident) => (ident.symbol(), ident.span()),
+                None => return Ok(()),
+            },
+            _ => return Ok(()),
+        };
+
+        let module = match self.modules.get(module_path) {
+            Some(m) => m,
+            None => return Ok(()),
+        };
+
+        if module.lookup_public_symbol(&symbol).is_some() {
+            return Ok(());
+        }
+
+        if module.lookup_symbol(&symbol).is_some() {
+            return Err(SemanticError::Undeclared { name: symbol, span }.into());
+        }
+
+        Ok(())
+    }
+
+    // Slice/array method dispatch. The impl may have been registered from a different
+    // module than the current one (e.g. autoload's `impl<T>[T]` lives in [autoload, slice],
+    // and during cross-module monomorphization the caller's module differs from where the
+    // impl was generated). Try the current module first, then fall back to any module that
+    // has the key — slice keys are concrete-element-typed and unique per compile unit.
+    fn create_slice_method_call_ir(
+        &mut self,
+        method_name: Symbol,
+        parent_name: Symbol,
+        call_node: &ast::expr::FnCall,
+        this: ir::expr::Expr,
+        span: Span,
+    ) -> anyhow::Result<ir::expr::Expr> {
+        let method_key = self.create_method_key(parent_name, method_name, false);
+
+        let module_path = self
+            .lookup_qualified_symbol(QualifiedSymbol::new(self.module_path().clone(), method_key))
+            .map(|_| self.module_path().clone())
+            .or_else(|| {
+                self.modules
+                    .iter()
+                    .find_map(|(mp, module)| module.lookup_symbol(&method_key).map(|_| mp.clone()))
+            })
+            .unwrap_or_else(|| self.module_path().clone());
+
+        self.create_method_call_ir(method_name, module_path, parent_name, call_node, this, span)
     }
 
     fn create_method_call_ir(

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -3429,7 +3429,7 @@ impl SemanticAnalyzer {
 
             self.create_method_call_ir(
                 callee_symbol,
-                ModulePath::new(vec![]),
+                ModulePath::root(),
                 "str".to_owned().into(),
                 call_node,
                 left,
@@ -4003,7 +4003,7 @@ impl SemanticAnalyzer {
 
         self.create_method_call_ir(
             callee_symbol,
-            ModulePath::new(vec![]),
+            ModulePath::root(),
             fty.kind.to_string().into(),
             call_node,
             left,

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -3850,7 +3850,17 @@ impl SemanticAnalyzer {
                 if module.lookup_public_symbol(&symbol).is_none()
                     && module.lookup_symbol(&symbol).is_some()
                 {
-                    return Err(SemanticError::Undeclared { name: symbol, span }.into());
+                    return Err(SemanticError::PrivateItemAccess {
+                        name: symbol,
+                        module: module_path
+                            .get_module_names_from_root()
+                            .iter()
+                            .map(|s| s.as_str().to_string())
+                            .collect::<Vec<_>>()
+                            .join("."),
+                        span,
+                    }
+                    .into());
                 }
             }
         }

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -308,6 +308,13 @@ impl SemanticAnalyzer {
             .unwrap();
     }
 
+    fn create_module_context(file_path: FilePath, module_path: ModulePath) -> ModuleContext {
+        let mut module_context = ModuleContext::new(file_path);
+        module_context.push_scope(SymbolTable::new());
+        Self::insert_builtin_slice_symbol(&mut module_context, module_path);
+        module_context
+    }
+
     pub fn new(file_path: FilePath, root_dir: PathBuf) -> Self {
         if !root_dir.is_dir() {
             panic!("Root directory is not a directory");
@@ -345,9 +352,10 @@ impl SemanticAnalyzer {
         let mut context = AnalysisContext::new(module_path.clone());
         context.set_current_module_path(module_path.clone());
 
-        let mut module_context = ModuleContext::new(FilePath::from(PathBuf::from("test.kd")));
-        Self::insert_builtin_slice_symbol(&mut module_context, module_path.clone());
-        module_context.push_scope(SymbolTable::new());
+        let module_context = Self::create_module_context(
+            FilePath::from(PathBuf::from("test.kd")),
+            module_path.clone(),
+        );
 
         Self {
             modules: HashMap::from([(module_path, module_context)]),
@@ -1282,9 +1290,7 @@ impl SemanticAnalyzer {
         let mut top_level_irs = vec![];
 
         // Create root module
-        let mut root_module = ModuleContext::new(FilePath::dummy());
-        root_module.push_scope(SymbolTable::new());
-        Self::insert_builtin_slice_symbol(&mut root_module, ModulePath::new(vec![]));
+        let root_module = Self::create_module_context(FilePath::dummy(), ModulePath::new(vec![]));
         self.modules.insert(ModulePath::new(vec![]), root_module);
 
         self.context.set_no_prelude(options.no_prelude);

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -949,7 +949,7 @@ impl SemanticAnalyzer {
         let main_fn_decl = ir::top::FnDecl {
             lang_linkage: kaede_common::LangLinkage::Default,
             link_once: false,
-            name: QualifiedSymbol::new(ModulePath::new(vec![]), "main".to_owned().into()),
+            name: QualifiedSymbol::new(ModulePath::root(), "main".to_owned().into()),
             params,
             is_c_variadic: false,
             return_ty: Rc::new(ir::ty::make_fundamental_type(
@@ -962,10 +962,7 @@ impl SemanticAnalyzer {
         let runtime_init_decl = ir::top::FnDecl {
             lang_linkage: kaede_common::LangLinkage::C,
             link_once: false,
-            name: QualifiedSymbol::new(
-                ModulePath::new(vec![]),
-                "kaede_runtime_init".to_owned().into(),
-            ),
+            name: QualifiedSymbol::new(ModulePath::root(), "kaede_runtime_init".to_owned().into()),
             params: vec![],
             is_c_variadic: false,
             return_ty: Rc::new(ir::ty::Ty::new_unit()),
@@ -975,10 +972,7 @@ impl SemanticAnalyzer {
         let runtime_run_decl = ir::top::FnDecl {
             lang_linkage: kaede_common::LangLinkage::C,
             link_once: false,
-            name: QualifiedSymbol::new(
-                ModulePath::new(vec![]),
-                "kaede_runtime_run".to_owned().into(),
-            ),
+            name: QualifiedSymbol::new(ModulePath::root(), "kaede_runtime_run".to_owned().into()),
             params: vec![],
             is_c_variadic: false,
             return_ty: Rc::new(ir::ty::make_fundamental_type(
@@ -992,7 +986,7 @@ impl SemanticAnalyzer {
             lang_linkage: kaede_common::LangLinkage::C,
             link_once: false,
             name: QualifiedSymbol::new(
-                ModulePath::new(vec![]),
+                ModulePath::root(),
                 "kaede_runtime_shutdown".to_owned().into(),
             ),
             params: vec![],
@@ -1277,7 +1271,7 @@ impl SemanticAnalyzer {
 
         // Create root module
         let root_module = Self::create_module_context(FilePath::dummy());
-        self.modules.insert(ModulePath::new(vec![]), root_module);
+        self.modules.insert(ModulePath::root(), root_module);
 
         self.context.set_no_prelude(options.no_prelude);
 

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -17,8 +17,8 @@ use kaede_parse::Parser;
 use kaede_span::{file::FilePath, Span};
 use kaede_symbol::{Ident, Symbol};
 use kaede_symbol_table::{
-    GenericInfo, GenericKind, GenericSliceInfo, QualifiedSymbolTable, SymbolResolver, SymbolTable,
-    SymbolTableValue, SymbolTableValueKind,
+    GenericImplInfo, QualifiedSymbolTable, SymbolResolver, SymbolTable, SymbolTableValue,
+    SymbolTableValueKind,
 };
 
 mod context;
@@ -54,6 +54,14 @@ pub struct AnalyzeOptions {
     pub is_entry_unit: bool,
 }
 
+// The `impl<T>[T] { ... }` block lives in a single autoload module but applies to every
+// slice type anywhere in the compile unit. Storing it here — rather than as a per-module
+// symbol — gives every lookup a direct, canonical handle.
+pub struct SliceIntrinsic {
+    pub impl_info: GenericImplInfo,
+    pub module_path: ModulePath,
+}
+
 pub struct SemanticAnalyzer {
     modules: HashMap<ModulePath, ModuleContext>,
     context: AnalysisContext,
@@ -69,6 +77,7 @@ pub struct SemanticAnalyzer {
     temp_symbol_counter: usize,
     generic_fn_substitutions: HashMap<QualifiedSymbol, HashMap<ir_type::VarId, Rc<ir_type::Ty>>>,
     pending_generic_instance: Option<ir_type::GenericInstanceInfo>,
+    slice_intrinsic: Option<SliceIntrinsic>,
 }
 
 impl SemanticAnalyzer {
@@ -286,32 +295,9 @@ impl SemanticAnalyzer {
         Ok(())
     }
 
-    fn insert_builtin_slice_symbol(module_context: &mut ModuleContext, module_path: ModulePath) {
-        let symbol_table_value = SymbolTableValue::new(
-            SymbolTableValueKind::Generic(
-                GenericInfo::new(
-                    GenericKind::Slice(GenericSliceInfo::new()),
-                    module_path.clone(),
-                )
-                .into(),
-            ),
-            module_path,
-        );
-
-        module_context
-            .insert_symbol_to_root_scope(
-                Symbol::from("__builtin_slice".to_owned()),
-                symbol_table_value,
-                Visibility::Public,
-                Span::dummy(),
-            )
-            .unwrap();
-    }
-
-    fn create_module_context(file_path: FilePath, module_path: ModulePath) -> ModuleContext {
+    fn create_module_context(file_path: FilePath) -> ModuleContext {
         let mut module_context = ModuleContext::new(file_path);
         module_context.push_scope(SymbolTable::new());
-        Self::insert_builtin_slice_symbol(&mut module_context, module_path);
         module_context
     }
 
@@ -326,8 +312,7 @@ impl SemanticAnalyzer {
         let mut context = AnalysisContext::new(module_path.clone());
         context.set_current_module_path(module_path.clone());
 
-        let mut module_context = ModuleContext::new(file_path);
-        Self::insert_builtin_slice_symbol(&mut module_context, module_path.clone());
+        let module_context = ModuleContext::new(file_path);
 
         Self {
             modules: HashMap::from([(module_path, module_context)]),
@@ -344,6 +329,7 @@ impl SemanticAnalyzer {
             temp_symbol_counter: 0,
             generic_fn_substitutions: HashMap::new(),
             pending_generic_instance: None,
+            slice_intrinsic: None,
         }
     }
 
@@ -352,10 +338,7 @@ impl SemanticAnalyzer {
         let mut context = AnalysisContext::new(module_path.clone());
         context.set_current_module_path(module_path.clone());
 
-        let module_context = Self::create_module_context(
-            FilePath::from(PathBuf::from("test.kd")),
-            module_path.clone(),
-        );
+        let module_context = Self::create_module_context(FilePath::from(PathBuf::from("test.kd")));
 
         Self {
             modules: HashMap::from([(module_path, module_context)]),
@@ -371,6 +354,7 @@ impl SemanticAnalyzer {
             closure_capture_stack: Vec::new(),
             temp_symbol_counter: 0,
             generic_fn_substitutions: HashMap::new(),
+            slice_intrinsic: None,
             pending_generic_instance: None,
         }
     }
@@ -583,6 +567,16 @@ impl SemanticAnalyzer {
 
     pub fn slice_method_parent_name(&self, elem_ty: &Rc<ir_type::Ty>) -> Symbol {
         format!("slice<{}>", elem_ty.kind).into()
+    }
+
+    // Module that owns the concrete slice methods (`slice<T>.len`, …). They are generated
+    // under the module that declared `impl<T>[T]`, so callers in other modules need this
+    // path to build a qualified lookup.
+    pub fn slice_impl_module_path(&self) -> ModulePath {
+        self.slice_intrinsic
+            .as_ref()
+            .map(|s| s.module_path.clone())
+            .unwrap_or_else(|| self.module_path().clone())
     }
 
     pub fn create_method_key(
@@ -1290,7 +1284,7 @@ impl SemanticAnalyzer {
         let mut top_level_irs = vec![];
 
         // Create root module
-        let root_module = Self::create_module_context(FilePath::dummy(), ModulePath::new(vec![]));
+        let root_module = Self::create_module_context(FilePath::dummy());
         self.modules.insert(ModulePath::new(vec![]), root_module);
 
         self.context.set_no_prelude(options.no_prelude);

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -56,9 +56,9 @@ pub struct AnalyzeOptions {
 
 // `impl<T>[T] { ... }` is declared once (autoload) but applies to every slice type in the
 // compile unit, so it's stored here as an analyzer-level intrinsic instead of a module
-// symbol. `defining_module` is the module that wrote the block; it's used as a lookup
-// fallback during monomorphization so helpers referenced in the body (e.g.
-// `__slice_from_raw_parts`) resolve. Generated methods themselves live in the root module.
+// symbol. Generated methods are registered in the root module; `defining_module` records
+// where the block was written and serves as a lookup fallback during monomorphization so
+// method bodies can reach symbols declared alongside the impl block.
 pub struct SliceIntrinsic {
     pub impl_info: GenericImplInfo,
     pub defining_module: ModulePath,

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -54,12 +54,14 @@ pub struct AnalyzeOptions {
     pub is_entry_unit: bool,
 }
 
-// The `impl<T>[T] { ... }` block lives in a single autoload module but applies to every
-// slice type anywhere in the compile unit. Storing it here — rather than as a per-module
-// symbol — gives every lookup a direct, canonical handle.
+// `impl<T>[T] { ... }` is declared once (autoload) but applies to every slice type in the
+// compile unit, so it's stored here as an analyzer-level intrinsic instead of a module
+// symbol. `defining_module` is the module that wrote the block; it's used as a lookup
+// fallback during monomorphization so helpers referenced in the body (e.g.
+// `__slice_from_raw_parts`) resolve. Generated methods themselves live in the root module.
 pub struct SliceIntrinsic {
     pub impl_info: GenericImplInfo,
-    pub module_path: ModulePath,
+    pub defining_module: ModulePath,
 }
 
 pub struct SemanticAnalyzer {
@@ -567,16 +569,6 @@ impl SemanticAnalyzer {
 
     pub fn slice_method_parent_name(&self, elem_ty: &Rc<ir_type::Ty>) -> Symbol {
         format!("slice<{}>", elem_ty.kind).into()
-    }
-
-    // Module that owns the concrete slice methods (`slice<T>.len`, …). They are generated
-    // under the module that declared `impl<T>[T]`, so callers in other modules need this
-    // path to build a qualified lookup.
-    pub fn slice_impl_module_path(&self) -> ModulePath {
-        self.slice_intrinsic
-            .as_ref()
-            .map(|s| s.module_path.clone())
-            .unwrap_or_else(|| self.module_path().clone())
     }
 
     pub fn create_method_key(

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -542,10 +542,8 @@ impl SemanticAnalyzer {
 
         let parent_ty = self.analyze_type(&ty)?;
 
-        // `should_route_to_root_module` is true for built-in language types (fundamental
-        // scalars and slices): they have no defining module, so their methods live in the
-        // anonymous root module where every caller can find them with a direct qualified
-        // lookup.
+        // Built-in types (fundamentals, slices) have no defining module, so their methods
+        // live in the root module, reachable from anywhere by direct qualified lookup.
         let (parent_name, should_route_to_root_module) = match parent_ty.kind.as_ref() {
             ir::ty::TyKind::Reference(ty) => {
                 let base_ty = ty.get_base_type();
@@ -583,8 +581,8 @@ impl SemanticAnalyzer {
 
         if should_route_to_root_module {
             let source_module_path = self.current_module_path().clone();
-            self.with_lookup_fallback_module(source_module_path, |analyzer| {
-                analyzer.with_root_module(|analyzer| analyzer.analyze_fn_internal(node))
+            self.with_root_module_and_fallback(source_module_path, |analyzer| {
+                analyzer.analyze_fn_internal(node)
             })
             .map(Some)
         } else {
@@ -614,16 +612,14 @@ impl SemanticAnalyzer {
 
         if should_route_to_root_module {
             let source_module_path = self.current_module_path().clone();
-            self.with_lookup_fallback_module(source_module_path, |analyzer| {
-                analyzer.with_root_module(|analyzer| {
-                    analyzer.register_generic_method_symbol(
-                        name,
-                        node,
-                        resolved_generic_params,
-                        vis,
-                        span,
-                    )
-                })
+            self.with_root_module_and_fallback(source_module_path, |analyzer| {
+                analyzer.register_generic_method_symbol(
+                    name,
+                    node,
+                    resolved_generic_params,
+                    vis,
+                    span,
+                )
             })
         } else {
             self.register_generic_method_symbol(name, node, resolved_generic_params, vis, span)

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -212,6 +212,7 @@ impl SemanticAnalyzer {
         // Add the module to the module table
         let mut module_context = ModuleContext::new(path);
         module_context.push_scope(SymbolTable::new());
+        Self::insert_builtin_slice_symbol(&mut module_context, module_path.clone());
         self.modules.insert(module_path.clone(), module_context);
 
         let mut parsed_module = Parser::new(&fs::read_to_string(path.path()).unwrap(), path)
@@ -373,6 +374,7 @@ impl SemanticAnalyzer {
         if !self.modules.contains_key(&module_path) {
             let mut module_context = ModuleContext::new(FilePath::dummy());
             module_context.push_scope(SymbolTable::new());
+            Self::insert_builtin_slice_symbol(&mut module_context, module_path.clone());
             self.modules.insert(module_path.clone(), module_context);
         }
 

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -4,10 +4,7 @@ use std::{
     rc::Rc,
 };
 
-use crate::{
-    context::{AnalyzeCommand, ModuleContext},
-    rust_import, SemanticAnalyzer, SemanticError,
-};
+use crate::{context::AnalyzeCommand, rust_import, SemanticAnalyzer, SemanticError};
 use kaede_symbol_table::{
     GenericEnumInfo, GenericFuncInfo, GenericImplInfo, GenericInfo, GenericKind, GenericStructInfo,
     ResolvedGenericParam, ResolvedGenericParams, SymbolTable, SymbolTableValue,
@@ -210,9 +207,7 @@ impl SemanticAnalyzer {
         }
 
         // Add the module to the module table
-        let mut module_context = ModuleContext::new(path);
-        module_context.push_scope(SymbolTable::new());
-        Self::insert_builtin_slice_symbol(&mut module_context, module_path.clone());
+        let module_context = Self::create_module_context(path, module_path.clone());
         self.modules.insert(module_path.clone(), module_context);
 
         let mut parsed_module = Parser::new(&fs::read_to_string(path.path()).unwrap(), path)
@@ -372,9 +367,8 @@ impl SemanticAnalyzer {
 
         let module_path = resolved.module_path.clone();
         if !self.modules.contains_key(&module_path) {
-            let mut module_context = ModuleContext::new(FilePath::dummy());
-            module_context.push_scope(SymbolTable::new());
-            Self::insert_builtin_slice_symbol(&mut module_context, module_path.clone());
+            let module_context =
+                Self::create_module_context(FilePath::dummy(), module_path.clone());
             self.modules.insert(module_path.clone(), module_context);
         }
 

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -542,7 +542,7 @@ impl SemanticAnalyzer {
 
         let parent_ty = self.analyze_type(&ty)?;
 
-        let (parent_name, is_builtin) = match parent_ty.kind.as_ref() {
+        let (parent_name, is_fundamental_type) = match parent_ty.kind.as_ref() {
             ir::ty::TyKind::Reference(ty) => {
                 let base_ty = ty.get_base_type();
                 match base_ty.kind.as_ref() {
@@ -554,7 +554,6 @@ impl SemanticAnalyzer {
                 }
             }
 
-            // Built-in types
             ir::ty::TyKind::Fundamental(fty) => (Symbol::from(fty.kind.to_string()), true),
             ir::ty::TyKind::Slice(elem_ty) => (self.slice_method_parent_name(elem_ty), false),
 
@@ -573,10 +572,12 @@ impl SemanticAnalyzer {
         node.decl.self_ = None;
 
         if node.decl.generic_params.is_some() {
-            return self.analyze_generic_method(node, is_builtin).map(|()| None);
+            return self
+                .analyze_generic_method(node, is_fundamental_type)
+                .map(|()| None);
         }
 
-        if is_builtin {
+        if is_fundamental_type {
             let source_module_path = self.current_module_path().clone();
             self.with_lookup_fallback_module(source_module_path, |analyzer| {
                 analyzer.with_root_module(|analyzer| analyzer.analyze_fn_internal(node))
@@ -590,7 +591,7 @@ impl SemanticAnalyzer {
     fn analyze_generic_method(
         &mut self,
         node: ast::top::Fn,
-        is_builtin: bool,
+        is_fundamental_type: bool,
     ) -> anyhow::Result<()> {
         // Body-analysis pass is a no-op for generic methods; they are
         // monomorphized on demand at each call site.
@@ -607,7 +608,7 @@ impl SemanticAnalyzer {
         let resolved_generic_params =
             self.resolve_generic_params(node.decl.generic_params.as_ref())?;
 
-        if is_builtin {
+        if is_fundamental_type {
             let source_module_path = self.current_module_path().clone();
             self.with_lookup_fallback_module(source_module_path, |analyzer| {
                 analyzer.with_root_module(|analyzer| {

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -523,6 +523,9 @@ impl SemanticAnalyzer {
         )))
     }
 
+    // Returns `None` for generic methods: their IR is materialized lazily at each
+    // monomorphization call site, so there's nothing to add to the enclosing `impl` now.
+    // Non-generic methods return `Some(Fn)`.
     fn analyze_method(
         &mut self,
         ty: Rc<ast_type::Ty>,

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -207,7 +207,7 @@ impl SemanticAnalyzer {
         }
 
         // Add the module to the module table
-        let module_context = Self::create_module_context(path, module_path.clone());
+        let module_context = Self::create_module_context(path);
         self.modules.insert(module_path.clone(), module_context);
 
         let mut parsed_module = Parser::new(&fs::read_to_string(path.path()).unwrap(), path)
@@ -367,8 +367,7 @@ impl SemanticAnalyzer {
 
         let module_path = resolved.module_path.clone();
         if !self.modules.contains_key(&module_path) {
-            let module_context =
-                Self::create_module_context(FilePath::dummy(), module_path.clone());
+            let module_context = Self::create_module_context(FilePath::dummy());
             self.modules.insert(module_path.clone(), module_context);
         }
 
@@ -493,31 +492,10 @@ impl SemanticAnalyzer {
                 }
 
                 ast_type::TyKind::Slice(_) => {
-                    let slice_symbol: Symbol = "__builtin_slice".to_owned().into();
-                    let symbol_kind =
-                        self.lookup_symbol(slice_symbol)
-                            .ok_or(SemanticError::Undeclared {
-                                name: slice_symbol,
-                                span: node.span,
-                            })?;
-
-                    match &mut symbol_kind.borrow_mut().kind {
-                        SymbolTableValueKind::Generic(ref mut generic_info) => {
-                            match &mut generic_info.kind {
-                                GenericKind::Slice(info) => {
-                                    info.impl_info = Some(GenericImplInfo::new(
-                                        node,
-                                        resolved_generic_params,
-                                        span,
-                                    ));
-                                }
-                                _ => todo!("Error"),
-                            }
-                        }
-
-                        _ => todo!("Error"),
-                    }
-
+                    self.slice_intrinsic = Some(crate::SliceIntrinsic {
+                        impl_info: GenericImplInfo::new(node, resolved_generic_params, span),
+                        module_path: self.current_module_path().clone(),
+                    });
                     return Ok(TopLevelAnalysisResult::GenericTopLevel);
                 }
 

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -774,7 +774,7 @@ impl SemanticAnalyzer {
         let name = node.name.symbol();
 
         let qualified_name = if name.as_str() == "main" {
-            QualifiedSymbol::new(ModulePath::new(vec![]), "kdmain".to_owned().into())
+            QualifiedSymbol::new(ModulePath::root(), "kdmain".to_owned().into())
         } else {
             QualifiedSymbol::new(self.current_module_path().clone(), name)
         };

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -539,7 +539,9 @@ impl SemanticAnalyzer {
         for item in node.items.iter() {
             match &item.kind {
                 ast::top::TopLevelKind::Fn(fn_) => {
-                    methods.push(self.analyze_method(ast_ty.clone(), fn_.clone())?)
+                    if let Some(method) = self.analyze_method(ast_ty.clone(), fn_.clone())? {
+                        methods.push(method);
+                    }
                 }
                 _ => todo!("Error"),
             }
@@ -554,7 +556,7 @@ impl SemanticAnalyzer {
         &mut self,
         ty: Rc<ast_type::Ty>,
         mut node: ast::top::Fn,
-    ) -> anyhow::Result<Rc<ir::top::Fn>> {
+    ) -> anyhow::Result<Option<Rc<ir::top::Fn>>> {
         // If the method isn't static, insert self to the front of the parameters
         if let Some(mutability) = node.decl.self_ {
             node.decl.params.v.insert(
@@ -599,14 +601,82 @@ impl SemanticAnalyzer {
 
         node.decl.self_ = None;
 
+        if node.decl.generic_params.is_some() {
+            return self.analyze_generic_method(node, is_builtin).map(|()| None);
+        }
+
         if is_builtin {
             let source_module_path = self.current_module_path().clone();
             self.with_lookup_fallback_module(source_module_path, |analyzer| {
                 analyzer.with_root_module(|analyzer| analyzer.analyze_fn_internal(node))
             })
+            .map(Some)
         } else {
-            self.analyze_fn_internal(node)
+            self.analyze_fn_internal(node).map(Some)
         }
+    }
+
+    fn analyze_generic_method(
+        &mut self,
+        node: ast::top::Fn,
+        is_builtin: bool,
+    ) -> anyhow::Result<()> {
+        // Body-analysis pass is a no-op for generic methods; they are
+        // monomorphized on demand at each call site.
+        if matches!(
+            self.context.analyze_command(),
+            AnalyzeCommand::WithoutFnDeclare
+        ) {
+            return Ok(());
+        }
+
+        let span = node.span;
+        let vis = node.decl.vis;
+        let name = node.decl.name.symbol();
+        let resolved_generic_params =
+            self.resolve_generic_params(node.decl.generic_params.as_ref())?;
+
+        if is_builtin {
+            let source_module_path = self.current_module_path().clone();
+            self.with_lookup_fallback_module(source_module_path, |analyzer| {
+                analyzer.with_root_module(|analyzer| {
+                    analyzer.register_generic_method_symbol(
+                        name,
+                        node,
+                        resolved_generic_params,
+                        vis,
+                        span,
+                    )
+                })
+            })
+        } else {
+            self.register_generic_method_symbol(name, node, resolved_generic_params, vis, span)
+        }
+    }
+
+    fn register_generic_method_symbol(
+        &mut self,
+        name: Symbol,
+        node: ast::top::Fn,
+        resolved_generic_params: Option<ResolvedGenericParams>,
+        vis: ast::top::Visibility,
+        span: Span,
+    ) -> anyhow::Result<()> {
+        let module_path = self.current_module_path().clone();
+        let symbol_table_value = SymbolTableValue::new(
+            SymbolTableValueKind::Generic(
+                GenericInfo::new(
+                    GenericKind::Func(GenericFuncInfo {
+                        ast: node,
+                        resolved_generic_params,
+                    }),
+                    module_path.clone(),
+                )
+                .into(),
+            ),
+            module_path,
+        );
+        self.insert_symbol_to_root_scope(name, symbol_table_value, vis, span)
     }
 
     pub fn analyze_fn(&mut self, node: ast::top::Fn) -> anyhow::Result<TopLevelAnalysisResult> {

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -332,12 +332,9 @@ impl SemanticAnalyzer {
                 }
             }
 
-            // Clear the private symbol table after analyzing the module
-            analyzer
-                .modules
-                .get_mut(&analyzer.current_module_path().clone())
-                .unwrap()
-                .clear_private_symbol_table();
+            // Note: the module's private symbol table is intentionally retained so that
+            // cross-module monomorphization of generic functions/methods can resolve
+            // private helpers referenced from their bodies.
 
             Ok::<(), anyhow::Error>(())
         })?;

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -494,7 +494,7 @@ impl SemanticAnalyzer {
                 ast_type::TyKind::Slice(_) => {
                     self.slice_intrinsic = Some(crate::SliceIntrinsic {
                         impl_info: GenericImplInfo::new(node, resolved_generic_params, span),
-                        module_path: self.current_module_path().clone(),
+                        defining_module: self.current_module_path().clone(),
                     });
                     return Ok(TopLevelAnalysisResult::GenericTopLevel);
                 }
@@ -542,20 +542,23 @@ impl SemanticAnalyzer {
 
         let parent_ty = self.analyze_type(&ty)?;
 
-        let (parent_name, is_fundamental_type) = match parent_ty.kind.as_ref() {
+        // `route_to_root_module` is true for built-in language types (fundamental scalars
+        // and slices): they have no defining module, so their methods live in the anonymous
+        // root module where every caller can find them with a direct qualified lookup.
+        let (parent_name, route_to_root_module) = match parent_ty.kind.as_ref() {
             ir::ty::TyKind::Reference(ty) => {
                 let base_ty = ty.get_base_type();
                 match base_ty.kind.as_ref() {
                     ir::ty::TyKind::UserDefined(udt) => (udt.name(), false),
                     ir::ty::TyKind::Slice(elem_ty) => {
-                        (self.slice_method_parent_name(elem_ty), false)
+                        (self.slice_method_parent_name(elem_ty), true)
                     }
                     _ => (Symbol::from(base_ty.kind.to_string()), true),
                 }
             }
 
             ir::ty::TyKind::Fundamental(fty) => (Symbol::from(fty.kind.to_string()), true),
-            ir::ty::TyKind::Slice(elem_ty) => (self.slice_method_parent_name(elem_ty), false),
+            ir::ty::TyKind::Slice(elem_ty) => (self.slice_method_parent_name(elem_ty), true),
 
             _ => unreachable!(),
         };
@@ -573,11 +576,11 @@ impl SemanticAnalyzer {
 
         if node.decl.generic_params.is_some() {
             return self
-                .analyze_generic_method(node, is_fundamental_type)
+                .analyze_generic_method(node, route_to_root_module)
                 .map(|()| None);
         }
 
-        if is_fundamental_type {
+        if route_to_root_module {
             let source_module_path = self.current_module_path().clone();
             self.with_lookup_fallback_module(source_module_path, |analyzer| {
                 analyzer.with_root_module(|analyzer| analyzer.analyze_fn_internal(node))
@@ -591,7 +594,7 @@ impl SemanticAnalyzer {
     fn analyze_generic_method(
         &mut self,
         node: ast::top::Fn,
-        is_fundamental_type: bool,
+        route_to_root_module: bool,
     ) -> anyhow::Result<()> {
         // Body-analysis pass is a no-op for generic methods; they are
         // monomorphized on demand at each call site.
@@ -608,7 +611,7 @@ impl SemanticAnalyzer {
         let resolved_generic_params =
             self.resolve_generic_params(node.decl.generic_params.as_ref())?;
 
-        if is_fundamental_type {
+        if route_to_root_module {
             let source_module_path = self.current_module_path().clone();
             self.with_lookup_fallback_module(source_module_path, |analyzer| {
                 analyzer.with_root_module(|analyzer| {

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -542,10 +542,11 @@ impl SemanticAnalyzer {
 
         let parent_ty = self.analyze_type(&ty)?;
 
-        // `route_to_root_module` is true for built-in language types (fundamental scalars
-        // and slices): they have no defining module, so their methods live in the anonymous
-        // root module where every caller can find them with a direct qualified lookup.
-        let (parent_name, route_to_root_module) = match parent_ty.kind.as_ref() {
+        // `should_route_to_root_module` is true for built-in language types (fundamental
+        // scalars and slices): they have no defining module, so their methods live in the
+        // anonymous root module where every caller can find them with a direct qualified
+        // lookup.
+        let (parent_name, should_route_to_root_module) = match parent_ty.kind.as_ref() {
             ir::ty::TyKind::Reference(ty) => {
                 let base_ty = ty.get_base_type();
                 match base_ty.kind.as_ref() {
@@ -576,11 +577,11 @@ impl SemanticAnalyzer {
 
         if node.decl.generic_params.is_some() {
             return self
-                .analyze_generic_method(node, route_to_root_module)
+                .analyze_generic_method(node, should_route_to_root_module)
                 .map(|()| None);
         }
 
-        if route_to_root_module {
+        if should_route_to_root_module {
             let source_module_path = self.current_module_path().clone();
             self.with_lookup_fallback_module(source_module_path, |analyzer| {
                 analyzer.with_root_module(|analyzer| analyzer.analyze_fn_internal(node))
@@ -594,7 +595,7 @@ impl SemanticAnalyzer {
     fn analyze_generic_method(
         &mut self,
         node: ast::top::Fn,
-        route_to_root_module: bool,
+        should_route_to_root_module: bool,
     ) -> anyhow::Result<()> {
         // Body-analysis pass is a no-op for generic methods; they are
         // monomorphized on demand at each call site.
@@ -611,7 +612,7 @@ impl SemanticAnalyzer {
         let resolved_generic_params =
             self.resolve_generic_params(node.decl.generic_params.as_ref())?;
 
-        if route_to_root_module {
+        if should_route_to_root_module {
             let source_module_path = self.current_module_path().clone();
             self.with_lookup_fallback_module(source_module_path, |analyzer| {
                 analyzer.with_root_module(|analyzer| {

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -116,27 +116,7 @@ impl SemanticAnalyzer {
         let (module_path, parent_name) = self.method_lookup_target(actual_ty)?;
         let method_key = self.create_method_key(parent_name, method.name, method.self_.is_none());
 
-        // Slice methods may be registered in the caller's module (user-defined
-        // `impl [T] { ... }`) or in whatever module generated the monomorphized
-        // `impl<T>[T]`. Fall back to scanning all modules for slice-typed receivers.
-        let is_slice_receiver = {
-            let base_ty = match actual_ty.kind.as_ref() {
-                ir_type::TyKind::Reference(rty) => rty.get_base_type(),
-                _ => actual_ty.clone(),
-            };
-            matches!(base_ty.kind.as_ref(), ir_type::TyKind::Slice(_))
-        };
-        let symbol = self
-            .lookup_qualified_symbol(QualifiedSymbol::new(module_path, method_key))
-            .or_else(|| {
-                is_slice_receiver
-                    .then(|| {
-                        self.modules
-                            .values()
-                            .find_map(|module| module.lookup_symbol(&method_key))
-                    })
-                    .flatten()
-            })?;
+        let symbol = self.lookup_qualified_symbol(QualifiedSymbol::new(module_path, method_key))?;
         let borrowed = symbol.borrow();
 
         match &borrowed.kind {
@@ -157,7 +137,7 @@ impl SemanticAnalyzer {
                 fty.kind.to_string().into(),
             )),
             ir_type::TyKind::Slice(elem_ty) => Some((
-                self.module_path().clone(),
+                kaede_ir::module_path::ModulePath::new(vec![]),
                 self.slice_method_parent_name(elem_ty),
             )),
             _ => None,
@@ -846,7 +826,7 @@ impl SemanticAnalyzer {
             return Ok(());
         }
 
-        let module_path = slice.module_path.clone();
+        let defining_module = slice.defining_module.clone();
         let generic_params = slice
             .impl_info
             .impl_
@@ -894,10 +874,15 @@ impl SemanticAnalyzer {
             .collect();
         impl_ast.items = Rc::new(methods);
 
-        let impl_ir = self.with_module(module_path, |analyzer| {
-            analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {
-                analyzer.with_analyze_command(AnalyzeCommand::NoCommand, |analyzer| {
-                    analyzer.analyze_impl(impl_ast.clone())
+        // Slice methods live in the root module (so every call site can find them with a
+        // direct lookup), but symbol references inside the body resolve from the module
+        // that declared `impl<T>[T]` — e.g. helpers like `__slice_from_raw_parts`.
+        let impl_ir = self.with_lookup_fallback_module(defining_module, |analyzer| {
+            analyzer.with_root_module(|analyzer| {
+                analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {
+                    analyzer.with_analyze_command(AnalyzeCommand::NoCommand, |analyzer| {
+                        analyzer.analyze_impl(impl_ast.clone())
+                    })
                 })
             })
         })?;

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -116,12 +116,11 @@ impl SemanticAnalyzer {
         let (module_path, parent_name) = self.method_lookup_target(actual_ty)?;
         let method_key = self.create_method_key(parent_name, method.name, method.self_.is_none());
 
+        // Slice methods are generated on demand at the caller; fall back to any
+        // module that has the key if the defining one doesn't.
         let symbol = self
             .lookup_qualified_symbol(QualifiedSymbol::new(module_path, method_key))
             .or_else(|| {
-                // Slice methods may live in a different module than the slice's
-                // "defining" one (they are generated on demand at the caller's site).
-                // Fall back to any module that has registered this exact method key.
                 self.modules
                     .values()
                     .find_map(|module| module.lookup_symbol(&method_key))
@@ -836,22 +835,23 @@ impl SemanticAnalyzer {
         };
 
         if needs_fallback_lookup {
-            // The __builtin_slice with impl_info is registered in the autoload module
-            // (where `impl<T>[T] { ... }` actually lives). Search all modules to find it.
+            // The impl_info-bearing __builtin_slice lives in the autoload module (where
+            // `impl<T>[T] { ... }` is declared); find it regardless of which module we're in.
             for module in self.modules.values() {
-                if let Some(symbol) = module.lookup_symbol(&slice_symbol_name) {
-                    let has_impl_info = matches!(
-                        &symbol.borrow().kind,
-                        SymbolTableValueKind::Generic(generic_info)
-                            if matches!(
-                                &generic_info.kind,
-                                GenericKind::Slice(info) if info.impl_info.is_some()
-                            )
-                    );
-                    if has_impl_info {
-                        slice_symbol = symbol;
-                        break;
-                    }
+                let Some(symbol) = module.lookup_symbol(&slice_symbol_name) else {
+                    continue;
+                };
+                let has_impl_info = matches!(
+                    &symbol.borrow().kind,
+                    SymbolTableValueKind::Generic(generic_info)
+                        if matches!(
+                            &generic_info.kind,
+                            GenericKind::Slice(info) if info.impl_info.is_some()
+                        )
+                );
+                if has_impl_info {
+                    slice_symbol = symbol;
+                    break;
                 }
             }
         }

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -874,9 +874,10 @@ impl SemanticAnalyzer {
             .collect();
         impl_ast.items = Rc::new(methods);
 
-        // Slice methods live in the root module (so every call site can find them with a
-        // direct lookup), but symbol references inside the body resolve from the module
-        // that declared `impl<T>[T]` — e.g. helpers like `__slice_from_raw_parts`.
+        // Monomorphized slice methods are registered in the root module so every call site
+        // finds them with a direct qualified lookup. The defining module (where `impl<T>[T]`
+        // is written) is set as a lookup fallback so method bodies can still reference
+        // symbols declared alongside the impl block — which the root module has no view of.
         let impl_ir = self.with_lookup_fallback_module(defining_module, |analyzer| {
             analyzer.with_root_module(|analyzer| {
                 analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -133,11 +133,11 @@ impl SemanticAnalyzer {
             ir_type::TyKind::Reference(rty) => self.method_lookup_target(&rty.get_base_type()),
             ir_type::TyKind::UserDefined(udt) => Some((udt.module_path(), udt.name())),
             ir_type::TyKind::Fundamental(fty) => Some((
-                kaede_ir::module_path::ModulePath::new(vec![]),
+                kaede_ir::module_path::ModulePath::root(),
                 fty.kind.to_string().into(),
             )),
             ir_type::TyKind::Slice(elem_ty) => Some((
-                kaede_ir::module_path::ModulePath::new(vec![]),
+                kaede_ir::module_path::ModulePath::root(),
                 self.slice_method_parent_name(elem_ty),
             )),
             _ => None,
@@ -874,16 +874,13 @@ impl SemanticAnalyzer {
             .collect();
         impl_ast.items = Rc::new(methods);
 
-        // Monomorphized slice methods are registered in the root module so every call site
-        // finds them with a direct qualified lookup. The defining module (where `impl<T>[T]`
-        // is written) is set as a lookup fallback so method bodies can still reference
-        // symbols declared alongside the impl block — which the root module has no view of.
-        let impl_ir = self.with_lookup_fallback_module(defining_module, |analyzer| {
-            analyzer.with_root_module(|analyzer| {
-                analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {
-                    analyzer.with_analyze_command(AnalyzeCommand::NoCommand, |analyzer| {
-                        analyzer.analyze_impl(impl_ast.clone())
-                    })
+        // Fallback to the module that declared `impl<T>[T]` so method bodies can still
+        // reference symbols declared alongside the impl block — which the root module
+        // has no view of.
+        let impl_ir = self.with_root_module_and_fallback(defining_module, |analyzer| {
+            analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {
+                analyzer.with_analyze_command(AnalyzeCommand::NoCommand, |analyzer| {
+                    analyzer.analyze_impl(impl_ast.clone())
                 })
             })
         })?;

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -115,7 +115,17 @@ impl SemanticAnalyzer {
     ) -> Option<Rc<ir::top::FnDecl>> {
         let (module_path, parent_name) = self.method_lookup_target(actual_ty)?;
         let method_key = self.create_method_key(parent_name, method.name, method.self_.is_none());
-        let symbol = self.lookup_qualified_symbol(QualifiedSymbol::new(module_path, method_key))?;
+
+        let symbol = self
+            .lookup_qualified_symbol(QualifiedSymbol::new(module_path, method_key))
+            .or_else(|| {
+                // Slice methods may live in a different module than the slice's
+                // "defining" one (they are generated on demand at the caller's site).
+                // Fall back to any module that has registered this exact method key.
+                self.modules
+                    .values()
+                    .find_map(|module| module.lookup_symbol(&method_key))
+            })?;
         let borrowed = symbol.borrow();
 
         match &borrowed.kind {
@@ -822,16 +832,27 @@ impl SemanticAnalyzer {
                         &generic_info.kind,
                         GenericKind::Slice(info) if info.impl_info.is_none()
                     )
-            ) && self.current_module_path() != self.module_path()
+            )
         };
 
         if needs_fallback_lookup {
-            if let Some(symbol) = self
-                .modules
-                .get(self.module_path())
-                .and_then(|module| module.lookup_symbol(&slice_symbol_name))
-            {
-                slice_symbol = symbol;
+            // The __builtin_slice with impl_info is registered in the autoload module
+            // (where `impl<T>[T] { ... }` actually lives). Search all modules to find it.
+            for module in self.modules.values() {
+                if let Some(symbol) = module.lookup_symbol(&slice_symbol_name) {
+                    let has_impl_info = matches!(
+                        &symbol.borrow().kind,
+                        SymbolTableValueKind::Generic(generic_info)
+                            if matches!(
+                                &generic_info.kind,
+                                GenericKind::Slice(info) if info.impl_info.is_some()
+                            )
+                    );
+                    if has_impl_info {
+                        slice_symbol = symbol;
+                        break;
+                    }
+                }
             }
         }
 

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -116,14 +116,26 @@ impl SemanticAnalyzer {
         let (module_path, parent_name) = self.method_lookup_target(actual_ty)?;
         let method_key = self.create_method_key(parent_name, method.name, method.self_.is_none());
 
-        // Slice methods are generated on demand at the caller; fall back to any
-        // module that has the key if the defining one doesn't.
+        // Slice methods may be registered in the caller's module (user-defined
+        // `impl [T] { ... }`) or in whatever module generated the monomorphized
+        // `impl<T>[T]`. Fall back to scanning all modules for slice-typed receivers.
+        let is_slice_receiver = {
+            let base_ty = match actual_ty.kind.as_ref() {
+                ir_type::TyKind::Reference(rty) => rty.get_base_type(),
+                _ => actual_ty.clone(),
+            };
+            matches!(base_ty.kind.as_ref(), ir_type::TyKind::Slice(_))
+        };
         let symbol = self
             .lookup_qualified_symbol(QualifiedSymbol::new(module_path, method_key))
             .or_else(|| {
-                self.modules
-                    .values()
-                    .find_map(|module| module.lookup_symbol(&method_key))
+                is_slice_receiver
+                    .then(|| {
+                        self.modules
+                            .values()
+                            .find_map(|module| module.lookup_symbol(&method_key))
+                    })
+                    .flatten()
             })?;
         let borrowed = symbol.borrow();
 
@@ -489,7 +501,6 @@ impl SemanticAnalyzer {
             let impl_info = match &generic_info.kind {
                 GenericKind::Struct(info) => info.impl_info.as_ref(),
                 GenericKind::Enum(info) => info.impl_info.as_ref(),
-                GenericKind::Slice(info) => info.impl_info.as_ref(),
                 _ => unreachable!(),
             };
 
@@ -508,7 +519,6 @@ impl SemanticAnalyzer {
                 let impl_info = match &mut generic_info.kind {
                     GenericKind::Struct(info) => info.impl_info.as_mut().unwrap(),
                     GenericKind::Enum(info) => info.impl_info.as_mut().unwrap(),
-                    GenericKind::Slice(info) => info.impl_info.as_mut().unwrap(),
                     _ => unreachable!(),
                 };
 
@@ -815,78 +825,14 @@ impl SemanticAnalyzer {
     }
 
     pub(crate) fn generate_slice_impl(&mut self, elem_ty: Rc<ir_type::Ty>) -> anyhow::Result<()> {
-        let slice_symbol_name = Symbol::from("__builtin_slice".to_owned());
-
-        let mut slice_symbol = match self.lookup_symbol(slice_symbol_name) {
-            Some(symbol) => symbol,
-            None => return Ok(()),
-        };
-
-        let needs_fallback_lookup = {
-            let borrowed = slice_symbol.borrow();
-            matches!(
-                &borrowed.kind,
-                SymbolTableValueKind::Generic(generic_info)
-                    if matches!(
-                        &generic_info.kind,
-                        GenericKind::Slice(info) if info.impl_info.is_none()
-                    )
-            )
-        };
-
-        if needs_fallback_lookup {
-            // The impl_info-bearing __builtin_slice lives in the autoload module (where
-            // `impl<T>[T] { ... }` is declared); find it regardless of which module we're in.
-            for module in self.modules.values() {
-                let Some(symbol) = module.lookup_symbol(&slice_symbol_name) else {
-                    continue;
-                };
-                let has_impl_info = matches!(
-                    &symbol.borrow().kind,
-                    SymbolTableValueKind::Generic(generic_info)
-                        if matches!(
-                            &generic_info.kind,
-                            GenericKind::Slice(info) if info.impl_info.is_some()
-                        )
-                );
-                if has_impl_info {
-                    slice_symbol = symbol;
-                    break;
-                }
-            }
-        }
-
-        let module_path = {
-            let borrowed = slice_symbol.borrow();
-            match &borrowed.kind {
-                SymbolTableValueKind::Generic(generic_info) => match &generic_info.kind {
-                    GenericKind::Slice(_) => generic_info.module_path.clone(),
-                    _ => return Ok(()),
-                },
-
-                _ => return Ok(()),
-            }
-        };
-
-        let mut borrowed_mut = slice_symbol.borrow_mut();
-        let generic_info = match &mut borrowed_mut.kind {
-            SymbolTableValueKind::Generic(generic_info) => generic_info,
-            _ => return Ok(()),
-        };
-
-        let slice_info = match &mut generic_info.kind {
-            GenericKind::Slice(info) => info,
-            _ => return Ok(()),
-        };
-
-        let impl_info = match &mut slice_info.impl_info {
-            Some(info) => info,
-            None => return Ok(()),
+        // Autoload hasn't been processed yet; nothing to generate.
+        let Some(slice) = self.slice_intrinsic.as_ref() else {
+            return Ok(());
         };
 
         let generic_args = vec![elem_ty.clone()];
 
-        let already_generated = impl_info.generateds.iter().any(|args| {
+        let already_generated = slice.impl_info.generateds.iter().any(|args| {
             args.len() == generic_args.len()
                 && args.iter().zip(&generic_args).all(|(a, b)| {
                     match (a.kind.as_ref(), b.kind.as_ref()) {
@@ -896,13 +842,20 @@ impl SemanticAnalyzer {
                     }
                 })
         });
-
         if already_generated {
             return Ok(());
         }
 
-        let generic_params = impl_info.impl_.generic_params.as_ref().unwrap().clone();
-        let resolved_generic_params = impl_info.resolved_generic_params.clone();
+        let module_path = slice.module_path.clone();
+        let generic_params = slice
+            .impl_info
+            .impl_
+            .generic_params
+            .as_ref()
+            .unwrap()
+            .clone();
+        let resolved_generic_params = slice.impl_info.resolved_generic_params.clone();
+        let mut impl_ast = slice.impl_info.impl_.clone();
 
         self.verify_generic_argument_length(&generic_params, &generic_args, generic_params.span)?;
         self.verify_resolved_generic_bounds(
@@ -911,32 +864,35 @@ impl SemanticAnalyzer {
             generic_params.span,
         )?;
 
-        impl_info.generateds.push(generic_args.clone());
+        self.slice_intrinsic
+            .as_mut()
+            .unwrap()
+            .impl_info
+            .generateds
+            .push(generic_args.clone());
 
-        let mut impl_ast = impl_info.impl_.clone();
         impl_ast.generic_params = None;
 
-        let mut methods = vec![];
-
-        for method in impl_ast.items.iter() {
-            if let ast::top::TopLevelKind::Fn(fn_) = &method.kind {
-                let mut fn_decl = fn_.decl.clone();
-                fn_decl.link_once = true;
-
-                methods.push(ast::top::TopLevel {
-                    kind: ast::top::TopLevelKind::Fn(ast::top::Fn {
-                        decl: fn_decl,
-                        body: fn_.body.clone(),
+        let methods = impl_ast
+            .items
+            .iter()
+            .filter_map(|method| match &method.kind {
+                ast::top::TopLevelKind::Fn(fn_) => {
+                    let mut fn_decl = fn_.decl.clone();
+                    fn_decl.link_once = true;
+                    Some(ast::top::TopLevel {
+                        kind: ast::top::TopLevelKind::Fn(ast::top::Fn {
+                            decl: fn_decl,
+                            body: fn_.body.clone(),
+                            span: fn_.span,
+                        }),
                         span: fn_.span,
-                    }),
-                    span: fn_.span,
-                });
-            }
-        }
-
+                    })
+                }
+                _ => None,
+            })
+            .collect();
         impl_ast.items = Rc::new(methods);
-
-        drop(borrowed_mut);
 
         let impl_ir = self.with_module(module_path, |analyzer| {
             analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {

--- a/compiler/symbol_table/src/lib.rs
+++ b/compiler/symbol_table/src/lib.rs
@@ -106,28 +106,10 @@ pub struct GenericFuncInfo {
 }
 
 #[derive(Debug)]
-pub struct GenericSliceInfo {
-    pub impl_info: Option<GenericImplInfo>,
-}
-
-impl GenericSliceInfo {
-    pub fn new() -> Self {
-        Self { impl_info: None }
-    }
-}
-
-impl Default for GenericSliceInfo {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[derive(Debug)]
 pub enum GenericKind {
     Struct(GenericStructInfo),
     Enum(GenericEnumInfo),
     Func(GenericFuncInfo),
-    Slice(GenericSliceInfo),
 }
 
 #[derive(Debug)]
@@ -146,7 +128,6 @@ impl GenericInfo {
             GenericKind::Struct(info) => info.resolved_generic_params.as_ref(),
             GenericKind::Enum(info) => info.resolved_generic_params.as_ref(),
             GenericKind::Func(info) => info.resolved_generic_params.as_ref(),
-            GenericKind::Slice(_) => None,
         }
     }
 
@@ -154,7 +135,6 @@ impl GenericInfo {
         match &self.kind {
             GenericKind::Struct(info) => info.ast.generic_params.as_ref().unwrap().len(),
             GenericKind::Enum(info) => info.ast.generic_params.as_ref().unwrap().len(),
-            GenericKind::Slice(_) => 1,
             _ => unreachable!(),
         }
     }

--- a/compiler/type_infer/src/lib.rs
+++ b/compiler/type_infer/src/lib.rs
@@ -2123,7 +2123,7 @@ mod tests {
 
     fn generic_instance(args: Vec<Rc<Ty>>) -> GenericInstanceInfo {
         GenericInstanceInfo::new(
-            QualifiedSymbol::new(ModulePath::new(vec![]), Symbol::from("id".to_owned())),
+            QualifiedSymbol::new(ModulePath::root(), Symbol::from("id".to_owned())),
             args,
         )
     }
@@ -2132,7 +2132,7 @@ mod tests {
         let callee = Rc::new(FnDecl {
             lang_linkage: LangLinkage::Default,
             link_once: true,
-            name: QualifiedSymbol::new(ModulePath::new(vec![]), Symbol::from("id".to_owned())),
+            name: QualifiedSymbol::new(ModulePath::root(), Symbol::from("id".to_owned())),
             params: vec![],
             is_c_variadic: false,
             return_ty: return_ty.clone(),
@@ -2201,14 +2201,11 @@ mod tests {
             Rc::new(Ty {
                 kind: TyKind::UserDefined(UserDefinedType::with_generic_instance(
                     UserDefinedTypeKind::Placeholder(QualifiedSymbol::new(
-                        ModulePath::new(vec![]),
+                        ModulePath::root(),
                         Symbol::from("Option".to_owned()),
                     )),
                     GenericInstanceInfo::new(
-                        QualifiedSymbol::new(
-                            ModulePath::new(vec![]),
-                            Symbol::from("Option".to_owned()),
-                        ),
+                        QualifiedSymbol::new(ModulePath::root(), Symbol::from("Option".to_owned())),
                         vec![var_ty(1), var_ty(2)],
                     ),
                 ))
@@ -2252,7 +2249,7 @@ mod tests {
         let substitutions = inferrer.into_generic_fn_substitutions();
         let bindings = substitutions
             .get(&QualifiedSymbol::new(
-                ModulePath::new(vec![]),
+                ModulePath::root(),
                 Symbol::from("id".to_owned()),
             ))
             .unwrap();
@@ -2267,7 +2264,7 @@ mod tests {
         let mut inferrer = make_inferrer();
         let field_ty = i32_ty();
         let struct_info = Rc::new(Struct {
-            name: QualifiedSymbol::new(ModulePath::new(vec![]), Symbol::from("S".to_owned())),
+            name: QualifiedSymbol::new(ModulePath::root(), Symbol::from("S".to_owned())),
             fields: vec![StructField {
                 name: Symbol::from("n".to_owned()),
                 ty: field_ty.clone(),

--- a/example/comment_app/src/main.kd
+++ b/example/comment_app/src/main.kd
@@ -50,7 +50,7 @@ app.get("/comments", |req, res| {
     since := match parse_since(req) {
         Option::Some(value) => value,
         Option::None => {
-            res.status(Status::BadRequest).send_text("since must be u64")
+            res.status(Status::BadRequest).send("since must be u64")
             return
         }
     }
@@ -67,7 +67,7 @@ app.get("/comments", |req, res| {
         i += 1
     }
 
-    res.send_text(out.as_str())
+    res.send(out.as_str())
 })
 
 app.post("/comments", |req, res| {
@@ -82,18 +82,18 @@ app.post("/comments", |req, res| {
         normalized_author.clone()
     }
     if author.len() > 32 {
-        res.status(Status::BadRequest).send_text("author too long")
+        res.status(Status::BadRequest).send("author too long")
         return
     }
 
     body_text := String::from_bytes(req.body)
     message := rust::comment_app::normalize_message(body_text.as_str())
     if message.len() == 0 {
-        res.status(Status::BadRequest).send_text("message must not be empty")
+        res.status(Status::BadRequest).send("message must not be empty")
         return
     }
     if message.len() > 280 {
-        res.status(Status::BadRequest).send_text("message too long")
+        res.status(Status::BadRequest).send("message too long")
         return
     }
 
@@ -119,7 +119,7 @@ app.post("/comments", |req, res| {
     })
     lock.unlock()
 
-    res.send_text(id.to_string().as_str())
+    res.send(id.to_string().as_str())
 })
 
 app.ws("/ws/comments", |req, ws| {
@@ -143,7 +143,7 @@ app.ws("/ws/comments", |req, ws| {
     mut i := 0
     while i < pending.len() {
         comment := pending.at(i).unwrap()
-        if !ws.send_text(comment.json.as_str()) {
+        if !ws.send(comment.json.as_str()) {
             events.close()
             lock.lock()
             subscribers.retain(|subscriber| subscriber.id != subscriber_id)
@@ -165,7 +165,7 @@ app.ws("/ws/comments", |req, ws| {
             }
         }
 
-        if !ws.send_text(json.as_str()) {
+        if !ws.send(json.as_str()) {
             events.close()
             lock.lock()
             subscribers.retain(|subscriber| subscriber.id != subscriber_id)

--- a/example/http_kv_store/src/main.kd
+++ b/example/http_kv_store/src/main.kd
@@ -21,21 +21,21 @@ mut pub_entries := HashMap<String, Vector<PubMessage>>::new(hash_string, eq_stri
 mut next_pub_id := Counter::new(1)
 
 app.get("/health", |req, res| {
-    res.send_text("OK")
+    res.send("OK")
 })
 
 app.post("/kv/:key", |req, res| {
     key := match req.param("key") {
         Option::Some(v) => v,
         Option::None => {
-            res.status(Status::BadRequest).send_text("missing path parameter")
+            res.status(Status::BadRequest).send("missing path parameter")
             return
         }
     }
     value := match req.query("value") {
         Option::Some(v) => v,
         Option::None => {
-            res.status(Status::BadRequest).send_text("missing query parameter")
+            res.status(Status::BadRequest).send("missing query parameter")
             return
         }
     }
@@ -44,14 +44,14 @@ app.post("/kv/:key", |req, res| {
     kvs.insert(key.clone(), value.clone())
     lock.unlock()
 
-    res.send_text("OK")
+    res.send("OK")
 })
 
 app.get("/kv/:key", |req, res| {
     key := match req.param("key") {
         Option::Some(v) => v,
         Option::None => {
-            res.status(Status::BadRequest).send_text("missing path parameter")
+            res.status(Status::BadRequest).send("missing path parameter")
             return
         }
     }
@@ -62,10 +62,10 @@ app.get("/kv/:key", |req, res| {
 
     match found {
         Option::Some(v) => {
-            res.send_text(v.as_str())
+            res.send(v.as_str())
         }
         Option::None => {
-            res.status(Status::NotFound).send_text("(nil)")
+            res.status(Status::NotFound).send("(nil)")
         },
     }
 })
@@ -74,7 +74,7 @@ app.post("/kv/:key/del", |req, res| {
     key := match req.param("key") {
         Option::Some(v) => v,
         Option::None => {
-            res.status(Status::BadRequest).send_text("missing path parameter")
+            res.status(Status::BadRequest).send("missing path parameter")
             return
         }
     }
@@ -87,9 +87,9 @@ app.post("/kv/:key/del", |req, res| {
     lock.unlock()
 
     if removed {
-        res.send_text("1")
+        res.send("1")
     } else {
-        res.send_text("0")
+        res.send("0")
     }
 })
 
@@ -97,7 +97,7 @@ app.post("/kv/:key/incr", |req, res| {
     key := match req.param("key") {
         Option::Some(v) => v,
         Option::None => {
-            res.status(Status::BadRequest).send_text("missing path parameter")
+            res.status(Status::BadRequest).send("missing path parameter")
             return
         }
     }
@@ -112,7 +112,7 @@ app.post("/kv/:key/incr", |req, res| {
                 }
                 Option::None => {
                     lock.unlock()
-                    res.status(Status::BadRequest).send_text("value is not integer")
+                    res.status(Status::BadRequest).send("value is not integer")
                     return
                 }
             }
@@ -125,19 +125,19 @@ app.post("/kv/:key/incr", |req, res| {
     kvs.insert(key.clone(), out.clone())
     lock.unlock()
 
-    res.send_text(out.as_str())
+    res.send(out.as_str())
 })
 
 app.post("/list/:key/lpush", |req, res| {
     key := match req.param("key") {
         Option::Some(v) => v,
-        Option::None => { res.status(Status::BadRequest).send_text("missing path parameter")
+        Option::None => { res.status(Status::BadRequest).send("missing path parameter")
             return },
     }
     value := match req.query("value") {
         Option::Some(v) => v,
         Option::None => {
-            res.status(Status::BadRequest).send_text("missing query parameter")
+            res.status(Status::BadRequest).send("missing query parameter")
             return
         }
     }
@@ -154,28 +154,28 @@ app.post("/list/:key/lpush", |req, res| {
     lock.unlock()
 
     out := len.to_string()
-    res.send_text(out.as_str())
+    res.send(out.as_str())
 })
 
 app.get("/list/:key/range", |req, res| {
     key := match req.param("key") {
         Option::Some(v) => v,
         Option::None => {
-            res.status(Status::BadRequest).send_text("missing path parameter")
+            res.status(Status::BadRequest).send("missing path parameter")
             return
         }
     }
     start_text := match req.query("start") {
         Option::Some(v) => v,
         Option::None => {
-            res.status(Status::BadRequest).send_text("missing query parameter")
+            res.status(Status::BadRequest).send("missing query parameter")
             return
         }
     }
     stop_text := match req.query("stop") {
         Option::Some(v) => v,
         Option::None => {
-            res.status(Status::BadRequest).send_text("missing query parameter")
+            res.status(Status::BadRequest).send("missing query parameter")
             return
         }
     }
@@ -183,14 +183,14 @@ app.get("/list/:key/range", |req, res| {
     start := match start_text.as_str().parse_u64() {
         Option::Some(v) => v,
         Option::None => {
-            res.status(Status::BadRequest).send_text("start/stop must be u64")
+            res.status(Status::BadRequest).send("start/stop must be u64")
             return
         }
     }
     stop := match stop_text.as_str().parse_u64() {
         Option::Some(v) => v,
         Option::None => {
-            res.status(Status::BadRequest).send_text("start/stop must be u64")
+            res.status(Status::BadRequest).send("start/stop must be u64")
             return
         }
     }
@@ -223,21 +223,21 @@ app.get("/list/:key/range", |req, res| {
         }
     }
 
-    res.send_text(out.as_str())
+    res.send(out.as_str())
 })
 
 app.post("/pub/:channel", |req, res| {
     channel := match req.param("channel") {
         Option::Some(v) => v,
         Option::None => {
-            res.status(Status::BadRequest).send_text("missing path parameter")
+            res.status(Status::BadRequest).send("missing path parameter")
             return
         }
     }
     message := match req.query("message") {
         Option::Some(v) => v,
         Option::None => {
-            res.status(Status::BadRequest).send_text("missing query parameter")
+            res.status(Status::BadRequest).send("missing query parameter")
             return
         }
     }
@@ -255,13 +255,13 @@ app.post("/pub/:channel", |req, res| {
     lock.unlock()
 
     out := id.to_string()
-    res.send_text(out.as_str())
+    res.send(out.as_str())
 })
 
 app.get("/pub/:channel/subscribe", |req, res| {
     channel := match req.param("channel") {
         Option::Some(v) => v,
-        Option::None => { res.status(Status::BadRequest).send_text("missing path parameter")
+        Option::None => { res.status(Status::BadRequest).send("missing path parameter")
             return },
     }
 
@@ -273,7 +273,7 @@ app.get("/pub/:channel/subscribe", |req, res| {
                     since = parsed
                 }
                 Option::None => {
-                    res.status(Status::BadRequest).send_text("since must be u64")
+                    res.status(Status::BadRequest).send("since must be u64")
                     return
                 }
             }
@@ -300,7 +300,7 @@ app.get("/pub/:channel/subscribe", |req, res| {
     }
     lock.unlock()
 
-    res.send_text(out.as_str())
+    res.send(out.as_str())
 })
 
 app.listen(port=8080)

--- a/example/http_server/src/main.kd
+++ b/example/http_server/src/main.kd
@@ -33,20 +33,20 @@ app.ws("/ws/echo", |req, ws| {
 })
 
 app.get("/", |req, res| {
-    res.send_text("Kaede!")
+    res.send("Kaede!")
 })
 
 app.post("/echo", |req, res| {
-    res.send_bytes(req.body)
+    res.send(req.body)
 })
 
 app.get("/status/notfound", |req, res| {
-    res.status(std.http.Status::NotFound).send_text("Not Found")
+    res.status(std.http.Status::NotFound).send("Not Found")
 })
 
 app.get("/query", |req, res| {
     name := req.query("name")
-    res.send_text(match name {
+    res.send(match name {
         Option::Some(name) => name.as_str(),
         Option::None => "No name provided"
     })
@@ -54,7 +54,7 @@ app.get("/query", |req, res| {
 
 app.get("/users/:id", |req, res| {
     id := req.param("id")
-    res.send_text(match id {
+    res.send(match id {
         Option::Some(id) => id.as_str(),
         Option::None => "No id provided"
     })

--- a/library/src/std/http.kd
+++ b/library/src/std/http.kd
@@ -29,6 +29,47 @@ export enum WebSocketMessageKind {
     Pong,
 }
 
+// Anything that can be written to an HTTP response body as raw bytes.
+export interface Payload {
+    fun as_bytes(self) -> [u8]
+}
+
+// A value that can be sent as a WebSocket frame.
+// `ws_opcode` returns the WebSocket opcode (1=text, 2=binary, 8=close, 9=ping, 10=pong);
+// `ws_payload` returns the frame payload bytes.
+export interface WebSocketPayload {
+    fun ws_opcode(self) -> u8
+    fun ws_payload(self) -> [u8]
+}
+
+impl str {
+    fun as_bytes(self) -> [u8] {
+        return __slice_from_raw_parts(self.as_ptr(), self.len())
+    }
+
+    fun ws_opcode(self) -> u8 {
+        return 1
+    }
+
+    fun ws_payload(self) -> [u8] {
+        return self.as_bytes()
+    }
+}
+
+impl [u8] {
+    fun as_bytes(self) -> [u8] {
+        return self
+    }
+
+    fun ws_opcode(self) -> u8 {
+        return 2
+    }
+
+    fun ws_payload(self) -> [u8] {
+        return self
+    }
+}
+
 struct PathParam {
     name: String,
     value: String,
@@ -47,6 +88,22 @@ export struct Request {
 export struct WebSocketMessage {
     kind: WebSocketMessageKind,
     payload: Vector<u8>,
+}
+
+impl WebSocketMessage {
+    fun ws_opcode(self) -> u8 {
+        return match self.kind {
+            WebSocketMessageKind::Text => 1,
+            WebSocketMessageKind::Binary => 2,
+            WebSocketMessageKind::Close => 8,
+            WebSocketMessageKind::Ping => 9,
+            WebSocketMessageKind::Pong => 10,
+        }
+    }
+
+    fun ws_payload(self) -> [u8] {
+        return self.payload.as_slice()
+    }
 }
 
 export struct WebSocket {
@@ -105,30 +162,21 @@ impl WebSocket {
         __unreachable()
     }
 
-    // Sends a message using the opcode that matches its kind.
-    // Returns false if the socket is already closed, the payload is invalid
-    // for a control frame, or the frame write fails.
-    export fun send(mut self, msg: WebSocketMessage) -> bool {
-        return match msg.kind {
-            WebSocketMessageKind::Text => self.send_frame(1, msg.payload.as_slice()),
-            WebSocketMessageKind::Binary => self.send_frame(2, msg.payload.as_slice()),
-            WebSocketMessageKind::Close => self.close_with_body(msg.payload.as_slice()),
-            WebSocketMessageKind::Ping => self.send_control_frame(9, msg.payload.as_slice()),
-            WebSocketMessageKind::Pong => self.send_pong(msg.payload.as_slice()),
+    // Sends a WebSocket frame. Accepts any value implementing `WebSocketPayload`
+    // (e.g. `str`, `[u8]`, `WebSocketMessage`); the opcode is derived from the
+    // value. Close frames are routed to `close_with_body`; ping/pong to the
+    // control-frame path. Returns false if the socket is already closed, the
+    // payload is invalid for a control frame, or the frame write fails.
+    export fun send<T: WebSocketPayload>(mut self, msg: T) -> bool {
+        let opcode = msg.ws_opcode()
+        let payload = msg.ws_payload()
+        if opcode == 8 {
+            return self.close_with_body(payload)
         }
-    }
-
-    // Sends a text frame.
-    // Returns false if the socket is already closed or the frame write fails.
-    export fun send_text(mut self, text: str) -> bool {
-        let bytes = text.to_bytes()
-        return self.send_frame(1, bytes.as_slice())
-    }
-
-    // Sends a binary frame.
-    // Returns false if the socket is already closed or the frame write fails.
-    export fun send_bytes(mut self, body: [u8]) -> bool {
-        return self.send_frame(2, body)
+        if opcode == 9 || opcode == 10 {
+            return self.send_control_frame(opcode, payload)
+        }
+        return self.send_frame(opcode, payload)
     }
 
     // Sends a ping control frame.
@@ -248,7 +296,10 @@ impl Response {
         self.write_failed = true
     }
 
-    export fun send_bytes(mut self, body: [u8]) {
+    // Writes the response body. Accepts any value implementing `Payload`
+    // (e.g. `str`, `[u8]`).
+    export fun send<T: Payload>(mut self, body: T) {
+        let bytes = body.as_bytes()
         if !write_status_line(self.conn, self.status) {
             self.mark_write_failed()
             return
@@ -261,7 +312,7 @@ impl Response {
             self.mark_write_failed()
             return
         }
-        if !write_content_length(self.conn, body.len()) {
+        if !write_content_length(self.conn, bytes.len()) {
             self.mark_write_failed()
             return
         }
@@ -269,21 +320,13 @@ impl Response {
             self.mark_write_failed()
             return
         }
-        if std.sys.write(self.conn, body).is_none() {
+        if std.sys.write(self.conn, bytes).is_none() {
             self.mark_write_failed()
         }
     }
 
-    export fun send_text(mut self, text: str) {
-        self.send_bytes(text.to_bytes().as_slice())
-    }
-
-    export fun send_string(mut self, text: str) {
-        self.send_text(text)
-    }
-
     export fun send_file(mut self, body: [u8], content_type: str) {
-        self.content_type(content_type).send_bytes(body)
+        self.content_type(content_type).send(body)
     }
 }
 
@@ -764,10 +807,6 @@ export fun write_text_response(conn: Fd, close_conn: bool, status: Status, body:
         return false
     }
     return std.sys.write(conn, body).is_some()
-}
-
-export fun write_bytes_response(conn: Fd, close_conn: bool, status: Status, body: [u8]) -> bool {
-    return write_text_response(conn, close_conn, status, body)
 }
 
 fun write_websocket_upgrade_response(conn: Fd, accept_value: [u8]) -> bool {
@@ -1438,21 +1477,21 @@ fun join_static_fs_path(dir: String, relative: String) -> String {
 // Opens a static file, validates it, reads it, and sends it with basic response headers.
 fun serve_static_path(res: mut Response, fs_path: String) {
     if fs_path.len() == 0 {
-        res.status(Status::NotFound).send_bytes(b"")
+        res.status(Status::NotFound).send(b"")
         return
     }
 
     let file = match std.sys.open_read(fs_path.as_str()) {
         Option::Some(fd) => fd,
         Option::None => {
-            res.status(Status::NotFound).send_bytes(b"")
+            res.status(Status::NotFound).send(b"")
             return
         }
     }
 
     if !std.sys.is_regular_file(file) {
         std.sys.close_quiet(file)
-        res.status(Status::NotFound).send_bytes(b"")
+        res.status(Status::NotFound).send(b"")
         return
     }
 
@@ -1460,7 +1499,7 @@ fun serve_static_path(res: mut Response, fs_path: String) {
         Option::Some(value) => value,
         Option::None => {
             std.sys.close_quiet(file)
-            res.status(Status::InternalServerError).send_bytes(b"")
+            res.status(Status::InternalServerError).send(b"")
             return
         }
     }
@@ -1468,7 +1507,7 @@ fun serve_static_path(res: mut Response, fs_path: String) {
     std.sys.close_quiet(file)
     let mut response = res.content_type(guess_content_type(fs_path.as_str()))
     response = response.header("Cache-Control", "no-store")
-    response.send_bytes(bytes.as_slice())
+    response.send(bytes.as_slice())
 }
 
 // Guesses a content type from the file extension for common static assets.
@@ -1612,7 +1651,7 @@ fun handle_conn(conn: Fd, app: App) {
 
         let handled = app.dispatch(req, res)
         if !handled {
-            res.status(Status::NotFound).send_bytes(b"")
+            res.status(Status::NotFound).send(b"")
         }
 
         if res.has_write_failed() || want_close {

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -34,7 +34,7 @@ import std.http
 mut app := std.http.App::new()
 
 app.get("/", |req, res| {
-    res.send_text("hello, world!")
+    res.send("hello, world!")
 })
 
 app.listen(port=8080)

--- a/website/docs/language/control-flow.md
+++ b/website/docs/language/control-flow.md
@@ -12,7 +12,7 @@ Kaede code in this repository uses familiar control-flow building blocks: `if`, 
 
 ```rust
 if author.len() > 32 {
-    res.status(Status::BadRequest).send_text("author too long")
+    res.status(Status::BadRequest).send("author too long")
     return
 }
 ```

--- a/website/docs/language/overview.md
+++ b/website/docs/language/overview.md
@@ -64,7 +64,7 @@ Closures are commonly used in HTTP handlers and collection helpers.
 
 ```rust
 app.get("/", |req, res| {
-    res.send_text("Kaede!")
+    res.send("Kaede!")
 })
 
 subscribers.retain(|subscriber| {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -8,7 +8,7 @@ const sampleProgram = `import std.http
 mut app := std.http.App::new()
 
 app.get("/", |req, res| {
-    res.send_text("hello, world!")
+    res.send("hello, world!")
 })
 
 app.ws("/ws/echo", |req, ws| {


### PR DESCRIPTION
Closes #132

## Summary

- Introduce `Payload` and `WebSocketPayload` interfaces in `std.http` and unify the multiple `send_*` methods into a single generic `Response.send<T: Payload>` / `WebSocket.send<T: WebSocketPayload>`.
- Implement these interfaces for `str`, `[u8]`, and `WebSocketMessage` so existing call sites (`res.send("…")`, `res.send(b"…")`, `res.send(bytes)`) keep working.
- Fix a semantic blocker that prevented user code from calling the unified `send` across modules (slice method dispatch failed during cross-module monomorphization).
- Update bundled examples (`http_server`, `http_kv_store`, `comment_app`) and a few docs touched along the way.

## Details on the semantic fix

`[u8].len` (and other slice methods) are registered in the autoload module `[autoload, slice]`. When monomorphizing a generic body originally defined in another module — e.g. `Vector<u8>::from_slice` invoked transitively from `std.string` while compiling user code that imports `std.http` — method lookup only consulted the caller's module and produced ``no method named `len` in `slice<u8>` ``.

Changes (`compiler/semantic`):

- New `create_slice_method_call_ir` searches the current module first, then falls back across all modules. Slice keys are concrete-element-typed and unique per compile unit, so the fallback is unambiguous.
- `generate_slice_impl` now: (a) is invoked on the slice path too (parity with the array path) so a substituted `[T]` produces methods at the call site, and (b) when the resolved `__builtin_slice` lacks `impl_info`, searches every module for one that has it (the autoload entry).
- `analyze_kaede_import` and `analyze_foreign_import` insert `__builtin_slice` into newly-created module contexts so monomorphized bodies executing under those modules can locate the symbol at all.
- `generate_generic_fn` checks the cache in the defining module first, so cross-module callers reuse the same instantiation instead of re-registering and tripping a "already declared" error.
- Cross-module privacy is enforced at the user-facing `module.symbol` / `module::symbol` boundary via a new `reject_private_cross_module_access` helper plus a `lookup_public_symbol` accessor on `ModuleContext`. (Necessary because the private symbol table is now retained post-analysis to support cross-module monomorphization.)

## Test plan

- [x] `cargo test --release` — all 240+ tests pass, including `import_private_items` and the http e2e suites
- [x] `./install.py` succeeds end-to-end
- [x] User program compiles and links: `res.send(b"…")`, `res.send("…")`, `res.send(v)` for `v: [u8]`
- [x] `cargo fmt` / `cargo clippy --release --all-targets` clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
