### PR TITLE
refactor(stdlib): inline Fd.read/Fd.write and drop free-function forms

### DIFF
--- a/compiler/driver/tests/runtime_netpoll.rs
+++ b/compiler/driver/tests/runtime_netpoll.rs
@@ -117,7 +117,7 @@ use std.sync.WaitGroup
 
 fun handle(conn: std.sys.Fd, wg: mut WaitGroup) {{
     let mut buf = [0; 1]
-    let n = match std.sys.read(conn, buf) {{
+    let n = match conn.read(buf) {{
         std.option.Option::Some(value) => value,
         std.option.Option::None => {{
             std.sys.close_quiet(conn)
@@ -126,7 +126,7 @@ fun handle(conn: std.sys.Fd, wg: mut WaitGroup) {{
         }}
     }}
 
-    if n > 0 && std.sys.write(conn, b"ok").is_none() {{
+    if n > 0 && conn.write(b"ok").is_none() {{
         std.sys.close_quiet(conn)
         wg.done()
         return
@@ -209,7 +209,7 @@ use std.sync.WaitGroup
 
 fun reader(conn: std.sys.Fd, wg: mut WaitGroup) {{
     let mut buf = [0; 1]
-    let _ = std.sys.read(conn, buf)
+    let _ = conn.read(buf)
     wg.done()
 }}
 
@@ -273,7 +273,7 @@ fn runtime_shutdown_exits_with_background_tasks_still_parked_on_io() -> anyhow::
 
 fun reader(conn: std.sys.Fd) {{
     let mut buf = [0; 1]
-    let _ = std.sys.read(conn, buf)
+    let _ = conn.read(buf)
 }}
 
 fun main() -> i32 {{

--- a/library/src/std/http.kd
+++ b/library/src/std/http.kd
@@ -304,7 +304,7 @@ impl Response {
             self.mark_write_failed()
             return
         }
-        if self.close_conn && std.sys.write(self.conn, b"Connection: close\r\n").is_none() {
+        if self.close_conn && self.conn.write(b"Connection: close\r\n").is_none() {
             self.mark_write_failed()
             return
         }
@@ -316,11 +316,11 @@ impl Response {
             self.mark_write_failed()
             return
         }
-        if std.sys.write(self.conn, b"\r\n").is_none() {
+        if self.conn.write(b"\r\n").is_none() {
             self.mark_write_failed()
             return
         }
-        if std.sys.write(self.conn, bytes).is_none() {
+        if self.conn.write(bytes).is_none() {
             self.mark_write_failed()
         }
     }
@@ -724,7 +724,7 @@ export fun parse_content_length(header: [u8]) -> i32 {
 
 fun write_content_length(conn: Fd, len: u64) -> bool {
     let prefix = b"Content-Length: "
-    if std.sys.write(conn, prefix).is_none() {
+    if conn.write(prefix).is_none() {
         return false
     }
 
@@ -751,21 +751,21 @@ fun write_content_length(conn: Fd, len: u64) -> bool {
         j -= 1
         let mut one = [0; 1]
         one[0] = digits[j]
-        if std.sys.write(conn, one).is_none() {
+        if conn.write(one).is_none() {
             return false
         }
     }
 
-    return std.sys.write(conn, b"\r\n").is_some()
+    return conn.write(b"\r\n").is_some()
 }
 
 export fun write_status_line(conn: Fd, status: Status) -> bool {
     match status {
-        Status::Ok => return std.sys.write(conn, b"HTTP/1.1 200 OK\r\n").is_some(),
-        Status::NotFound => return std.sys.write(conn, b"HTTP/1.1 404 Not Found\r\n").is_some(),
-        Status::BadRequest => return std.sys.write(conn, b"HTTP/1.1 400 Bad Request\r\n").is_some(),
-        Status::PayloadTooLarge => return std.sys.write(conn, b"HTTP/1.1 413 Payload Too Large\r\n").is_some(),
-        Status::InternalServerError => return std.sys.write(conn, b"HTTP/1.1 500 Internal Server Error\r\n").is_some(),
+        Status::Ok => return conn.write(b"HTTP/1.1 200 OK\r\n").is_some(),
+        Status::NotFound => return conn.write(b"HTTP/1.1 404 Not Found\r\n").is_some(),
+        Status::BadRequest => return conn.write(b"HTTP/1.1 400 Bad Request\r\n").is_some(),
+        Status::PayloadTooLarge => return conn.write(b"HTTP/1.1 413 Payload Too Large\r\n").is_some(),
+        Status::InternalServerError => return conn.write(b"HTTP/1.1 500 Internal Server Error\r\n").is_some(),
     }
 
     return false
@@ -775,16 +775,16 @@ fun write_response_headers(conn: Fd, headers: Vector<ResponseHeader>) -> bool {
     let mut i = 0
     while i < headers.len() {
         let header = headers.at(i).unwrap()
-        if std.sys.write(conn, header.name.as_str().to_bytes().as_slice()).is_none() {
+        if conn.write(header.name.as_str().to_bytes().as_slice()).is_none() {
             return false
         }
-        if std.sys.write(conn, b": ").is_none() {
+        if conn.write(b": ").is_none() {
             return false
         }
-        if std.sys.write(conn, header.value.as_str().to_bytes().as_slice()).is_none() {
+        if conn.write(header.value.as_str().to_bytes().as_slice()).is_none() {
             return false
         }
-        if std.sys.write(conn, b"\r\n").is_none() {
+        if conn.write(b"\r\n").is_none() {
             return false
         }
         i += 1
@@ -797,35 +797,35 @@ export fun write_text_response(conn: Fd, close_conn: bool, status: Status, body:
     if !write_status_line(conn, status) {
         return false
     }
-    if close_conn && std.sys.write(conn, b"Connection: close\r\n").is_none() {
+    if close_conn && conn.write(b"Connection: close\r\n").is_none() {
         return false
     }
     if !write_content_length(conn, body.len()) {
         return false
     }
-    if std.sys.write(conn, b"\r\n").is_none() {
+    if conn.write(b"\r\n").is_none() {
         return false
     }
-    return std.sys.write(conn, body).is_some()
+    return conn.write(body).is_some()
 }
 
 fun write_websocket_upgrade_response(conn: Fd, accept_value: [u8]) -> bool {
-    if std.sys.write(conn, b"HTTP/1.1 101 Switching Protocols\r\n").is_none() {
+    if conn.write(b"HTTP/1.1 101 Switching Protocols\r\n").is_none() {
         return false
     }
-    if std.sys.write(conn, b"Upgrade: websocket\r\n").is_none() {
+    if conn.write(b"Upgrade: websocket\r\n").is_none() {
         return false
     }
-    if std.sys.write(conn, b"Connection: Upgrade\r\n").is_none() {
+    if conn.write(b"Connection: Upgrade\r\n").is_none() {
         return false
     }
-    if std.sys.write(conn, b"Sec-WebSocket-Accept: ").is_none() {
+    if conn.write(b"Sec-WebSocket-Accept: ").is_none() {
         return false
     }
-    if std.sys.write(conn, accept_value).is_none() {
+    if conn.write(accept_value).is_none() {
         return false
     }
-    return std.sys.write(conn, b"\r\n\r\n").is_some()
+    return conn.write(b"\r\n\r\n").is_some()
 }
 
 // Writes a WebSocket control frame and enforces its payload size limit.
@@ -863,7 +863,7 @@ fun write_ws_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
         10
     }
 
-    if std.sys.write(conn, header[0:header_len]).is_none() {
+    if conn.write(header[0:header_len]).is_none() {
         return false
     }
 
@@ -871,7 +871,7 @@ fun write_ws_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
         return true
     }
 
-    return std.sys.write(conn, payload).is_some()
+    return conn.write(payload).is_some()
 }
 
 // Reads an exact number of bytes and reports whether it succeeded.

--- a/library/src/std/sys.kd
+++ b/library/src/std/sys.kd
@@ -23,11 +23,37 @@ impl Fd {
     }
 
     export fun read(self, buf: mut [u8]) -> Option<u64> {
-        return std.sys.read(self, buf)
+        let n = __sys_read(self.raw, buf.as_ptr(), buf.len())
+        if n < 0 {
+            return Option::None
+        }
+        return Option::Some(n as u64)
     }
 
     export fun write(self, buf: [u8]) -> Option<u64> {
-        return std.sys.write(self, buf)
+        let mut off = 0
+        let total = buf.len()
+
+        while off < total {
+            // Short writes are normal on sockets, so keep advancing until all bytes
+            // are written or the syscall reports failure.
+            let ptr = __ptr_add(buf.as_ptr(), off)
+            let rem = total - off
+
+            let n = __sys_write(self.raw, ptr, rem)
+
+            if n < 0 {
+                return Option::None
+            }
+
+            if n == 0 {
+                return Option::None
+            }
+
+            off += n as u64
+        }
+
+        return Option::Some(total)
     }
 }
 
@@ -109,20 +135,12 @@ export fun is_regular_file(fd: Fd) -> bool {
     return __sys_is_regular_file(fd.raw) == 1
 }
 
-export fun read(fd: Fd, buf: mut [u8]) -> Option<u64> {
-    let n = __sys_read(fd.raw, buf.as_ptr(), buf.len())
-    if n < 0 {
-        return Option::None
-    }
-    return Option::Some(n as u64)
-}
-
 // Read exactly `len` bytes unless EOF is hit; returns bytes read.
 export fun read_exact(fd: Fd, buf: mut [u8], len: u64) -> Option<u64> {
     let mut read_total = 0
     while read_total < len {
         let mut slice = buf[read_total:buf.len()]
-        let n = match std.sys.read(fd, slice) {
+        let n = match fd.read(slice) {
             Option::Some(value) => value,
             Option::None => return Option::None,
         }
@@ -134,42 +152,12 @@ export fun read_exact(fd: Fd, buf: mut [u8], len: u64) -> Option<u64> {
     return Option::Some(read_total)
 }
 
-export fun write(fd: Fd, buf: [u8]) -> Option<u64> {
-    return write_all(fd, buf)
-}
-
-fun write_all(fd: Fd, buf: [u8]) -> Option<u64> {
-    let mut off = 0
-    let total = buf.len()
-
-    while off < total {
-        // Short writes are normal on sockets, so keep advancing until all bytes
-        // are written or the syscall reports failure.
-        let ptr = __ptr_add(buf.as_ptr(), off)
-        let rem = total - off
-
-        let n = __sys_write(fd.raw, ptr, rem)
-
-        if n < 0 {
-            return Option::None
-        }
-
-        if n == 0 {
-            return Option::None
-        }
-
-        off += n as u64
-    }
-
-    return Option::Some(total)
-}
-
 export fun read_all(fd: Fd, max_bytes: u64) -> Option<Vector<u8>> {
     let mut out = Vector<u8>::new()
     let mut buf = [0; 4096]
 
     loop {
-        let n = match read(fd, buf) {
+        let n = match fd.read(buf) {
             Option::Some(value) => value,
             Option::None => return Option::None,
         }
@@ -203,7 +191,7 @@ export fun read_until(fd: Fd, buf: mut [u8], delim: [u8]) -> Option<u64> {
         // Read 1 byte at a time so HTTP keep-alive parsing does not consume
         // bytes that belong to the next request on the same connection.
         let mut tail = buf[filled:(filled + 1)]
-        let n = match std.sys.read(fd, tail) {
+        let n = match fd.read(tail) {
             Option::Some(value) => value,
             Option::None => return Option::None,
         }


### PR DESCRIPTION
## Summary

- Inline the real bodies of `read` / `write` into `impl Fd` and delete the `std.sys.read(fd, buf)` / `std.sys.write(fd, buf)` / `write_all` free functions.
- Migrate every remaining call site (26 in `std.http`, 4 in the runtime-netpoll integration tests) from `std.sys.write(conn, x)` to `conn.write(x)` and similarly for `read`.
- `read_exact` / `read_all` / `read_until` remain free functions over `Fd` — they update their internal callsites to the new method form but are otherwise unchanged. Migrating them to methods (or generalizing over `Reader`/`Writer`) is deferred to a follow-up.

Stacked on #240 — review/merge that first. This PR's diff against `feat/io-reader-writer` is the mechanical read/write migration only.

## Why

Before this change `Fd::read` / `Fd::write` existed as one-line methods that forwarded to free `std.sys.read` / `std.sys.write`, so there were two syntactic forms for the same operation and the method form was the one idiomatic with the newly-added `io.Reader` / `io.Writer` interfaces. Collapsing to a single form removes the duplication and lines `Fd` up shape-wise with the interfaces from #240.

## Test plan

- [x] `cargo test --release` — all suites pass, including `compiler/driver/tests/runtime_netpoll.rs` (which embeds Kaede programs as string literals that were also migrated).
- [x] `cargo fmt --check`
- [x] `cargo clippy --release --all-targets` — no new warnings.
- [x] Rebuilt `~/.kaede/lib/libkd.so` against the updated stdlib before running tests.