### PR TITLE
feat(stdlib): add io.Reader/Writer interfaces and migrate sys/http helpers

### DIFF
--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -5106,6 +5106,51 @@ fn fd_satisfies_io_reader_and_writer() -> anyhow::Result<()> {
 }
 
 #[test]
+fn generic_param_mutability_does_not_leak_via_substitution() -> anyhow::Result<()> {
+    // A generic fn instantiated first via a `mut` field would cache a fn_decl
+    // whose param.ty carried `mut`. A later call from an immutable site reused
+    // the cache and tripped the immutable-to-mutable check. Confirms that a
+    // `T` parameter stays immutable regardless of the substituted type's
+    // mutability.
+    let program = r#"
+        interface Sink {
+            fun put(self, b: u8) -> bool
+        }
+
+        struct Counter { n: i32 }
+        impl Counter {
+            fun put(self, b: u8) -> bool { return true }
+        }
+
+        struct Holder { c: Counter }
+        impl Holder {
+            fun call_mut(mut self) -> bool {
+                return do_put(self.c)
+            }
+        }
+
+        fun do_put<S: Sink>(s: S) -> bool {
+            return s.put(1)
+        }
+
+        fun via_immutable<S: Sink>(s: S) -> bool {
+            return do_put(s)
+        }
+
+        fun main() -> i32 {
+            let mut h = Holder { c: Counter { n: 0 } }
+            h.call_mut()
+            let c = Counter { n: 0 }
+            if via_immutable(c) { return 1 }
+            return 0
+        }
+    "#;
+
+    assert_eq!(exec(program)?, 1);
+    Ok(())
+}
+
+#[test]
 fn generic_method_dispatches_on_str_and_slice() -> anyhow::Result<()> {
     let program = r#"
         interface Payload {

--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -5071,6 +5071,41 @@ fn generic_method_with_interface_bound() -> anyhow::Result<()> {
 }
 
 #[test]
+fn fd_satisfies_io_reader_and_writer() -> anyhow::Result<()> {
+    // Verifies that std.sys.Fd conforms to the cross-module interfaces
+    // std.io.Reader and std.io.Writer declared in a different stdlib module.
+    // The generic functions coerce Fd into the interface at the call site but
+    // never invoke the methods, so we do not need a real file descriptor.
+    let program = r#"
+        import std.io
+        import std.sys
+
+        use std.io.Reader
+        use std.io.Writer
+        use std.sys.Fd
+
+        fun is_reader<R: Reader>(r: R) -> bool {
+            return true
+        }
+
+        fun is_writer<W: Writer>(w: W) -> bool {
+            return true
+        }
+
+        fun main() -> i32 {
+            let fd = Fd::new(-1)
+            if is_reader(fd) && is_writer(fd) {
+                return 1
+            }
+            return 0
+        }
+    "#;
+
+    assert_eq!(exec(program)?, 1);
+    Ok(())
+}
+
+#[test]
 fn generic_method_dispatches_on_str_and_slice() -> anyhow::Result<()> {
     let program = r#"
         interface Payload {

--- a/compiler/driver/tests/runtime_netpoll.rs
+++ b/compiler/driver/tests/runtime_netpoll.rs
@@ -117,7 +117,7 @@ use std.sync.WaitGroup
 
 fun handle(conn: std.sys.Fd, wg: mut WaitGroup) {{
     let mut buf = [0; 1]
-    let n = match std.sys.read(conn, buf) {{
+    let n = match conn.read(buf) {{
         std.option.Option::Some(value) => value,
         std.option.Option::None => {{
             std.sys.close_quiet(conn)
@@ -126,7 +126,7 @@ fun handle(conn: std.sys.Fd, wg: mut WaitGroup) {{
         }}
     }}
 
-    if n > 0 && std.sys.write(conn, b"ok").is_none() {{
+    if n > 0 && conn.write(b"ok").is_none() {{
         std.sys.close_quiet(conn)
         wg.done()
         return
@@ -209,7 +209,7 @@ use std.sync.WaitGroup
 
 fun reader(conn: std.sys.Fd, wg: mut WaitGroup) {{
     let mut buf = [0; 1]
-    let _ = std.sys.read(conn, buf)
+    let _ = conn.read(buf)
     wg.done()
 }}
 
@@ -273,7 +273,7 @@ fn runtime_shutdown_exits_with_background_tasks_still_parked_on_io() -> anyhow::
 
 fun reader(conn: std.sys.Fd) {{
     let mut buf = [0; 1]
-    let _ = std.sys.read(conn, buf)
+    let _ = conn.read(buf)
 }}
 
 fun main() -> i32 {{

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -210,7 +210,9 @@ impl SemanticAnalyzer {
                 )?
                 .into()),
 
-            ast_type::TyKind::Generic(gty) => self.analyze_generic_type(gty, ty.span),
+            ast_type::TyKind::Generic(gty) => {
+                self.analyze_generic_type(gty, ty.span, ty.mutability.into())
+            }
 
             ast_type::TyKind::External(inner_ty, access_chain) => {
                 let outer_mutability = ty.mutability;
@@ -246,11 +248,16 @@ impl SemanticAnalyzer {
         &self,
         gty: &ast_type::GenericType,
         span: Span,
+        outer_mutability: ir_type::Mutability,
     ) -> anyhow::Result<Rc<ir_type::Ty>> {
         let name = gty.name.symbol();
 
+        // The substituted type's mutability comes from the call site's argument,
+        // but the source position (`T` vs `mut T`) determines the parameter's
+        // mutability. Without this override, a first instantiation with a `mut`
+        // argument would poison the cached fn_decl for later immutable callers.
         match self.lookup_generic_argument(name) {
-            Some(ty) => Ok(ty),
+            Some(ty) => Ok(ir_type::change_mutability_dup(ty, outer_mutability)),
             None => Err(SemanticError::Undeclared { name, span }.into()),
         }
     }

--- a/compiler/semantic/tests/top.rs
+++ b/compiler/semantic/tests/top.rs
@@ -626,9 +626,11 @@ fn plain_functions_are_allowed_in_non_entry_units() -> anyhow::Result<()> {
 
 #[test]
 fn interface_declarations_are_accepted() -> anyhow::Result<()> {
+    // Name the interface something the prelude does not export, so the
+    // `find_map` below is guaranteed to match this source file's declaration.
     let unit = semantic_analyze_as_non_entry(
         "\
-interface Reader {
+interface TestReader {
     fun read(mut self, buf: i32) -> i32
     fun peek(self) -> i32
 }
@@ -640,13 +642,13 @@ interface Reader {
         .iter()
         .find_map(|tl| match tl {
             TopLevel::Interface(iface)
-                if iface.name.symbol() == Symbol::from("Reader".to_string()) =>
+                if iface.name.symbol() == Symbol::from("TestReader".to_string()) =>
             {
                 Some(iface)
             }
             _ => None,
         })
-        .expect("Reader interface must be emitted");
+        .expect("TestReader interface must be emitted");
 
     assert_eq!(iface.methods.len(), 2);
     assert_eq!(iface.methods[0].name, Symbol::from("read".to_string()));

--- a/library/src/std/http.kd
+++ b/library/src/std/http.kd
@@ -304,7 +304,7 @@ impl Response {
             self.mark_write_failed()
             return
         }
-        if self.close_conn && std.sys.write(self.conn, b"Connection: close\r\n").is_none() {
+        if self.close_conn && self.conn.write(b"Connection: close\r\n").is_none() {
             self.mark_write_failed()
             return
         }
@@ -316,11 +316,11 @@ impl Response {
             self.mark_write_failed()
             return
         }
-        if std.sys.write(self.conn, b"\r\n").is_none() {
+        if self.conn.write(b"\r\n").is_none() {
             self.mark_write_failed()
             return
         }
-        if std.sys.write(self.conn, bytes).is_none() {
+        if self.conn.write(bytes).is_none() {
             self.mark_write_failed()
         }
     }
@@ -724,7 +724,7 @@ export fun parse_content_length(header: [u8]) -> i32 {
 
 fun write_content_length(conn: Fd, len: u64) -> bool {
     let prefix = b"Content-Length: "
-    if std.sys.write(conn, prefix).is_none() {
+    if conn.write(prefix).is_none() {
         return false
     }
 
@@ -751,21 +751,21 @@ fun write_content_length(conn: Fd, len: u64) -> bool {
         j -= 1
         let mut one = [0; 1]
         one[0] = digits[j]
-        if std.sys.write(conn, one).is_none() {
+        if conn.write(one).is_none() {
             return false
         }
     }
 
-    return std.sys.write(conn, b"\r\n").is_some()
+    return conn.write(b"\r\n").is_some()
 }
 
 export fun write_status_line(conn: Fd, status: Status) -> bool {
     match status {
-        Status::Ok => return std.sys.write(conn, b"HTTP/1.1 200 OK\r\n").is_some(),
-        Status::NotFound => return std.sys.write(conn, b"HTTP/1.1 404 Not Found\r\n").is_some(),
-        Status::BadRequest => return std.sys.write(conn, b"HTTP/1.1 400 Bad Request\r\n").is_some(),
-        Status::PayloadTooLarge => return std.sys.write(conn, b"HTTP/1.1 413 Payload Too Large\r\n").is_some(),
-        Status::InternalServerError => return std.sys.write(conn, b"HTTP/1.1 500 Internal Server Error\r\n").is_some(),
+        Status::Ok => return conn.write(b"HTTP/1.1 200 OK\r\n").is_some(),
+        Status::NotFound => return conn.write(b"HTTP/1.1 404 Not Found\r\n").is_some(),
+        Status::BadRequest => return conn.write(b"HTTP/1.1 400 Bad Request\r\n").is_some(),
+        Status::PayloadTooLarge => return conn.write(b"HTTP/1.1 413 Payload Too Large\r\n").is_some(),
+        Status::InternalServerError => return conn.write(b"HTTP/1.1 500 Internal Server Error\r\n").is_some(),
     }
 
     return false
@@ -775,16 +775,16 @@ fun write_response_headers(conn: Fd, headers: Vector<ResponseHeader>) -> bool {
     let mut i = 0
     while i < headers.len() {
         let header = headers.at(i).unwrap()
-        if std.sys.write(conn, header.name.as_str().to_bytes().as_slice()).is_none() {
+        if conn.write(header.name.as_str().to_bytes().as_slice()).is_none() {
             return false
         }
-        if std.sys.write(conn, b": ").is_none() {
+        if conn.write(b": ").is_none() {
             return false
         }
-        if std.sys.write(conn, header.value.as_str().to_bytes().as_slice()).is_none() {
+        if conn.write(header.value.as_str().to_bytes().as_slice()).is_none() {
             return false
         }
-        if std.sys.write(conn, b"\r\n").is_none() {
+        if conn.write(b"\r\n").is_none() {
             return false
         }
         i += 1
@@ -797,35 +797,35 @@ export fun write_text_response(conn: Fd, close_conn: bool, status: Status, body:
     if !write_status_line(conn, status) {
         return false
     }
-    if close_conn && std.sys.write(conn, b"Connection: close\r\n").is_none() {
+    if close_conn && conn.write(b"Connection: close\r\n").is_none() {
         return false
     }
     if !write_content_length(conn, body.len()) {
         return false
     }
-    if std.sys.write(conn, b"\r\n").is_none() {
+    if conn.write(b"\r\n").is_none() {
         return false
     }
-    return std.sys.write(conn, body).is_some()
+    return conn.write(body).is_some()
 }
 
 fun write_websocket_upgrade_response(conn: Fd, accept_value: [u8]) -> bool {
-    if std.sys.write(conn, b"HTTP/1.1 101 Switching Protocols\r\n").is_none() {
+    if conn.write(b"HTTP/1.1 101 Switching Protocols\r\n").is_none() {
         return false
     }
-    if std.sys.write(conn, b"Upgrade: websocket\r\n").is_none() {
+    if conn.write(b"Upgrade: websocket\r\n").is_none() {
         return false
     }
-    if std.sys.write(conn, b"Connection: Upgrade\r\n").is_none() {
+    if conn.write(b"Connection: Upgrade\r\n").is_none() {
         return false
     }
-    if std.sys.write(conn, b"Sec-WebSocket-Accept: ").is_none() {
+    if conn.write(b"Sec-WebSocket-Accept: ").is_none() {
         return false
     }
-    if std.sys.write(conn, accept_value).is_none() {
+    if conn.write(accept_value).is_none() {
         return false
     }
-    return std.sys.write(conn, b"\r\n\r\n").is_some()
+    return conn.write(b"\r\n\r\n").is_some()
 }
 
 // Writes a WebSocket control frame and enforces its payload size limit.
@@ -863,7 +863,7 @@ fun write_ws_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
         10
     }
 
-    if std.sys.write(conn, header[0:header_len]).is_none() {
+    if conn.write(header[0:header_len]).is_none() {
         return false
     }
 
@@ -871,7 +871,7 @@ fun write_ws_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
         return true
     }
 
-    return std.sys.write(conn, payload).is_some()
+    return conn.write(payload).is_some()
 }
 
 // Reads an exact number of bytes and reports whether it succeeded.

--- a/library/src/std/http.kd
+++ b/library/src/std/http.kd
@@ -8,6 +8,8 @@ import std.ffi.http
 use std.sys.Fd
 use std.string.String
 use std.collections.Vector
+use std.io.Reader
+use std.io.Writer
 use std.option.Option
 use std.ffi.http.__http_ws_accept
 
@@ -722,7 +724,7 @@ export fun parse_content_length(header: [u8]) -> i32 {
     return val
 }
 
-fun write_content_length(conn: Fd, len: u64) -> bool {
+fun write_content_length<W: Writer>(conn: W, len: u64) -> bool {
     let prefix = b"Content-Length: "
     if conn.write(prefix).is_none() {
         return false
@@ -759,7 +761,7 @@ fun write_content_length(conn: Fd, len: u64) -> bool {
     return conn.write(b"\r\n").is_some()
 }
 
-export fun write_status_line(conn: Fd, status: Status) -> bool {
+export fun write_status_line<W: Writer>(conn: W, status: Status) -> bool {
     match status {
         Status::Ok => return conn.write(b"HTTP/1.1 200 OK\r\n").is_some(),
         Status::NotFound => return conn.write(b"HTTP/1.1 404 Not Found\r\n").is_some(),
@@ -771,7 +773,7 @@ export fun write_status_line(conn: Fd, status: Status) -> bool {
     return false
 }
 
-fun write_response_headers(conn: Fd, headers: Vector<ResponseHeader>) -> bool {
+fun write_response_headers<W: Writer>(conn: W, headers: Vector<ResponseHeader>) -> bool {
     let mut i = 0
     while i < headers.len() {
         let header = headers.at(i).unwrap()
@@ -793,7 +795,7 @@ fun write_response_headers(conn: Fd, headers: Vector<ResponseHeader>) -> bool {
     return true
 }
 
-export fun write_text_response(conn: Fd, close_conn: bool, status: Status, body: [u8]) -> bool {
+export fun write_text_response<W: Writer>(conn: W, close_conn: bool, status: Status, body: [u8]) -> bool {
     if !write_status_line(conn, status) {
         return false
     }
@@ -809,7 +811,7 @@ export fun write_text_response(conn: Fd, close_conn: bool, status: Status, body:
     return conn.write(body).is_some()
 }
 
-fun write_websocket_upgrade_response(conn: Fd, accept_value: [u8]) -> bool {
+fun write_websocket_upgrade_response<W: Writer>(conn: W, accept_value: [u8]) -> bool {
     if conn.write(b"HTTP/1.1 101 Switching Protocols\r\n").is_none() {
         return false
     }
@@ -829,7 +831,7 @@ fun write_websocket_upgrade_response(conn: Fd, accept_value: [u8]) -> bool {
 }
 
 // Writes a WebSocket control frame and enforces its payload size limit.
-fun write_ws_control_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
+fun write_ws_control_frame<W: Writer>(conn: W, opcode: u8, payload: [u8]) -> bool {
     if payload.len() > 125 {
         return false
     }
@@ -838,7 +840,7 @@ fun write_ws_control_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
 }
 
 // Encodes and writes a single server-side WebSocket frame.
-fun write_ws_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
+fun write_ws_frame<W: Writer>(conn: W, opcode: u8, payload: [u8]) -> bool {
     let mut header = [0; 10]
     header[0] = opcode + 128
 
@@ -875,15 +877,15 @@ fun write_ws_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
 }
 
 // Reads an exact number of bytes and reports whether it succeeded.
-fun read_exact_bytes(fd: Fd, buf: mut [u8], len: u64) -> bool {
-    return match std.sys.read_exact(fd, buf, len) {
+fun read_exact_bytes<R: Reader>(r: R, buf: mut [u8], len: u64) -> bool {
+    return match std.sys.read_exact(r, buf, len) {
         Option::Some(n) => n == len,
         Option::None => false,
     }
 }
 
 // Reads a 16-bit extended WebSocket payload length.
-fun read_ws_len16(conn: Fd) -> Option<u64> {
+fun read_ws_len16<R: Reader>(conn: R) -> Option<u64> {
     let mut buf = [0; 2]
     if !read_exact_bytes(conn, buf, 2) {
         return Option::None
@@ -893,7 +895,7 @@ fun read_ws_len16(conn: Fd) -> Option<u64> {
 }
 
 // Reads a 64-bit extended WebSocket payload length.
-fun read_ws_len64(conn: Fd) -> Option<u64> {
+fun read_ws_len64<R: Reader>(conn: R) -> Option<u64> {
     let mut buf = [0; 8]
     if !read_exact_bytes(conn, buf, 8) {
         return Option::None
@@ -913,7 +915,7 @@ fun read_ws_len64(conn: Fd) -> Option<u64> {
 }
 
 // Reads and unmasks a WebSocket payload body.
-fun read_ws_payload(conn: Fd, payload_len: u64, mask_key: [u8]) -> Option<Vector<u8>> {
+fun read_ws_payload<R: Reader>(conn: R, payload_len: u64, mask_key: [u8]) -> Option<Vector<u8>> {
     let mut out = Vector<u8>::new()
     let mut chunk = [0; 256]
     let mut remaining = payload_len
@@ -944,7 +946,7 @@ fun read_ws_payload(conn: Fd, payload_len: u64, mask_key: [u8]) -> Option<Vector
 
 // Discards a bounded amount of frame body bytes so the server can send a close
 // frame before tearing the connection down on protocol errors.
-fun discard_ws_frame_body(conn: Fd, len: u64) -> bool {
+fun discard_ws_frame_body<R: Reader>(conn: R, len: u64) -> bool {
     let mut chunk = [0; 256]
     let mut remaining = len
 
@@ -960,7 +962,7 @@ fun discard_ws_frame_body(conn: Fd, len: u64) -> bool {
 }
 
 // Reads one client WebSocket frame and validates the minimal protocol rules.
-fun read_ws_frame(conn: Fd) -> FrameReadResult {
+fun read_ws_frame<R: Reader>(conn: R) -> FrameReadResult {
     let mut first_bytes = [0; 2]
     let n = match std.sys.read_exact(conn, first_bytes, 2) {
         Option::Some(value) => value,

--- a/library/src/std/io.kd
+++ b/library/src/std/io.kd
@@ -1,6 +1,20 @@
 import std.ffi.io
+import std.option
 
 use std.ffi.io.write
+use std.option.Option
+
+// A source of bytes. Implementors populate `buf` and return how many bytes were
+// read, or `None` on failure. A return of `Some(0)` signals end-of-stream.
+export interface Reader {
+    fun read(self, buf: mut [u8]) -> Option<u64>
+}
+
+// A sink of bytes. Implementors consume `buf` and return how many bytes were
+// written, or `None` on failure.
+export interface Writer {
+    fun write(self, buf: [u8]) -> Option<u64>
+}
 
 export fun print(msg: str) -> i32 {
     return write(1, msg)

--- a/library/src/std/sys.kd
+++ b/library/src/std/sys.kd
@@ -21,6 +21,14 @@ impl Fd {
     export fun raw(self) -> i32 {
         return self.raw
     }
+
+    export fun read(self, buf: mut [u8]) -> Option<u64> {
+        return std.sys.read(self, buf)
+    }
+
+    export fun write(self, buf: [u8]) -> Option<u64> {
+        return std.sys.write(self, buf)
+    }
 }
 
 export fun socket_tcp4() -> Fd {

--- a/library/src/std/sys.kd
+++ b/library/src/std/sys.kd
@@ -23,11 +23,37 @@ impl Fd {
     }
 
     export fun read(self, buf: mut [u8]) -> Option<u64> {
-        return std.sys.read(self, buf)
+        let n = __sys_read(self.raw, buf.as_ptr(), buf.len())
+        if n < 0 {
+            return Option::None
+        }
+        return Option::Some(n as u64)
     }
 
     export fun write(self, buf: [u8]) -> Option<u64> {
-        return std.sys.write(self, buf)
+        let mut off = 0
+        let total = buf.len()
+
+        while off < total {
+            // Short writes are normal on sockets, so keep advancing until all bytes
+            // are written or the syscall reports failure.
+            let ptr = __ptr_add(buf.as_ptr(), off)
+            let rem = total - off
+
+            let n = __sys_write(self.raw, ptr, rem)
+
+            if n < 0 {
+                return Option::None
+            }
+
+            if n == 0 {
+                return Option::None
+            }
+
+            off += n as u64
+        }
+
+        return Option::Some(total)
     }
 }
 
@@ -109,20 +135,12 @@ export fun is_regular_file(fd: Fd) -> bool {
     return __sys_is_regular_file(fd.raw) == 1
 }
 
-export fun read(fd: Fd, buf: mut [u8]) -> Option<u64> {
-    let n = __sys_read(fd.raw, buf.as_ptr(), buf.len())
-    if n < 0 {
-        return Option::None
-    }
-    return Option::Some(n as u64)
-}
-
 // Read exactly `len` bytes unless EOF is hit; returns bytes read.
 export fun read_exact(fd: Fd, buf: mut [u8], len: u64) -> Option<u64> {
     let mut read_total = 0
     while read_total < len {
         let mut slice = buf[read_total:buf.len()]
-        let n = match std.sys.read(fd, slice) {
+        let n = match fd.read(slice) {
             Option::Some(value) => value,
             Option::None => return Option::None,
         }
@@ -134,42 +152,12 @@ export fun read_exact(fd: Fd, buf: mut [u8], len: u64) -> Option<u64> {
     return Option::Some(read_total)
 }
 
-export fun write(fd: Fd, buf: [u8]) -> Option<u64> {
-    return write_all(fd, buf)
-}
-
-fun write_all(fd: Fd, buf: [u8]) -> Option<u64> {
-    let mut off = 0
-    let total = buf.len()
-
-    while off < total {
-        // Short writes are normal on sockets, so keep advancing until all bytes
-        // are written or the syscall reports failure.
-        let ptr = __ptr_add(buf.as_ptr(), off)
-        let rem = total - off
-
-        let n = __sys_write(fd.raw, ptr, rem)
-
-        if n < 0 {
-            return Option::None
-        }
-
-        if n == 0 {
-            return Option::None
-        }
-
-        off += n as u64
-    }
-
-    return Option::Some(total)
-}
-
 export fun read_all(fd: Fd, max_bytes: u64) -> Option<Vector<u8>> {
     let mut out = Vector<u8>::new()
     let mut buf = [0; 4096]
 
     loop {
-        let n = match read(fd, buf) {
+        let n = match fd.read(buf) {
             Option::Some(value) => value,
             Option::None => return Option::None,
         }
@@ -203,7 +191,7 @@ export fun read_until(fd: Fd, buf: mut [u8], delim: [u8]) -> Option<u64> {
         // Read 1 byte at a time so HTTP keep-alive parsing does not consume
         // bytes that belong to the next request on the same connection.
         let mut tail = buf[filled:(filled + 1)]
-        let n = match std.sys.read(fd, tail) {
+        let n = match fd.read(tail) {
             Option::Some(value) => value,
             Option::None => return Option::None,
         }

--- a/library/src/std/sys.kd
+++ b/library/src/std/sys.kd
@@ -2,8 +2,10 @@ import std.ffi.sys
 import std.string
 import std.collections
 import std.option
+import std.io
 
 use std.collections.Vector
+use std.io.Reader
 use std.option.Option
 use std.string.String
 
@@ -136,11 +138,11 @@ export fun is_regular_file(fd: Fd) -> bool {
 }
 
 // Read exactly `len` bytes unless EOF is hit; returns bytes read.
-export fun read_exact(fd: Fd, buf: mut [u8], len: u64) -> Option<u64> {
+export fun read_exact<R: Reader>(r: R, buf: mut [u8], len: u64) -> Option<u64> {
     let mut read_total = 0
     while read_total < len {
         let mut slice = buf[read_total:buf.len()]
-        let n = match fd.read(slice) {
+        let n = match r.read(slice) {
             Option::Some(value) => value,
             Option::None => return Option::None,
         }
@@ -152,12 +154,12 @@ export fun read_exact(fd: Fd, buf: mut [u8], len: u64) -> Option<u64> {
     return Option::Some(read_total)
 }
 
-export fun read_all(fd: Fd, max_bytes: u64) -> Option<Vector<u8>> {
+export fun read_all<R: Reader>(r: R, max_bytes: u64) -> Option<Vector<u8>> {
     let mut out = Vector<u8>::new()
     let mut buf = [0; 4096]
 
     loop {
-        let n = match fd.read(buf) {
+        let n = match r.read(buf) {
             Option::Some(value) => value,
             Option::None => return Option::None,
         }
@@ -180,7 +182,7 @@ export fun read_all(fd: Fd, max_bytes: u64) -> Option<Vector<u8>> {
     return Option::Some(out)
 }
 
-export fun read_until(fd: Fd, buf: mut [u8], delim: [u8]) -> Option<u64> {
+export fun read_until<R: Reader>(r: R, buf: mut [u8], delim: [u8]) -> Option<u64> {
     let mut filled = 0
 
     loop {
@@ -191,7 +193,7 @@ export fun read_until(fd: Fd, buf: mut [u8], delim: [u8]) -> Option<u64> {
         // Read 1 byte at a time so HTTP keep-alive parsing does not consume
         // bytes that belong to the next request on the same connection.
         let mut tail = buf[filled:(filled + 1)]
-        let n = match fd.read(tail) {
+        let n = match r.read(tail) {
             Option::Some(value) => value,
             Option::None => return Option::None,
         }


### PR DESCRIPTION
This PR is the merged-back trunk of a small stack — #242, #243, and #244 all landed on this branch first, so merging here brings them all to `main` together.

## Summary
Adds two export interfaces in `std.io` and threads them through the stdlib I/O helpers:

- `Reader` — `fun read(self, buf: mut [u8]) -> Option<u64>`
- `Writer` — `fun write(self, buf: [u8]) -> Option<u64>`

`std.sys.Fd` satisfies both. The `sys.kd` and `http.kd` byte-stream helpers no longer hard-code `Fd` — they take `<R: Reader>` / `<W: Writer>` so any user-defined adapter works.

This is the first stdlib interface declared in one module (`std.io`) and implemented in another (`std.sys`) — prior interfaces (`Stringer`, `Payload`, `WebSocketPayload`) all colocated declaration and impls.

## What lands together
- **Interfaces + Fd adaptation** (5c4715a, originally this PR): `Reader`, `Writer`, and `impl Fd { read, write }`.
- **Method-form Fd** (#242, 10582ca): inline `Fd.read`/`Fd.write`; drop the free-function forms.
- **sys helpers over Reader** (#243, 455b953): `read_exact`, `read_all`, `read_until` take `<R: Reader>`.
- **Compiler fix** (a2352ef, from #244): `analyze_generic_type` now applies source-position mutability to substituted generic params. Without this, a generic fn first instantiated via a `mut` value (e.g. `self.conn` from `mut self`) cached a fn_decl with a `mut` param, and later immutable callers tripped the immutable-to-mutable check. Includes a regression test (`generic_param_mutability_does_not_leak_via_substitution`).
- **http helpers over Reader/Writer** (#244, 852bbf6): the seven write helpers (`write_status_line`, `write_content_length`, `write_response_headers`, `write_text_response`, `write_websocket_upgrade_response`, `write_ws_control_frame`, `write_ws_frame`) take `<W: Writer>`; the six read helpers (`read_exact_bytes`, `read_ws_len16`, `read_ws_len64`, `read_ws_payload`, `discard_ws_frame_body`, `read_ws_frame`) take `<R: Reader>`. Behavior is unchanged when called with `Fd`.

## Why `self` and not `mut self`
Matches the existing `Payload` / `WebSocketPayload` interfaces. `Fd` wraps only an `i32` and doesn't mutate internal state; the write-path mutation is on `buf`, which already carries `mut`. A future buffered reader needing `mut self` can revisit this.

## Test plan
- [x] `cargo fmt`
- [x] `cargo test --release` — all tests pass, including `fd_satisfies_io_reader_and_writer` and `generic_param_mutability_does_not_leak_via_substitution`
- [x] `cargo clippy --release --all-targets` — clean apart from the pre-existing `items_after_test_module` warning in `kaede_monomorphize`
- [x] Stdlib rebuilds (`libkd.so`)
- [x] `example/http_server` and `example/comment_app` build cleanly