### PR TITLE
refactor(semantic): route slice methods through the root module

### DIFF
--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -218,7 +218,7 @@ impl<'ctx> CodeGenerator<'ctx> {
             &FnDecl {
                 lang_linkage: LangLinkage::Default,
                 link_once: false,
-                name: QualifiedSymbol::new(ModulePath::new(vec![]), self.cgcx.malloc_symbol),
+                name: QualifiedSymbol::new(ModulePath::root(), self.cgcx.malloc_symbol),
                 is_c_variadic: false,
                 return_ty,
                 params,

--- a/compiler/ir/src/module_path.rs
+++ b/compiler/ir/src/module_path.rs
@@ -10,6 +10,13 @@ impl ModulePath {
         Self { modules_from_root }
     }
 
+    // The anonymous module at the top of the module tree — used for symbols that have no
+    // natural defining module (fundamental types, slice intrinsic methods, the main
+    // entry point).
+    pub fn root() -> Self {
+        Self::new(vec![])
+    }
+
     pub fn get_module_names_from_root(&self) -> &[Symbol] {
         &self.modules_from_root
     }

--- a/compiler/monomorphize/src/lib.rs
+++ b/compiler/monomorphize/src/lib.rs
@@ -44,7 +44,7 @@ mod tests {
         Rc::new(FnDecl {
             lang_linkage: LangLinkage::Default,
             link_once: false,
-            name: QualifiedSymbol::new(ModulePath::new(vec![]), Symbol::from(name.to_owned())),
+            name: QualifiedSymbol::new(ModulePath::root(), Symbol::from(name.to_owned())),
             params: vec![],
             is_c_variadic: false,
             return_ty: unit_ty(),
@@ -198,7 +198,7 @@ mod tests {
 
     fn dummy_interface(name: &str) -> Rc<Interface> {
         Rc::new(Interface {
-            name: QualifiedSymbol::new(ModulePath::new(vec![]), Symbol::from(name.to_owned())),
+            name: QualifiedSymbol::new(ModulePath::root(), Symbol::from(name.to_owned())),
             methods: vec![InterfaceMethod {
                 name: Symbol::from("m".to_owned()),
                 self_: None,

--- a/compiler/semantic/src/context.rs
+++ b/compiler/semantic/src/context.rs
@@ -33,7 +33,7 @@ pub struct AnalysisContext {
 impl AnalysisContext {
     pub fn new(module_path: ModulePath) -> Self {
         Self {
-            current_module_path: ModulePath::new(vec![]),
+            current_module_path: ModulePath::root(),
             module_path,
             fallback_lookup_module_path: None,
             is_inside_loop: false,

--- a/compiler/semantic/src/context.rs
+++ b/compiler/semantic/src/context.rs
@@ -123,7 +123,18 @@ impl SemanticAnalyzer {
     where
         F: FnOnce(&mut Self) -> R,
     {
-        self.with_module(ModulePath::new(vec![]), f)
+        self.with_module(ModulePath::root(), f)
+    }
+
+    // Register a decl in the root module while keeping `fallback` as a lookup fallback,
+    // so the body can still reach symbols declared alongside it in its original module.
+    // Used for built-in types (fundamentals, slices) whose methods live in the root module
+    // but whose bodies may reference helpers from wherever the `impl` block was written.
+    pub fn with_root_module_and_fallback<F, R>(&mut self, fallback: ModulePath, f: F) -> R
+    where
+        F: FnOnce(&mut Self) -> R,
+    {
+        self.with_lookup_fallback_module(fallback, |analyzer| analyzer.with_root_module(f))
     }
 
     // Temporarily changes the fallback module path used for symbol lookup.

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -3577,7 +3577,7 @@ impl SemanticAnalyzer {
 
                     self.create_method_call_ir(
                         callee_symbol,
-                        ModulePath::new(vec![]),
+                        ModulePath::root(),
                         self.slice_method_parent_name(elem_ty),
                         call_node,
                         lhs,
@@ -3615,7 +3615,7 @@ impl SemanticAnalyzer {
                     // Arrays use slice methods (array is coerced to slice at codegen)
                     self.create_method_call_ir(
                         callee_symbol,
-                        ModulePath::new(vec![]),
+                        ModulePath::root(),
                         self.slice_method_parent_name(elem_ty),
                         call_node,
                         lhs,

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -3575,8 +3575,9 @@ impl SemanticAnalyzer {
                     // registered at the call site; ensure they exist before dispatching.
                     self.generate_slice_impl(elem_ty.clone())?;
 
-                    self.create_slice_method_call_ir(
+                    self.create_method_call_ir(
                         callee_symbol,
+                        ModulePath::new(vec![]),
                         self.slice_method_parent_name(elem_ty),
                         call_node,
                         lhs,
@@ -3612,8 +3613,9 @@ impl SemanticAnalyzer {
                     self.generate_slice_impl(elem_ty.clone())?;
 
                     // Arrays use slice methods (array is coerced to slice at codegen)
-                    self.create_slice_method_call_ir(
+                    self.create_method_call_ir(
                         callee_symbol,
+                        ModulePath::new(vec![]),
                         self.slice_method_parent_name(elem_ty),
                         call_node,
                         lhs,
@@ -3876,32 +3878,6 @@ impl SemanticAnalyzer {
             }
             _ => None,
         }
-    }
-
-    // Slice/array method dispatch. The impl may live in a different module than the
-    // current one: autoload's monomorphized `impl<T>[T]` registers under the intrinsic
-    // module, while user-defined `impl [T] { ... }` registers under the caller's module.
-    fn create_slice_method_call_ir(
-        &mut self,
-        method_name: Symbol,
-        parent_name: Symbol,
-        call_node: &ast::expr::FnCall,
-        this: ir::expr::Expr,
-        span: Span,
-    ) -> anyhow::Result<ir::expr::Expr> {
-        let method_key = self.create_method_key(parent_name, method_name, false);
-
-        let module_path = self
-            .lookup_qualified_symbol(QualifiedSymbol::new(self.module_path().clone(), method_key))
-            .map(|_| self.module_path().clone())
-            .or_else(|| {
-                self.modules
-                    .iter()
-                    .find_map(|(mp, module)| module.lookup_symbol(&method_key).map(|_| mp.clone()))
-            })
-            .unwrap_or_else(|| self.module_path().clone());
-
-        self.create_method_call_ir(method_name, module_path, parent_name, call_node, this, span)
     }
 
     fn create_method_call_ir(

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -3429,7 +3429,7 @@ impl SemanticAnalyzer {
 
             self.create_method_call_ir(
                 callee_symbol,
-                ModulePath::new(vec![]),
+                ModulePath::root(),
                 "str".to_owned().into(),
                 call_node,
                 left,
@@ -4003,7 +4003,7 @@ impl SemanticAnalyzer {
 
         self.create_method_call_ir(
             callee_symbol,
-            ModulePath::new(vec![]),
+            ModulePath::root(),
             fty.kind.to_string().into(),
             call_node,
             left,

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -949,7 +949,7 @@ impl SemanticAnalyzer {
         let main_fn_decl = ir::top::FnDecl {
             lang_linkage: kaede_common::LangLinkage::Default,
             link_once: false,
-            name: QualifiedSymbol::new(ModulePath::new(vec![]), "main".to_owned().into()),
+            name: QualifiedSymbol::new(ModulePath::root(), "main".to_owned().into()),
             params,
             is_c_variadic: false,
             return_ty: Rc::new(ir::ty::make_fundamental_type(
@@ -962,10 +962,7 @@ impl SemanticAnalyzer {
         let runtime_init_decl = ir::top::FnDecl {
             lang_linkage: kaede_common::LangLinkage::C,
             link_once: false,
-            name: QualifiedSymbol::new(
-                ModulePath::new(vec![]),
-                "kaede_runtime_init".to_owned().into(),
-            ),
+            name: QualifiedSymbol::new(ModulePath::root(), "kaede_runtime_init".to_owned().into()),
             params: vec![],
             is_c_variadic: false,
             return_ty: Rc::new(ir::ty::Ty::new_unit()),
@@ -975,10 +972,7 @@ impl SemanticAnalyzer {
         let runtime_run_decl = ir::top::FnDecl {
             lang_linkage: kaede_common::LangLinkage::C,
             link_once: false,
-            name: QualifiedSymbol::new(
-                ModulePath::new(vec![]),
-                "kaede_runtime_run".to_owned().into(),
-            ),
+            name: QualifiedSymbol::new(ModulePath::root(), "kaede_runtime_run".to_owned().into()),
             params: vec![],
             is_c_variadic: false,
             return_ty: Rc::new(ir::ty::make_fundamental_type(
@@ -992,7 +986,7 @@ impl SemanticAnalyzer {
             lang_linkage: kaede_common::LangLinkage::C,
             link_once: false,
             name: QualifiedSymbol::new(
-                ModulePath::new(vec![]),
+                ModulePath::root(),
                 "kaede_runtime_shutdown".to_owned().into(),
             ),
             params: vec![],
@@ -1277,7 +1271,7 @@ impl SemanticAnalyzer {
 
         // Create root module
         let root_module = Self::create_module_context(FilePath::dummy());
-        self.modules.insert(ModulePath::new(vec![]), root_module);
+        self.modules.insert(ModulePath::root(), root_module);
 
         self.context.set_no_prelude(options.no_prelude);
 

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -56,9 +56,9 @@ pub struct AnalyzeOptions {
 
 // `impl<T>[T] { ... }` is declared once (autoload) but applies to every slice type in the
 // compile unit, so it's stored here as an analyzer-level intrinsic instead of a module
-// symbol. `defining_module` is the module that wrote the block; it's used as a lookup
-// fallback during monomorphization so helpers referenced in the body (e.g.
-// `__slice_from_raw_parts`) resolve. Generated methods themselves live in the root module.
+// symbol. Generated methods are registered in the root module; `defining_module` records
+// where the block was written and serves as a lookup fallback during monomorphization so
+// method bodies can reach symbols declared alongside the impl block.
 pub struct SliceIntrinsic {
     pub impl_info: GenericImplInfo,
     pub defining_module: ModulePath,

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -54,12 +54,14 @@ pub struct AnalyzeOptions {
     pub is_entry_unit: bool,
 }
 
-// The `impl<T>[T] { ... }` block lives in a single autoload module but applies to every
-// slice type anywhere in the compile unit. Storing it here — rather than as a per-module
-// symbol — gives every lookup a direct, canonical handle.
+// `impl<T>[T] { ... }` is declared once (autoload) but applies to every slice type in the
+// compile unit, so it's stored here as an analyzer-level intrinsic instead of a module
+// symbol. `defining_module` is the module that wrote the block; it's used as a lookup
+// fallback during monomorphization so helpers referenced in the body (e.g.
+// `__slice_from_raw_parts`) resolve. Generated methods themselves live in the root module.
 pub struct SliceIntrinsic {
     pub impl_info: GenericImplInfo,
-    pub module_path: ModulePath,
+    pub defining_module: ModulePath,
 }
 
 pub struct SemanticAnalyzer {
@@ -567,16 +569,6 @@ impl SemanticAnalyzer {
 
     pub fn slice_method_parent_name(&self, elem_ty: &Rc<ir_type::Ty>) -> Symbol {
         format!("slice<{}>", elem_ty.kind).into()
-    }
-
-    // Module that owns the concrete slice methods (`slice<T>.len`, …). They are generated
-    // under the module that declared `impl<T>[T]`, so callers in other modules need this
-    // path to build a qualified lookup.
-    pub fn slice_impl_module_path(&self) -> ModulePath {
-        self.slice_intrinsic
-            .as_ref()
-            .map(|s| s.module_path.clone())
-            .unwrap_or_else(|| self.module_path().clone())
     }
 
     pub fn create_method_key(

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -542,10 +542,8 @@ impl SemanticAnalyzer {
 
         let parent_ty = self.analyze_type(&ty)?;
 
-        // `should_route_to_root_module` is true for built-in language types (fundamental
-        // scalars and slices): they have no defining module, so their methods live in the
-        // anonymous root module where every caller can find them with a direct qualified
-        // lookup.
+        // Built-in types (fundamentals, slices) have no defining module, so their methods
+        // live in the root module, reachable from anywhere by direct qualified lookup.
         let (parent_name, should_route_to_root_module) = match parent_ty.kind.as_ref() {
             ir::ty::TyKind::Reference(ty) => {
                 let base_ty = ty.get_base_type();
@@ -583,8 +581,8 @@ impl SemanticAnalyzer {
 
         if should_route_to_root_module {
             let source_module_path = self.current_module_path().clone();
-            self.with_lookup_fallback_module(source_module_path, |analyzer| {
-                analyzer.with_root_module(|analyzer| analyzer.analyze_fn_internal(node))
+            self.with_root_module_and_fallback(source_module_path, |analyzer| {
+                analyzer.analyze_fn_internal(node)
             })
             .map(Some)
         } else {
@@ -614,16 +612,14 @@ impl SemanticAnalyzer {
 
         if should_route_to_root_module {
             let source_module_path = self.current_module_path().clone();
-            self.with_lookup_fallback_module(source_module_path, |analyzer| {
-                analyzer.with_root_module(|analyzer| {
-                    analyzer.register_generic_method_symbol(
-                        name,
-                        node,
-                        resolved_generic_params,
-                        vis,
-                        span,
-                    )
-                })
+            self.with_root_module_and_fallback(source_module_path, |analyzer| {
+                analyzer.register_generic_method_symbol(
+                    name,
+                    node,
+                    resolved_generic_params,
+                    vis,
+                    span,
+                )
             })
         } else {
             self.register_generic_method_symbol(name, node, resolved_generic_params, vis, span)

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -774,7 +774,7 @@ impl SemanticAnalyzer {
         let name = node.name.symbol();
 
         let qualified_name = if name.as_str() == "main" {
-            QualifiedSymbol::new(ModulePath::new(vec![]), "kdmain".to_owned().into())
+            QualifiedSymbol::new(ModulePath::root(), "kdmain".to_owned().into())
         } else {
             QualifiedSymbol::new(self.current_module_path().clone(), name)
         };

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -494,7 +494,7 @@ impl SemanticAnalyzer {
                 ast_type::TyKind::Slice(_) => {
                     self.slice_intrinsic = Some(crate::SliceIntrinsic {
                         impl_info: GenericImplInfo::new(node, resolved_generic_params, span),
-                        module_path: self.current_module_path().clone(),
+                        defining_module: self.current_module_path().clone(),
                     });
                     return Ok(TopLevelAnalysisResult::GenericTopLevel);
                 }
@@ -542,20 +542,23 @@ impl SemanticAnalyzer {
 
         let parent_ty = self.analyze_type(&ty)?;
 
-        let (parent_name, is_fundamental_type) = match parent_ty.kind.as_ref() {
+        // `route_to_root_module` is true for built-in language types (fundamental scalars
+        // and slices): they have no defining module, so their methods live in the anonymous
+        // root module where every caller can find them with a direct qualified lookup.
+        let (parent_name, route_to_root_module) = match parent_ty.kind.as_ref() {
             ir::ty::TyKind::Reference(ty) => {
                 let base_ty = ty.get_base_type();
                 match base_ty.kind.as_ref() {
                     ir::ty::TyKind::UserDefined(udt) => (udt.name(), false),
                     ir::ty::TyKind::Slice(elem_ty) => {
-                        (self.slice_method_parent_name(elem_ty), false)
+                        (self.slice_method_parent_name(elem_ty), true)
                     }
                     _ => (Symbol::from(base_ty.kind.to_string()), true),
                 }
             }
 
             ir::ty::TyKind::Fundamental(fty) => (Symbol::from(fty.kind.to_string()), true),
-            ir::ty::TyKind::Slice(elem_ty) => (self.slice_method_parent_name(elem_ty), false),
+            ir::ty::TyKind::Slice(elem_ty) => (self.slice_method_parent_name(elem_ty), true),
 
             _ => unreachable!(),
         };
@@ -573,11 +576,11 @@ impl SemanticAnalyzer {
 
         if node.decl.generic_params.is_some() {
             return self
-                .analyze_generic_method(node, is_fundamental_type)
+                .analyze_generic_method(node, route_to_root_module)
                 .map(|()| None);
         }
 
-        if is_fundamental_type {
+        if route_to_root_module {
             let source_module_path = self.current_module_path().clone();
             self.with_lookup_fallback_module(source_module_path, |analyzer| {
                 analyzer.with_root_module(|analyzer| analyzer.analyze_fn_internal(node))
@@ -591,7 +594,7 @@ impl SemanticAnalyzer {
     fn analyze_generic_method(
         &mut self,
         node: ast::top::Fn,
-        is_fundamental_type: bool,
+        route_to_root_module: bool,
     ) -> anyhow::Result<()> {
         // Body-analysis pass is a no-op for generic methods; they are
         // monomorphized on demand at each call site.
@@ -608,7 +611,7 @@ impl SemanticAnalyzer {
         let resolved_generic_params =
             self.resolve_generic_params(node.decl.generic_params.as_ref())?;
 
-        if is_fundamental_type {
+        if route_to_root_module {
             let source_module_path = self.current_module_path().clone();
             self.with_lookup_fallback_module(source_module_path, |analyzer| {
                 analyzer.with_root_module(|analyzer| {

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -542,10 +542,11 @@ impl SemanticAnalyzer {
 
         let parent_ty = self.analyze_type(&ty)?;
 
-        // `route_to_root_module` is true for built-in language types (fundamental scalars
-        // and slices): they have no defining module, so their methods live in the anonymous
-        // root module where every caller can find them with a direct qualified lookup.
-        let (parent_name, route_to_root_module) = match parent_ty.kind.as_ref() {
+        // `should_route_to_root_module` is true for built-in language types (fundamental
+        // scalars and slices): they have no defining module, so their methods live in the
+        // anonymous root module where every caller can find them with a direct qualified
+        // lookup.
+        let (parent_name, should_route_to_root_module) = match parent_ty.kind.as_ref() {
             ir::ty::TyKind::Reference(ty) => {
                 let base_ty = ty.get_base_type();
                 match base_ty.kind.as_ref() {
@@ -576,11 +577,11 @@ impl SemanticAnalyzer {
 
         if node.decl.generic_params.is_some() {
             return self
-                .analyze_generic_method(node, route_to_root_module)
+                .analyze_generic_method(node, should_route_to_root_module)
                 .map(|()| None);
         }
 
-        if route_to_root_module {
+        if should_route_to_root_module {
             let source_module_path = self.current_module_path().clone();
             self.with_lookup_fallback_module(source_module_path, |analyzer| {
                 analyzer.with_root_module(|analyzer| analyzer.analyze_fn_internal(node))
@@ -594,7 +595,7 @@ impl SemanticAnalyzer {
     fn analyze_generic_method(
         &mut self,
         node: ast::top::Fn,
-        route_to_root_module: bool,
+        should_route_to_root_module: bool,
     ) -> anyhow::Result<()> {
         // Body-analysis pass is a no-op for generic methods; they are
         // monomorphized on demand at each call site.
@@ -611,7 +612,7 @@ impl SemanticAnalyzer {
         let resolved_generic_params =
             self.resolve_generic_params(node.decl.generic_params.as_ref())?;
 
-        if route_to_root_module {
+        if should_route_to_root_module {
             let source_module_path = self.current_module_path().clone();
             self.with_lookup_fallback_module(source_module_path, |analyzer| {
                 analyzer.with_root_module(|analyzer| {

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -116,27 +116,7 @@ impl SemanticAnalyzer {
         let (module_path, parent_name) = self.method_lookup_target(actual_ty)?;
         let method_key = self.create_method_key(parent_name, method.name, method.self_.is_none());
 
-        // Slice methods may be registered in the caller's module (user-defined
-        // `impl [T] { ... }`) or in whatever module generated the monomorphized
-        // `impl<T>[T]`. Fall back to scanning all modules for slice-typed receivers.
-        let is_slice_receiver = {
-            let base_ty = match actual_ty.kind.as_ref() {
-                ir_type::TyKind::Reference(rty) => rty.get_base_type(),
-                _ => actual_ty.clone(),
-            };
-            matches!(base_ty.kind.as_ref(), ir_type::TyKind::Slice(_))
-        };
-        let symbol = self
-            .lookup_qualified_symbol(QualifiedSymbol::new(module_path, method_key))
-            .or_else(|| {
-                is_slice_receiver
-                    .then(|| {
-                        self.modules
-                            .values()
-                            .find_map(|module| module.lookup_symbol(&method_key))
-                    })
-                    .flatten()
-            })?;
+        let symbol = self.lookup_qualified_symbol(QualifiedSymbol::new(module_path, method_key))?;
         let borrowed = symbol.borrow();
 
         match &borrowed.kind {
@@ -157,7 +137,7 @@ impl SemanticAnalyzer {
                 fty.kind.to_string().into(),
             )),
             ir_type::TyKind::Slice(elem_ty) => Some((
-                self.module_path().clone(),
+                kaede_ir::module_path::ModulePath::new(vec![]),
                 self.slice_method_parent_name(elem_ty),
             )),
             _ => None,
@@ -846,7 +826,7 @@ impl SemanticAnalyzer {
             return Ok(());
         }
 
-        let module_path = slice.module_path.clone();
+        let defining_module = slice.defining_module.clone();
         let generic_params = slice
             .impl_info
             .impl_
@@ -894,10 +874,15 @@ impl SemanticAnalyzer {
             .collect();
         impl_ast.items = Rc::new(methods);
 
-        let impl_ir = self.with_module(module_path, |analyzer| {
-            analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {
-                analyzer.with_analyze_command(AnalyzeCommand::NoCommand, |analyzer| {
-                    analyzer.analyze_impl(impl_ast.clone())
+        // Slice methods live in the root module (so every call site can find them with a
+        // direct lookup), but symbol references inside the body resolve from the module
+        // that declared `impl<T>[T]` — e.g. helpers like `__slice_from_raw_parts`.
+        let impl_ir = self.with_lookup_fallback_module(defining_module, |analyzer| {
+            analyzer.with_root_module(|analyzer| {
+                analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {
+                    analyzer.with_analyze_command(AnalyzeCommand::NoCommand, |analyzer| {
+                        analyzer.analyze_impl(impl_ast.clone())
+                    })
                 })
             })
         })?;

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -874,9 +874,10 @@ impl SemanticAnalyzer {
             .collect();
         impl_ast.items = Rc::new(methods);
 
-        // Slice methods live in the root module (so every call site can find them with a
-        // direct lookup), but symbol references inside the body resolve from the module
-        // that declared `impl<T>[T]` — e.g. helpers like `__slice_from_raw_parts`.
+        // Monomorphized slice methods are registered in the root module so every call site
+        // finds them with a direct qualified lookup. The defining module (where `impl<T>[T]`
+        // is written) is set as a lookup fallback so method bodies can still reference
+        // symbols declared alongside the impl block — which the root module has no view of.
         let impl_ir = self.with_lookup_fallback_module(defining_module, |analyzer| {
             analyzer.with_root_module(|analyzer| {
                 analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -133,11 +133,11 @@ impl SemanticAnalyzer {
             ir_type::TyKind::Reference(rty) => self.method_lookup_target(&rty.get_base_type()),
             ir_type::TyKind::UserDefined(udt) => Some((udt.module_path(), udt.name())),
             ir_type::TyKind::Fundamental(fty) => Some((
-                kaede_ir::module_path::ModulePath::new(vec![]),
+                kaede_ir::module_path::ModulePath::root(),
                 fty.kind.to_string().into(),
             )),
             ir_type::TyKind::Slice(elem_ty) => Some((
-                kaede_ir::module_path::ModulePath::new(vec![]),
+                kaede_ir::module_path::ModulePath::root(),
                 self.slice_method_parent_name(elem_ty),
             )),
             _ => None,
@@ -874,16 +874,13 @@ impl SemanticAnalyzer {
             .collect();
         impl_ast.items = Rc::new(methods);
 
-        // Monomorphized slice methods are registered in the root module so every call site
-        // finds them with a direct qualified lookup. The defining module (where `impl<T>[T]`
-        // is written) is set as a lookup fallback so method bodies can still reference
-        // symbols declared alongside the impl block — which the root module has no view of.
-        let impl_ir = self.with_lookup_fallback_module(defining_module, |analyzer| {
-            analyzer.with_root_module(|analyzer| {
-                analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {
-                    analyzer.with_analyze_command(AnalyzeCommand::NoCommand, |analyzer| {
-                        analyzer.analyze_impl(impl_ast.clone())
-                    })
+        // Fallback to the module that declared `impl<T>[T]` so method bodies can still
+        // reference symbols declared alongside the impl block — which the root module
+        // has no view of.
+        let impl_ir = self.with_root_module_and_fallback(defining_module, |analyzer| {
+            analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {
+                analyzer.with_analyze_command(AnalyzeCommand::NoCommand, |analyzer| {
+                    analyzer.analyze_impl(impl_ast.clone())
                 })
             })
         })?;

--- a/compiler/type_infer/src/lib.rs
+++ b/compiler/type_infer/src/lib.rs
@@ -2123,7 +2123,7 @@ mod tests {
 
     fn generic_instance(args: Vec<Rc<Ty>>) -> GenericInstanceInfo {
         GenericInstanceInfo::new(
-            QualifiedSymbol::new(ModulePath::new(vec![]), Symbol::from("id".to_owned())),
+            QualifiedSymbol::new(ModulePath::root(), Symbol::from("id".to_owned())),
             args,
         )
     }
@@ -2132,7 +2132,7 @@ mod tests {
         let callee = Rc::new(FnDecl {
             lang_linkage: LangLinkage::Default,
             link_once: true,
-            name: QualifiedSymbol::new(ModulePath::new(vec![]), Symbol::from("id".to_owned())),
+            name: QualifiedSymbol::new(ModulePath::root(), Symbol::from("id".to_owned())),
             params: vec![],
             is_c_variadic: false,
             return_ty: return_ty.clone(),
@@ -2201,14 +2201,11 @@ mod tests {
             Rc::new(Ty {
                 kind: TyKind::UserDefined(UserDefinedType::with_generic_instance(
                     UserDefinedTypeKind::Placeholder(QualifiedSymbol::new(
-                        ModulePath::new(vec![]),
+                        ModulePath::root(),
                         Symbol::from("Option".to_owned()),
                     )),
                     GenericInstanceInfo::new(
-                        QualifiedSymbol::new(
-                            ModulePath::new(vec![]),
-                            Symbol::from("Option".to_owned()),
-                        ),
+                        QualifiedSymbol::new(ModulePath::root(), Symbol::from("Option".to_owned())),
                         vec![var_ty(1), var_ty(2)],
                     ),
                 ))
@@ -2252,7 +2249,7 @@ mod tests {
         let substitutions = inferrer.into_generic_fn_substitutions();
         let bindings = substitutions
             .get(&QualifiedSymbol::new(
-                ModulePath::new(vec![]),
+                ModulePath::root(),
                 Symbol::from("id".to_owned()),
             ))
             .unwrap();
@@ -2267,7 +2264,7 @@ mod tests {
         let mut inferrer = make_inferrer();
         let field_ty = i32_ty();
         let struct_info = Rc::new(Struct {
-            name: QualifiedSymbol::new(ModulePath::new(vec![]), Symbol::from("S".to_owned())),
+            name: QualifiedSymbol::new(ModulePath::root(), Symbol::from("S".to_owned())),
             fields: vec![StructField {
                 name: Symbol::from("n".to_owned()),
                 ty: field_ty.clone(),


### PR DESCRIPTION
## Summary
- Register slice methods in the anonymous root module (alongside fundamental-type methods) instead of the caller's module.
- Remove the cross-module scan and the Reference-peel fallback in both method lookup and slice method dispatch; call sites now do a direct qualified lookup with `ModulePath::new(vec![])`.
- Keep the module that declared `impl<T>[T]` around as `SliceIntrinsic::defining_module` so body references (`__slice_from_raw_parts`, etc.) still resolve during monomorphization via `with_lookup_fallback_module`.

## Motivation
Slice has no defining module — the single `impl<T>[T]` block applies everywhere a slice appears. The previous design leaked that asymmetry to every call site: dispatch scanned all modules, and `method_lookup_target` had a Reference-peel special case. Routing through the root module unifies slice with fundamentals and removes the special cases.

## Test plan
- [x] `cargo test --release --workspace` (all passing)
- [x] Rebuilt `~/.kaede/lib/libkd.so` with the new mangling and verified `slice<u8>.as_bytes` (no `std.http.` prefix) via `nm`
- [x] `cargo fmt --all`
- [x] `cargo clippy -p kaede_semantic -p kaede_codegen -p kaede_ir --all-targets -- -D warnings` clean

**Note for reviewers**: this change renames the mangled symbols of slice methods (drops the per-module prefix). Precompiled `libkd.so` must be rebuilt after merging; running `python3 -c 'import library; library.install(...)'` or re-running the normal install flow produces the matching library.