### PR TITLE
refactor(stdlib): generalize sys read helpers over Reader

### DIFF
--- a/library/src/std/sys.kd
+++ b/library/src/std/sys.kd
@@ -2,8 +2,10 @@ import std.ffi.sys
 import std.string
 import std.collections
 import std.option
+import std.io
 
 use std.collections.Vector
+use std.io.Reader
 use std.option.Option
 use std.string.String
 
@@ -136,11 +138,11 @@ export fun is_regular_file(fd: Fd) -> bool {
 }
 
 // Read exactly `len` bytes unless EOF is hit; returns bytes read.
-export fun read_exact(fd: Fd, buf: mut [u8], len: u64) -> Option<u64> {
+export fun read_exact<R: Reader>(r: R, buf: mut [u8], len: u64) -> Option<u64> {
     let mut read_total = 0
     while read_total < len {
         let mut slice = buf[read_total:buf.len()]
-        let n = match fd.read(slice) {
+        let n = match r.read(slice) {
             Option::Some(value) => value,
             Option::None => return Option::None,
         }
@@ -152,12 +154,12 @@ export fun read_exact(fd: Fd, buf: mut [u8], len: u64) -> Option<u64> {
     return Option::Some(read_total)
 }
 
-export fun read_all(fd: Fd, max_bytes: u64) -> Option<Vector<u8>> {
+export fun read_all<R: Reader>(r: R, max_bytes: u64) -> Option<Vector<u8>> {
     let mut out = Vector<u8>::new()
     let mut buf = [0; 4096]
 
     loop {
-        let n = match fd.read(buf) {
+        let n = match r.read(buf) {
             Option::Some(value) => value,
             Option::None => return Option::None,
         }
@@ -180,7 +182,7 @@ export fun read_all(fd: Fd, max_bytes: u64) -> Option<Vector<u8>> {
     return Option::Some(out)
 }
 
-export fun read_until(fd: Fd, buf: mut [u8], delim: [u8]) -> Option<u64> {
+export fun read_until<R: Reader>(r: R, buf: mut [u8], delim: [u8]) -> Option<u64> {
     let mut filled = 0
 
     loop {
@@ -191,7 +193,7 @@ export fun read_until(fd: Fd, buf: mut [u8], delim: [u8]) -> Option<u64> {
         // Read 1 byte at a time so HTTP keep-alive parsing does not consume
         // bytes that belong to the next request on the same connection.
         let mut tail = buf[filled:(filled + 1)]
-        let n = match fd.read(tail) {
+        let n = match r.read(tail) {
             Option::Some(value) => value,
             Option::None => return Option::None,
         }


### PR DESCRIPTION
## Summary

Make `std.sys.read_exact`, `read_all`, and `read_until` generic over `<R: Reader>` instead of taking `Fd` directly. The `io.Reader` interface added in #240 was declared but had no actual consumer — this is the first one.

## Why

Before this change `Reader` was structurally satisfied by `Fd` but never referenced from any function signature, so the interface contributed nothing at use-site. Generalizing the existing read helpers makes them callable from any future `Reader` impl (in-memory buffers for tests, stream wrappers, mock connections, etc.) and validates that bounded-generic dispatch through an interface bound works on a real stdlib code path.

`Fd` already matches `Reader`'s method shape (`fun read(self, buf: mut [u8]) -> Option<u64>`), so all existing call sites in `std.http` (8 of them) keep compiling untouched via implicit conformance.

Stacked on #240 — review/merge that first. Diff against `feat/io-reader-writer` is just the three signature changes plus the `import std.io` / `use std.io.Reader` lines.

## Test plan

- [x] `cargo test --release` — all suites pass, including http and runtime-netpoll integration tests that exercise these helpers via `Fd`.
- [x] `cargo fmt --check`
- [x] `cargo clippy --release --all-targets` — no new warnings.
- [x] Rebuilt `~/.kaede/lib/libkd.so` against the updated stdlib before running tests.