### PR TITLE
refactor(stdlib): generalize http helpers over Reader/Writer (+ fix generic param mutability cache leak)

### DIFF
--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -5106,6 +5106,51 @@ fn fd_satisfies_io_reader_and_writer() -> anyhow::Result<()> {
 }
 
 #[test]
+fn generic_param_mutability_does_not_leak_via_substitution() -> anyhow::Result<()> {
+    // A generic fn instantiated first via a `mut` field would cache a fn_decl
+    // whose param.ty carried `mut`. A later call from an immutable site reused
+    // the cache and tripped the immutable-to-mutable check. Confirms that a
+    // `T` parameter stays immutable regardless of the substituted type's
+    // mutability.
+    let program = r#"
+        interface Sink {
+            fun put(self, b: u8) -> bool
+        }
+
+        struct Counter { n: i32 }
+        impl Counter {
+            fun put(self, b: u8) -> bool { return true }
+        }
+
+        struct Holder { c: Counter }
+        impl Holder {
+            fun call_mut(mut self) -> bool {
+                return do_put(self.c)
+            }
+        }
+
+        fun do_put<S: Sink>(s: S) -> bool {
+            return s.put(1)
+        }
+
+        fun via_immutable<S: Sink>(s: S) -> bool {
+            return do_put(s)
+        }
+
+        fun main() -> i32 {
+            let mut h = Holder { c: Counter { n: 0 } }
+            h.call_mut()
+            let c = Counter { n: 0 }
+            if via_immutable(c) { return 1 }
+            return 0
+        }
+    "#;
+
+    assert_eq!(exec(program)?, 1);
+    Ok(())
+}
+
+#[test]
 fn generic_method_dispatches_on_str_and_slice() -> anyhow::Result<()> {
     let program = r#"
         interface Payload {

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -210,7 +210,9 @@ impl SemanticAnalyzer {
                 )?
                 .into()),
 
-            ast_type::TyKind::Generic(gty) => self.analyze_generic_type(gty, ty.span),
+            ast_type::TyKind::Generic(gty) => {
+                self.analyze_generic_type(gty, ty.span, ty.mutability.into())
+            }
 
             ast_type::TyKind::External(inner_ty, access_chain) => {
                 let outer_mutability = ty.mutability;
@@ -246,11 +248,16 @@ impl SemanticAnalyzer {
         &self,
         gty: &ast_type::GenericType,
         span: Span,
+        outer_mutability: ir_type::Mutability,
     ) -> anyhow::Result<Rc<ir_type::Ty>> {
         let name = gty.name.symbol();
 
+        // The substituted type's mutability comes from the call site's argument,
+        // but the source position (`T` vs `mut T`) determines the parameter's
+        // mutability. Without this override, a first instantiation with a `mut`
+        // argument would poison the cached fn_decl for later immutable callers.
         match self.lookup_generic_argument(name) {
-            Some(ty) => Ok(ty),
+            Some(ty) => Ok(ir_type::change_mutability_dup(ty, outer_mutability)),
             None => Err(SemanticError::Undeclared { name, span }.into()),
         }
     }

--- a/library/src/std/http.kd
+++ b/library/src/std/http.kd
@@ -8,6 +8,8 @@ import std.ffi.http
 use std.sys.Fd
 use std.string.String
 use std.collections.Vector
+use std.io.Reader
+use std.io.Writer
 use std.option.Option
 use std.ffi.http.__http_ws_accept
 
@@ -722,7 +724,7 @@ export fun parse_content_length(header: [u8]) -> i32 {
     return val
 }
 
-fun write_content_length(conn: Fd, len: u64) -> bool {
+fun write_content_length<W: Writer>(conn: W, len: u64) -> bool {
     let prefix = b"Content-Length: "
     if conn.write(prefix).is_none() {
         return false
@@ -759,7 +761,7 @@ fun write_content_length(conn: Fd, len: u64) -> bool {
     return conn.write(b"\r\n").is_some()
 }
 
-export fun write_status_line(conn: Fd, status: Status) -> bool {
+export fun write_status_line<W: Writer>(conn: W, status: Status) -> bool {
     match status {
         Status::Ok => return conn.write(b"HTTP/1.1 200 OK\r\n").is_some(),
         Status::NotFound => return conn.write(b"HTTP/1.1 404 Not Found\r\n").is_some(),
@@ -771,7 +773,7 @@ export fun write_status_line(conn: Fd, status: Status) -> bool {
     return false
 }
 
-fun write_response_headers(conn: Fd, headers: Vector<ResponseHeader>) -> bool {
+fun write_response_headers<W: Writer>(conn: W, headers: Vector<ResponseHeader>) -> bool {
     let mut i = 0
     while i < headers.len() {
         let header = headers.at(i).unwrap()
@@ -793,7 +795,7 @@ fun write_response_headers(conn: Fd, headers: Vector<ResponseHeader>) -> bool {
     return true
 }
 
-export fun write_text_response(conn: Fd, close_conn: bool, status: Status, body: [u8]) -> bool {
+export fun write_text_response<W: Writer>(conn: W, close_conn: bool, status: Status, body: [u8]) -> bool {
     if !write_status_line(conn, status) {
         return false
     }
@@ -809,7 +811,7 @@ export fun write_text_response(conn: Fd, close_conn: bool, status: Status, body:
     return conn.write(body).is_some()
 }
 
-fun write_websocket_upgrade_response(conn: Fd, accept_value: [u8]) -> bool {
+fun write_websocket_upgrade_response<W: Writer>(conn: W, accept_value: [u8]) -> bool {
     if conn.write(b"HTTP/1.1 101 Switching Protocols\r\n").is_none() {
         return false
     }
@@ -829,7 +831,7 @@ fun write_websocket_upgrade_response(conn: Fd, accept_value: [u8]) -> bool {
 }
 
 // Writes a WebSocket control frame and enforces its payload size limit.
-fun write_ws_control_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
+fun write_ws_control_frame<W: Writer>(conn: W, opcode: u8, payload: [u8]) -> bool {
     if payload.len() > 125 {
         return false
     }
@@ -838,7 +840,7 @@ fun write_ws_control_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
 }
 
 // Encodes and writes a single server-side WebSocket frame.
-fun write_ws_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
+fun write_ws_frame<W: Writer>(conn: W, opcode: u8, payload: [u8]) -> bool {
     let mut header = [0; 10]
     header[0] = opcode + 128
 
@@ -875,15 +877,15 @@ fun write_ws_frame(conn: Fd, opcode: u8, payload: [u8]) -> bool {
 }
 
 // Reads an exact number of bytes and reports whether it succeeded.
-fun read_exact_bytes(fd: Fd, buf: mut [u8], len: u64) -> bool {
-    return match std.sys.read_exact(fd, buf, len) {
+fun read_exact_bytes<R: Reader>(r: R, buf: mut [u8], len: u64) -> bool {
+    return match std.sys.read_exact(r, buf, len) {
         Option::Some(n) => n == len,
         Option::None => false,
     }
 }
 
 // Reads a 16-bit extended WebSocket payload length.
-fun read_ws_len16(conn: Fd) -> Option<u64> {
+fun read_ws_len16<R: Reader>(conn: R) -> Option<u64> {
     let mut buf = [0; 2]
     if !read_exact_bytes(conn, buf, 2) {
         return Option::None
@@ -893,7 +895,7 @@ fun read_ws_len16(conn: Fd) -> Option<u64> {
 }
 
 // Reads a 64-bit extended WebSocket payload length.
-fun read_ws_len64(conn: Fd) -> Option<u64> {
+fun read_ws_len64<R: Reader>(conn: R) -> Option<u64> {
     let mut buf = [0; 8]
     if !read_exact_bytes(conn, buf, 8) {
         return Option::None
@@ -913,7 +915,7 @@ fun read_ws_len64(conn: Fd) -> Option<u64> {
 }
 
 // Reads and unmasks a WebSocket payload body.
-fun read_ws_payload(conn: Fd, payload_len: u64, mask_key: [u8]) -> Option<Vector<u8>> {
+fun read_ws_payload<R: Reader>(conn: R, payload_len: u64, mask_key: [u8]) -> Option<Vector<u8>> {
     let mut out = Vector<u8>::new()
     let mut chunk = [0; 256]
     let mut remaining = payload_len
@@ -944,7 +946,7 @@ fun read_ws_payload(conn: Fd, payload_len: u64, mask_key: [u8]) -> Option<Vector
 
 // Discards a bounded amount of frame body bytes so the server can send a close
 // frame before tearing the connection down on protocol errors.
-fun discard_ws_frame_body(conn: Fd, len: u64) -> bool {
+fun discard_ws_frame_body<R: Reader>(conn: R, len: u64) -> bool {
     let mut chunk = [0; 256]
     let mut remaining = len
 
@@ -960,7 +962,7 @@ fun discard_ws_frame_body(conn: Fd, len: u64) -> bool {
 }
 
 // Reads one client WebSocket frame and validates the minimal protocol rules.
-fun read_ws_frame(conn: Fd) -> FrameReadResult {
+fun read_ws_frame<R: Reader>(conn: R) -> FrameReadResult {
     let mut first_bytes = [0; 2]
     let n = match std.sys.read_exact(conn, first_bytes, 2) {
         Option::Some(value) => value,


### PR DESCRIPTION
## Summary

- **Stdlib**: Generalize `http.kd`'s 7 write helpers and 6 read helpers from `conn: Fd` to `<W: Writer>(conn: W)` / `<R: Reader>(conn: R)`. Behavior is unchanged when called with `Fd`; helpers now also accept any user-defined adapter that satisfies the `std.io.Reader` / `std.io.Writer` interfaces.
- **Compiler fix (prerequisite)**: `analyze_generic_type` previously returned the substituted type as-is. A `T` parameter therefore inherited the mutability of the value passed at the first instantiation. Combined with a generic-instance cache key that omits mutability, that meant a generic fn first called with a `mut` value (e.g. `self.conn` from a `mut self`) cached a fn_decl whose `param.ty` was `mut`. Subsequent immutable callers reused the cache and tripped the immutable-to-mutable assignment check. Without this fix, generalizing the http helpers would not compile, because `Response.send` calls `write_status_line(self.conn, ...)` first and the cache poisons the immutable callers in `write_text_response`. Fix: apply the source position's mutability the same way non-generic types do.

## Test plan

- [x] `cargo build --release`
- [x] `cargo fmt`
- [x] `cargo test --release` (243 codegen tests including new regression)
- [x] New regression: `generic_param_mutability_does_not_leak_via_substitution` in `compiler/codegen/src/tests.rs`
- [x] Stdlib rebuilds (`python3 /tmp/rebuild_lib.py`)
- [x] `example/http_server` and `example/comment_app` build cleanly