### PR TITLE
refactor(semantic): lift slice impl to analyzer intrinsic

### DIFF
--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -3879,8 +3879,8 @@ impl SemanticAnalyzer {
     }
 
     // Slice/array method dispatch. The impl may live in a different module than the
-    // current one (autoload's `impl<T>[T]` registers under [autoload, slice], and
-    // monomorphization may produce a slice type whose impl was generated elsewhere).
+    // current one: autoload's monomorphized `impl<T>[T]` registers under the intrinsic
+    // module, while user-defined `impl [T] { ... }` registers under the caller's module.
     fn create_slice_method_call_ir(
         &mut self,
         method_name: Symbol,

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -17,8 +17,8 @@ use kaede_parse::Parser;
 use kaede_span::{file::FilePath, Span};
 use kaede_symbol::{Ident, Symbol};
 use kaede_symbol_table::{
-    GenericInfo, GenericKind, GenericSliceInfo, QualifiedSymbolTable, SymbolResolver, SymbolTable,
-    SymbolTableValue, SymbolTableValueKind,
+    GenericImplInfo, QualifiedSymbolTable, SymbolResolver, SymbolTable, SymbolTableValue,
+    SymbolTableValueKind,
 };
 
 mod context;
@@ -54,6 +54,14 @@ pub struct AnalyzeOptions {
     pub is_entry_unit: bool,
 }
 
+// The `impl<T>[T] { ... }` block lives in a single autoload module but applies to every
+// slice type anywhere in the compile unit. Storing it here — rather than as a per-module
+// symbol — gives every lookup a direct, canonical handle.
+pub struct SliceIntrinsic {
+    pub impl_info: GenericImplInfo,
+    pub module_path: ModulePath,
+}
+
 pub struct SemanticAnalyzer {
     modules: HashMap<ModulePath, ModuleContext>,
     context: AnalysisContext,
@@ -69,6 +77,7 @@ pub struct SemanticAnalyzer {
     temp_symbol_counter: usize,
     generic_fn_substitutions: HashMap<QualifiedSymbol, HashMap<ir_type::VarId, Rc<ir_type::Ty>>>,
     pending_generic_instance: Option<ir_type::GenericInstanceInfo>,
+    slice_intrinsic: Option<SliceIntrinsic>,
 }
 
 impl SemanticAnalyzer {
@@ -286,32 +295,9 @@ impl SemanticAnalyzer {
         Ok(())
     }
 
-    fn insert_builtin_slice_symbol(module_context: &mut ModuleContext, module_path: ModulePath) {
-        let symbol_table_value = SymbolTableValue::new(
-            SymbolTableValueKind::Generic(
-                GenericInfo::new(
-                    GenericKind::Slice(GenericSliceInfo::new()),
-                    module_path.clone(),
-                )
-                .into(),
-            ),
-            module_path,
-        );
-
-        module_context
-            .insert_symbol_to_root_scope(
-                Symbol::from("__builtin_slice".to_owned()),
-                symbol_table_value,
-                Visibility::Public,
-                Span::dummy(),
-            )
-            .unwrap();
-    }
-
-    fn create_module_context(file_path: FilePath, module_path: ModulePath) -> ModuleContext {
+    fn create_module_context(file_path: FilePath) -> ModuleContext {
         let mut module_context = ModuleContext::new(file_path);
         module_context.push_scope(SymbolTable::new());
-        Self::insert_builtin_slice_symbol(&mut module_context, module_path);
         module_context
     }
 
@@ -326,8 +312,7 @@ impl SemanticAnalyzer {
         let mut context = AnalysisContext::new(module_path.clone());
         context.set_current_module_path(module_path.clone());
 
-        let mut module_context = ModuleContext::new(file_path);
-        Self::insert_builtin_slice_symbol(&mut module_context, module_path.clone());
+        let module_context = ModuleContext::new(file_path);
 
         Self {
             modules: HashMap::from([(module_path, module_context)]),
@@ -344,6 +329,7 @@ impl SemanticAnalyzer {
             temp_symbol_counter: 0,
             generic_fn_substitutions: HashMap::new(),
             pending_generic_instance: None,
+            slice_intrinsic: None,
         }
     }
 
@@ -352,10 +338,7 @@ impl SemanticAnalyzer {
         let mut context = AnalysisContext::new(module_path.clone());
         context.set_current_module_path(module_path.clone());
 
-        let module_context = Self::create_module_context(
-            FilePath::from(PathBuf::from("test.kd")),
-            module_path.clone(),
-        );
+        let module_context = Self::create_module_context(FilePath::from(PathBuf::from("test.kd")));
 
         Self {
             modules: HashMap::from([(module_path, module_context)]),
@@ -371,6 +354,7 @@ impl SemanticAnalyzer {
             closure_capture_stack: Vec::new(),
             temp_symbol_counter: 0,
             generic_fn_substitutions: HashMap::new(),
+            slice_intrinsic: None,
             pending_generic_instance: None,
         }
     }
@@ -583,6 +567,16 @@ impl SemanticAnalyzer {
 
     pub fn slice_method_parent_name(&self, elem_ty: &Rc<ir_type::Ty>) -> Symbol {
         format!("slice<{}>", elem_ty.kind).into()
+    }
+
+    // Module that owns the concrete slice methods (`slice<T>.len`, …). They are generated
+    // under the module that declared `impl<T>[T]`, so callers in other modules need this
+    // path to build a qualified lookup.
+    pub fn slice_impl_module_path(&self) -> ModulePath {
+        self.slice_intrinsic
+            .as_ref()
+            .map(|s| s.module_path.clone())
+            .unwrap_or_else(|| self.module_path().clone())
     }
 
     pub fn create_method_key(
@@ -1290,7 +1284,7 @@ impl SemanticAnalyzer {
         let mut top_level_irs = vec![];
 
         // Create root module
-        let root_module = Self::create_module_context(FilePath::dummy(), ModulePath::new(vec![]));
+        let root_module = Self::create_module_context(FilePath::dummy());
         self.modules.insert(ModulePath::new(vec![]), root_module);
 
         self.context.set_no_prelude(options.no_prelude);

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -207,7 +207,7 @@ impl SemanticAnalyzer {
         }
 
         // Add the module to the module table
-        let module_context = Self::create_module_context(path, module_path.clone());
+        let module_context = Self::create_module_context(path);
         self.modules.insert(module_path.clone(), module_context);
 
         let mut parsed_module = Parser::new(&fs::read_to_string(path.path()).unwrap(), path)
@@ -367,8 +367,7 @@ impl SemanticAnalyzer {
 
         let module_path = resolved.module_path.clone();
         if !self.modules.contains_key(&module_path) {
-            let module_context =
-                Self::create_module_context(FilePath::dummy(), module_path.clone());
+            let module_context = Self::create_module_context(FilePath::dummy());
             self.modules.insert(module_path.clone(), module_context);
         }
 
@@ -493,31 +492,10 @@ impl SemanticAnalyzer {
                 }
 
                 ast_type::TyKind::Slice(_) => {
-                    let slice_symbol: Symbol = "__builtin_slice".to_owned().into();
-                    let symbol_kind =
-                        self.lookup_symbol(slice_symbol)
-                            .ok_or(SemanticError::Undeclared {
-                                name: slice_symbol,
-                                span: node.span,
-                            })?;
-
-                    match &mut symbol_kind.borrow_mut().kind {
-                        SymbolTableValueKind::Generic(ref mut generic_info) => {
-                            match &mut generic_info.kind {
-                                GenericKind::Slice(info) => {
-                                    info.impl_info = Some(GenericImplInfo::new(
-                                        node,
-                                        resolved_generic_params,
-                                        span,
-                                    ));
-                                }
-                                _ => todo!("Error"),
-                            }
-                        }
-
-                        _ => todo!("Error"),
-                    }
-
+                    self.slice_intrinsic = Some(crate::SliceIntrinsic {
+                        impl_info: GenericImplInfo::new(node, resolved_generic_params, span),
+                        module_path: self.current_module_path().clone(),
+                    });
                     return Ok(TopLevelAnalysisResult::GenericTopLevel);
                 }
 

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -116,14 +116,26 @@ impl SemanticAnalyzer {
         let (module_path, parent_name) = self.method_lookup_target(actual_ty)?;
         let method_key = self.create_method_key(parent_name, method.name, method.self_.is_none());
 
-        // Slice methods are generated on demand at the caller; fall back to any
-        // module that has the key if the defining one doesn't.
+        // Slice methods may be registered in the caller's module (user-defined
+        // `impl [T] { ... }`) or in whatever module generated the monomorphized
+        // `impl<T>[T]`. Fall back to scanning all modules for slice-typed receivers.
+        let is_slice_receiver = {
+            let base_ty = match actual_ty.kind.as_ref() {
+                ir_type::TyKind::Reference(rty) => rty.get_base_type(),
+                _ => actual_ty.clone(),
+            };
+            matches!(base_ty.kind.as_ref(), ir_type::TyKind::Slice(_))
+        };
         let symbol = self
             .lookup_qualified_symbol(QualifiedSymbol::new(module_path, method_key))
             .or_else(|| {
-                self.modules
-                    .values()
-                    .find_map(|module| module.lookup_symbol(&method_key))
+                is_slice_receiver
+                    .then(|| {
+                        self.modules
+                            .values()
+                            .find_map(|module| module.lookup_symbol(&method_key))
+                    })
+                    .flatten()
             })?;
         let borrowed = symbol.borrow();
 
@@ -489,7 +501,6 @@ impl SemanticAnalyzer {
             let impl_info = match &generic_info.kind {
                 GenericKind::Struct(info) => info.impl_info.as_ref(),
                 GenericKind::Enum(info) => info.impl_info.as_ref(),
-                GenericKind::Slice(info) => info.impl_info.as_ref(),
                 _ => unreachable!(),
             };
 
@@ -508,7 +519,6 @@ impl SemanticAnalyzer {
                 let impl_info = match &mut generic_info.kind {
                     GenericKind::Struct(info) => info.impl_info.as_mut().unwrap(),
                     GenericKind::Enum(info) => info.impl_info.as_mut().unwrap(),
-                    GenericKind::Slice(info) => info.impl_info.as_mut().unwrap(),
                     _ => unreachable!(),
                 };
 
@@ -815,78 +825,14 @@ impl SemanticAnalyzer {
     }
 
     pub(crate) fn generate_slice_impl(&mut self, elem_ty: Rc<ir_type::Ty>) -> anyhow::Result<()> {
-        let slice_symbol_name = Symbol::from("__builtin_slice".to_owned());
-
-        let mut slice_symbol = match self.lookup_symbol(slice_symbol_name) {
-            Some(symbol) => symbol,
-            None => return Ok(()),
-        };
-
-        let needs_fallback_lookup = {
-            let borrowed = slice_symbol.borrow();
-            matches!(
-                &borrowed.kind,
-                SymbolTableValueKind::Generic(generic_info)
-                    if matches!(
-                        &generic_info.kind,
-                        GenericKind::Slice(info) if info.impl_info.is_none()
-                    )
-            )
-        };
-
-        if needs_fallback_lookup {
-            // The impl_info-bearing __builtin_slice lives in the autoload module (where
-            // `impl<T>[T] { ... }` is declared); find it regardless of which module we're in.
-            for module in self.modules.values() {
-                let Some(symbol) = module.lookup_symbol(&slice_symbol_name) else {
-                    continue;
-                };
-                let has_impl_info = matches!(
-                    &symbol.borrow().kind,
-                    SymbolTableValueKind::Generic(generic_info)
-                        if matches!(
-                            &generic_info.kind,
-                            GenericKind::Slice(info) if info.impl_info.is_some()
-                        )
-                );
-                if has_impl_info {
-                    slice_symbol = symbol;
-                    break;
-                }
-            }
-        }
-
-        let module_path = {
-            let borrowed = slice_symbol.borrow();
-            match &borrowed.kind {
-                SymbolTableValueKind::Generic(generic_info) => match &generic_info.kind {
-                    GenericKind::Slice(_) => generic_info.module_path.clone(),
-                    _ => return Ok(()),
-                },
-
-                _ => return Ok(()),
-            }
-        };
-
-        let mut borrowed_mut = slice_symbol.borrow_mut();
-        let generic_info = match &mut borrowed_mut.kind {
-            SymbolTableValueKind::Generic(generic_info) => generic_info,
-            _ => return Ok(()),
-        };
-
-        let slice_info = match &mut generic_info.kind {
-            GenericKind::Slice(info) => info,
-            _ => return Ok(()),
-        };
-
-        let impl_info = match &mut slice_info.impl_info {
-            Some(info) => info,
-            None => return Ok(()),
+        // Autoload hasn't been processed yet; nothing to generate.
+        let Some(slice) = self.slice_intrinsic.as_ref() else {
+            return Ok(());
         };
 
         let generic_args = vec![elem_ty.clone()];
 
-        let already_generated = impl_info.generateds.iter().any(|args| {
+        let already_generated = slice.impl_info.generateds.iter().any(|args| {
             args.len() == generic_args.len()
                 && args.iter().zip(&generic_args).all(|(a, b)| {
                     match (a.kind.as_ref(), b.kind.as_ref()) {
@@ -896,13 +842,20 @@ impl SemanticAnalyzer {
                     }
                 })
         });
-
         if already_generated {
             return Ok(());
         }
 
-        let generic_params = impl_info.impl_.generic_params.as_ref().unwrap().clone();
-        let resolved_generic_params = impl_info.resolved_generic_params.clone();
+        let module_path = slice.module_path.clone();
+        let generic_params = slice
+            .impl_info
+            .impl_
+            .generic_params
+            .as_ref()
+            .unwrap()
+            .clone();
+        let resolved_generic_params = slice.impl_info.resolved_generic_params.clone();
+        let mut impl_ast = slice.impl_info.impl_.clone();
 
         self.verify_generic_argument_length(&generic_params, &generic_args, generic_params.span)?;
         self.verify_resolved_generic_bounds(
@@ -911,32 +864,35 @@ impl SemanticAnalyzer {
             generic_params.span,
         )?;
 
-        impl_info.generateds.push(generic_args.clone());
+        self.slice_intrinsic
+            .as_mut()
+            .unwrap()
+            .impl_info
+            .generateds
+            .push(generic_args.clone());
 
-        let mut impl_ast = impl_info.impl_.clone();
         impl_ast.generic_params = None;
 
-        let mut methods = vec![];
-
-        for method in impl_ast.items.iter() {
-            if let ast::top::TopLevelKind::Fn(fn_) = &method.kind {
-                let mut fn_decl = fn_.decl.clone();
-                fn_decl.link_once = true;
-
-                methods.push(ast::top::TopLevel {
-                    kind: ast::top::TopLevelKind::Fn(ast::top::Fn {
-                        decl: fn_decl,
-                        body: fn_.body.clone(),
+        let methods = impl_ast
+            .items
+            .iter()
+            .filter_map(|method| match &method.kind {
+                ast::top::TopLevelKind::Fn(fn_) => {
+                    let mut fn_decl = fn_.decl.clone();
+                    fn_decl.link_once = true;
+                    Some(ast::top::TopLevel {
+                        kind: ast::top::TopLevelKind::Fn(ast::top::Fn {
+                            decl: fn_decl,
+                            body: fn_.body.clone(),
+                            span: fn_.span,
+                        }),
                         span: fn_.span,
-                    }),
-                    span: fn_.span,
-                });
-            }
-        }
-
+                    })
+                }
+                _ => None,
+            })
+            .collect();
         impl_ast.items = Rc::new(methods);
-
-        drop(borrowed_mut);
 
         let impl_ir = self.with_module(module_path, |analyzer| {
             analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {

--- a/compiler/symbol_table/src/lib.rs
+++ b/compiler/symbol_table/src/lib.rs
@@ -106,28 +106,10 @@ pub struct GenericFuncInfo {
 }
 
 #[derive(Debug)]
-pub struct GenericSliceInfo {
-    pub impl_info: Option<GenericImplInfo>,
-}
-
-impl GenericSliceInfo {
-    pub fn new() -> Self {
-        Self { impl_info: None }
-    }
-}
-
-impl Default for GenericSliceInfo {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[derive(Debug)]
 pub enum GenericKind {
     Struct(GenericStructInfo),
     Enum(GenericEnumInfo),
     Func(GenericFuncInfo),
-    Slice(GenericSliceInfo),
 }
 
 #[derive(Debug)]
@@ -146,7 +128,6 @@ impl GenericInfo {
             GenericKind::Struct(info) => info.resolved_generic_params.as_ref(),
             GenericKind::Enum(info) => info.resolved_generic_params.as_ref(),
             GenericKind::Func(info) => info.resolved_generic_params.as_ref(),
-            GenericKind::Slice(_) => None,
         }
     }
 
@@ -154,7 +135,6 @@ impl GenericInfo {
         match &self.kind {
             GenericKind::Struct(info) => info.ast.generic_params.as_ref().unwrap().len(),
             GenericKind::Enum(info) => info.ast.generic_params.as_ref().unwrap().len(),
-            GenericKind::Slice(_) => 1,
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
## Summary
- Replace the per-module `__builtin_slice` generic symbol with a single `SliceIntrinsic` field on `SemanticAnalyzer`. `impl<T>[T] { ... }` is a language-level intrinsic defined once in autoload, so threading it through each module's symbol table (and walking all modules to find the real one) was incidental complexity.
- Drop `GenericSliceInfo` / `GenericKind::Slice` from `kaede_symbol_table` and the `insert_builtin_slice_symbol` bootstrap. `create_module_context` no longer needs a module-path argument.
- Simplify `generate_slice_impl` to read directly from `self.slice_intrinsic` (no symbol-table ceremony, no fallback scan). Add `slice_impl_module_path()` for the module where the monomorphized methods live.

Cross-module method dispatch for slice receivers is preserved: user-defined `impl [T] {}` still registers methods under the caller's module, so `lookup_method_for_interface` and `create_slice_method_call_ir` still fall back to scanning all modules for slice-typed receivers. Refactor is scoped to removing the symbol-level hack, not redesigning method resolution.

## Test plan
- [x] `cargo test --release`
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features` (no new warnings from this change)