### PR TITLE
feat(stdlib): add Stringer impl for str

### DIFF
--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -734,6 +734,20 @@ fn fundamental_to_string_for_bool() -> anyhow::Result<()> {
 }
 
 #[test]
+fn fundamental_to_string_for_str() -> anyhow::Result<()> {
+    let program = r#"fun main() -> i32 {
+        let s: str = "hello"
+        if s.to_string().as_str() == "hello" {
+            return 1
+        }
+        return 0
+    }"#;
+
+    assert_eq!(exec(program)?, 1);
+    Ok(())
+}
+
+#[test]
 fn builtin_format_auto_calls_stringer_to_string() -> anyhow::Result<()> {
     let program = r#"fun main() -> i32 {
         if __format("{}+{}={}", 2 as i32, 3 as i32, 5 as i32) == "2+3=5" {

--- a/library/src/std/string.kd
+++ b/library/src/std/string.kd
@@ -295,6 +295,10 @@ impl str {
     export fun parse_i64(self) -> std.option.Option<i64> {
         return parse_i64_from_str(self)
     }
+
+    export fun to_string(self) -> String {
+        return String::from(self)
+    }
 }
 
 export interface Stringer {


### PR DESCRIPTION
## Summary
Add `to_string()` to `str`, delegating to `String::from(self)`. This rounds out the `Stringer` coverage for fundamental types that currently exist in the language — previously `u8/u16/u32/u64/i8/i16/i32/i64/bool/char` had `to_string()` but `str` did not.

`f32` / `f64` are intentionally **not** included: Kaede has no floating-point types yet (`FundamentalTypeKind` in `compiler/ir/src/ty.rs` defines only integer/bool/str/char). Adding float support is tracked separately in #236.

## Changes
- `library/src/std/string.kd`: add `impl str { export fun to_string(self) -> String }`
- `compiler/codegen/src/tests.rs`: add `fundamental_to_string_for_str` alongside the existing `_for_i32` / `_for_u32` / `_for_bool` tests

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo test --release` — all tests pass, including the new `fundamental_to_string_for_str`
- [x] `cargo clippy --release --all-targets` — clean (one pre-existing `items_after_test_module` warning in `kaede_monomorphize` unrelated to this change)
- [x] `~/.kaede/lib/libkd.so` rebuilt; `nm` confirms `str.to_string` is exported