### PR TITLE
docs(language): add Interfaces page; add stdlib end-to-end tests

### DIFF
--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -5106,6 +5106,88 @@ fn fd_satisfies_io_reader_and_writer() -> anyhow::Result<()> {
 }
 
 #[test]
+fn user_defined_reader_flows_through_stdlib_read_exact() -> anyhow::Result<()> {
+    // Confirms that a user-defined struct satisfying std.io.Reader is accepted
+    // by the stdlib generic helper std.sys.read_exact end-to-end: the helper
+    // is monomorphized for the user's type, calls its `read` at runtime, and
+    // returns the right byte count and contents.
+    let program = r#"
+        import std.io
+        import std.sys
+
+        use std.io.Reader
+        use std.option.Option
+        use std.sys.read_exact
+
+        struct ByteSource {
+            value: u8,
+        }
+
+        impl ByteSource {
+            fun read(self, buf: mut [u8]) -> Option<u64> {
+                let mut i = 0
+                while i < buf.len() {
+                    buf[i] = self.value
+                    i += 1
+                }
+                return Option::Some(buf.len())
+            }
+        }
+
+        fun main() -> i32 {
+            let src = ByteSource { value: 7 }
+            let mut buf = [0; 4]
+            let n = match read_exact(src, buf, 4) {
+                Option::Some(value) => value,
+                Option::None => return 1,
+            }
+            if n != 4 { return 2 }
+            if buf[0] != 7 { return 3 }
+            if buf[3] != 7 { return 4 }
+            return 0
+        }
+    "#;
+
+    assert_eq!(exec(program)?, 0);
+    Ok(())
+}
+
+#[test]
+fn user_defined_writer_flows_through_stdlib_http_helper() -> anyhow::Result<()> {
+    // Confirms a user-defined Writer routes through std.http.write_status_line
+    // end-to-end: the stdlib helper is monomorphized over the user's type and
+    // dispatches to its `write` at runtime.
+    let program = r#"
+        import std.http
+        import std.io
+
+        use std.http.Status
+        use std.http.write_status_line
+        use std.io.Writer
+        use std.option.Option
+
+        struct AcceptAll {
+            tag: i32,
+        }
+
+        impl AcceptAll {
+            fun write(self, buf: [u8]) -> Option<u64> {
+                return Option::Some(buf.len())
+            }
+        }
+
+        fun main() -> i32 {
+            let sink = AcceptAll { tag: 1 }
+            if !write_status_line(sink, Status::Ok) { return 1 }
+            return 0
+        }
+    "#;
+
+    assert_eq!(exec(program)?, 0);
+    Ok(())
+}
+
+#[test]
 fn generic_param_mutability_does_not_leak_via_substitution() -> anyhow::Result<()> {
     // A generic fn instantiated first via a `mut` field would cache a fn_decl
     // whose param.ty carried `mut`. A later call from an immutable site reused

--- a/website/docs/language/concurrency.md
+++ b/website/docs/language/concurrency.md
@@ -1,7 +1,7 @@
 ---
 title: Concurrency
 description: Typed channels, task spawning, and synchronization patterns used in Kaede.
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Concurrency

--- a/website/docs/language/control-flow.md
+++ b/website/docs/language/control-flow.md
@@ -1,7 +1,7 @@
 ---
 title: Control flow
 description: Branching and looping patterns currently used throughout Kaede examples and tests.
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Control flow

--- a/website/docs/language/interfaces.md
+++ b/website/docs/language/interfaces.md
@@ -1,0 +1,111 @@
+---
+title: Interfaces
+description: Define behavior contracts and use them as generic bounds in Kaede.
+sidebar_position: 7
+---
+
+# Interfaces
+
+An `interface` declares a set of method signatures. Any type whose method set covers those signatures **conforms to the interface implicitly** — there is no `impl X for Y` step. This is the same model Go uses.
+
+```rust
+interface Stringer {
+    fun to_string(self) -> String
+}
+```
+
+A struct conforms simply by defining matching methods:
+
+```rust
+struct Counter {
+    value: u64,
+}
+
+impl Counter {
+    fun to_string(self) -> String {
+        return String::from("Counter")
+    }
+}
+```
+
+`Counter` now satisfies `Stringer`. Nothing else is required.
+
+## Generic bounds
+
+The most common use is as a bound on a generic type parameter. Inside the function body, only the methods declared on the interface are callable on the bound parameter.
+
+```rust
+interface Stringer {
+    fun to_string(self) -> String
+}
+
+fun describe<S: Stringer>(value: S) -> String {
+    return value.to_string()
+}
+```
+
+Any type with a matching `to_string` method can be passed in:
+
+```rust
+let counter = Counter { value: 0 }
+let label = describe(counter)
+```
+
+A generic parameter without a bound (`fun identity<T>(value: T) -> T`) accepts any type but cannot call any methods on it.
+
+## Standard-library interfaces
+
+`std.io` declares two interfaces used throughout the stdlib I/O surface:
+
+```rust
+interface Reader {
+    fun read(self, buf: mut [u8]) -> Option<u64>
+}
+
+interface Writer {
+    fun write(self, buf: [u8]) -> Option<u64>
+}
+```
+
+`std.sys.Fd` (the file-descriptor wrapper used by `std.http`) satisfies both, so any helper that takes `<R: Reader>` or `<W: Writer>` works directly with a TCP connection or open file:
+
+```rust
+import std.io
+import std.sys
+
+use std.io.Writer
+use std.sys.Fd
+
+fun greet<W: Writer>(out: W) -> bool {
+    return out.write(b"hello\n").is_some()
+}
+
+fun main() -> i32 {
+    let stdout = Fd::new(1)
+    if greet(stdout) {
+        return 0
+    }
+    return 1
+}
+```
+
+Other stdlib interfaces follow the same pattern:
+
+- `std.io.Stringer` — anything with `fun to_string(self) -> String`
+- `std.http.Payload` — bodies accepted by `Response::send` (impls for `str` and `[u8]`)
+- `std.http.WebSocketPayload` — payloads accepted by `WebSocket::send`
+
+To plug in your own type, just give it the right method. No registration is needed.
+
+## When to reach for an interface
+
+- The same operation is meaningful on several unrelated types (printing, byte I/O, message payloads).
+- You want to write one generic helper that works for every conforming type without enumerating them in an `enum`.
+- You want callers to be able to plug in their own types later without modifying the helper.
+
+For one-off polymorphism, a plain enum is usually simpler.
+
+## See also
+
+- [Generics](./generics.md) — declaring `<T>` parameters and inferring type arguments.
+- [Types](./types.md) — structs, enums, and how methods are declared.

--- a/website/docs/language/interfaces.md
+++ b/website/docs/language/interfaces.md
@@ -1,6 +1,6 @@
 ---
 title: Interfaces
-description: Define behavior contracts and use them as generic bounds in Kaede.
+description: Declare method contracts and use them as interface values or generic bounds in Kaede.
 sidebar_position: 7
 ---
 
@@ -114,7 +114,7 @@ let counter = Counter { value: 0 }
 let label = describe(counter)
 ```
 
-A generic parameter without a bound (`fun identity<T>(value: T) -> T`) accepts any type but cannot call any methods on it.
+A generic parameter without a bound accepts any type, and methods on `T` can still be called — the compiler resolves them against the concrete type at each instantiation. The bound is a constraint, not a capability switch: it rejects callers whose type does not implement the interface, turning what would otherwise be a failure deeper in monomorphization into a clear error at the call site.
 
 ### Dynamic vs. static dispatch
 

--- a/website/docs/language/interfaces.md
+++ b/website/docs/language/interfaces.md
@@ -41,9 +41,9 @@ println($"counter = {c}")
 
 Giving a type `fun to_string(self) -> String` is all you need to make it printable this way — no registration, no trait derivation.
 
-## Interface values
+## Dynamic dispatch
 
-An interface can be used directly as a type — as a parameter, return type, local, or element type inside a container like `Vector<I>`. The value carries its concrete type along with it, and each method call looks up the matching implementation at runtime.
+An interface name can be used directly as a type — as a parameter, return type, local, or element type inside a container like `Vector<I>`. A value held through an interface type carries its concrete type along with it, and each method call is resolved at runtime against that concrete type. This is **dynamic dispatch**.
 
 ```rust
 interface Scorer {
@@ -116,14 +116,14 @@ let label = describe(counter)
 
 A generic parameter without a bound (`fun identity<T>(value: T) -> T`) accepts any type but cannot call any methods on it.
 
-### Values vs. bounds
+### Dynamic vs. static dispatch
 
-Both forms share the same conformance rule — the method set must match — but they differ in where dispatch happens:
+Both forms share the same conformance rule — the method set must match — but they differ in how method calls are resolved:
 
-- `fun f(s: Scorer)` (interface value): one function body, dynamic dispatch per method call. Different concrete types can flow through the same variable at runtime.
-- `fun f<S: Scorer>(s: S)` (generic bound): one specialization per concrete `S`, static dispatch. No runtime lookup, but each call site fixes a single concrete type.
+- `fun f(s: Scorer)` — **dynamic dispatch**. One function body, the method is looked up at runtime against the value's concrete type. Different concrete types can flow through the same variable.
+- `fun f<S: Scorer>(s: S)` — **static dispatch**. One specialization per concrete `S`, the call is resolved at compile time. No runtime lookup, but each call site fixes a single concrete type.
 
-Reach for an interface value when the concrete type can vary at runtime (heterogeneous containers, plug-in style APIs). Reach for a generic bound when each caller has a single concrete type and you want the compiler to monomorphize.
+Reach for dynamic dispatch when the concrete type can vary at runtime (heterogeneous containers, plug-in style APIs). Reach for a generic bound when each caller has a single concrete type and you want the compiler to monomorphize.
 
 ## Standard-library interfaces
 

--- a/website/docs/language/interfaces.md
+++ b/website/docs/language/interfaces.md
@@ -114,7 +114,7 @@ let counter = Counter { value: 0 }
 let label = describe(counter)
 ```
 
-A generic parameter without a bound accepts any type, and methods on `T` can still be called — the compiler resolves them against the concrete type at each instantiation. The bound is a constraint, not a capability switch: it rejects callers whose type does not implement the interface, turning what would otherwise be a failure deeper in monomorphization into a clear error at the call site.
+A generic parameter without a bound (`fun identity<T>(value: T) -> T`) accepts any type; the bound is a constraint on what callers may pass.
 
 ### Dynamic vs. static dispatch
 

--- a/website/docs/language/interfaces.md
+++ b/website/docs/language/interfaces.md
@@ -30,6 +30,17 @@ impl Counter {
 
 `Counter` now satisfies `Stringer`. Nothing else is required.
 
+### Stringer and `$"..."` interpolation
+
+Any type that satisfies `Stringer` can be dropped straight into a string-interpolation placeholder. Each `{}` calls `to_string` on its argument:
+
+```rust
+let c = Counter { value: 7 }
+println($"counter = {c}")
+```
+
+Giving a type `fun to_string(self) -> String` is all you need to make it printable this way — no registration, no trait derivation.
+
 ## Generic bounds
 
 The most common use is as a bound on a generic type parameter. Inside the function body, only the methods declared on the interface are callable on the bound parameter.

--- a/website/docs/language/interfaces.md
+++ b/website/docs/language/interfaces.md
@@ -41,9 +41,61 @@ println($"counter = {c}")
 
 Giving a type `fun to_string(self) -> String` is all you need to make it printable this way — no registration, no trait derivation.
 
+## Interface values
+
+An interface can be used directly as a type — as a parameter, return type, local, or element type inside a container like `Vector<I>`. The value carries its concrete type along with it, and each method call looks up the matching implementation at runtime.
+
+```rust
+interface Scorer {
+    fun score(self) -> i32
+}
+
+struct Alpha {
+    n: i32,
+}
+
+struct Beta {
+    n: i32,
+}
+
+impl Alpha {
+    fun score(self) -> i32 {
+        return self.n + 10
+    }
+}
+
+impl Beta {
+    fun score(self) -> i32 {
+        return self.n * 2
+    }
+}
+
+fun run(s: Scorer) -> i32 {
+    return s.score()
+}
+
+fun main() -> i32 {
+    let a = Alpha { n: 40 }
+    let b = Beta { n: 4 }
+    return run(a) + run(b)
+}
+```
+
+Both `Alpha` and `Beta` satisfy `Scorer`, and `run` dispatches to the right `score` for each concrete type.
+
+The same works for heterogeneous collections:
+
+```rust
+let mut items = Vector<Scorer>::new()
+items.push(Alpha { n: 40 })
+items.push(Beta { n: 4 })
+```
+
+Each element remembers the concrete type it was built from, and calling `.score()` on an element picks the matching implementation.
+
 ## Generic bounds
 
-The most common use is as a bound on a generic type parameter. Inside the function body, only the methods declared on the interface are callable on the bound parameter.
+An interface can also be used as a bound on a generic type parameter. Inside the function body, only the methods declared on the interface are callable on the bound parameter.
 
 ```rust
 interface Stringer {
@@ -63,6 +115,15 @@ let label = describe(counter)
 ```
 
 A generic parameter without a bound (`fun identity<T>(value: T) -> T`) accepts any type but cannot call any methods on it.
+
+### Values vs. bounds
+
+Both forms share the same conformance rule — the method set must match — but they differ in where dispatch happens:
+
+- `fun f(s: Scorer)` (interface value): one function body, dynamic dispatch per method call. Different concrete types can flow through the same variable at runtime.
+- `fun f<S: Scorer>(s: S)` (generic bound): one specialization per concrete `S`, static dispatch. No runtime lookup, but each call site fixes a single concrete type.
+
+Reach for an interface value when the concrete type can vary at runtime (heterogeneous containers, plug-in style APIs). Reach for a generic bound when each caller has a single concrete type and you want the compiler to monomorphize.
 
 ## Standard-library interfaces
 

--- a/website/docs/language/interfaces.md
+++ b/website/docs/language/interfaces.md
@@ -41,9 +41,9 @@ println($"counter = {c}")
 
 Giving a type `fun to_string(self) -> String` is all you need to make it printable this way — no registration, no trait derivation.
 
-## Dynamic dispatch
+## Interface values
 
-An interface name can be used directly as a type — as a parameter, return type, local, or element type inside a container like `Vector<I>`. A value held through an interface type carries its concrete type along with it, and each method call is resolved at runtime against that concrete type. This is **dynamic dispatch**.
+An interface name can be used directly as a type — as a parameter, return type, local, or element type inside a container like `Vector<I>`. A value held through an interface type (an **interface value**) carries its concrete type along with it, and each method call is resolved at runtime against that concrete type.
 
 ```rust
 interface Scorer {
@@ -120,10 +120,10 @@ A generic parameter without a bound (`fun identity<T>(value: T) -> T`) accepts a
 
 Both forms share the same conformance rule — the method set must match — but they differ in how method calls are resolved:
 
-- `fun f(s: Scorer)` — **dynamic dispatch**. One function body, the method is looked up at runtime against the value's concrete type. Different concrete types can flow through the same variable.
-- `fun f<S: Scorer>(s: S)` — **static dispatch**. One specialization per concrete `S`, the call is resolved at compile time. No runtime lookup, but each call site fixes a single concrete type.
+- **Interface values** (`fun f(s: Scorer)`) use **dynamic dispatch**. One function body, and the method is looked up at runtime against the value's concrete type. Different concrete types can flow through the same variable.
+- **Generic bounds** (`fun f<S: Scorer>(s: S)`) use **static dispatch**. One specialization per concrete `S`, resolved at compile time. No runtime lookup, but each call site fixes a single concrete type.
 
-Reach for dynamic dispatch when the concrete type can vary at runtime (heterogeneous containers, plug-in style APIs). Reach for a generic bound when each caller has a single concrete type and you want the compiler to monomorphize.
+Reach for an interface value when the concrete type can vary at runtime (heterogeneous containers, plug-in style APIs). Reach for a generic bound when each caller has a single concrete type and you want the compiler to monomorphize.
 
 ## Standard-library interfaces
 

--- a/website/docs/language/overview.md
+++ b/website/docs/language/overview.md
@@ -103,6 +103,7 @@ Continue with:
 
 - [Types](./types.md)
 - [Generics](./generics.md)
+- [Interfaces](./interfaces.md)
 - [Control flow](./control-flow.md)
 - [Concurrency](./concurrency.md)
 - [Rust interop](./rust-interop.md)

--- a/website/docs/language/rust-interop.md
+++ b/website/docs/language/rust-interop.md
@@ -1,7 +1,7 @@
 ---
 title: Rust interop
 description: Import Rust crates into Kaede and scaffold a mixed-language project.
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # Rust interop


### PR DESCRIPTION
Closes #219.

Closes the docs and end-to-end test gaps for the Reader/Writer interface work landed in #240/#244.

## Summary

- **New page**: `website/docs/language/interfaces.md` covering implicit conformance, generic bounds (`<T: Interface>`), and the four stdlib interfaces (`Reader`, `Writer`, `Stringer`, `Payload`).
- **Sidebar shift**: control-flow / concurrency / rust-interop move from positions 7/8/9 to 8/9/10 to make room for Interfaces at position 7. Overview's "see also" list now links the new page.
- **Two end-to-end codegen tests** confirming user-defined types satisfying the stdlib interfaces are accepted at runtime by the stdlib generic helpers — not just by the compiler:
  - `user_defined_reader_flows_through_stdlib_read_exact`: a custom `ByteSource` with a `read` method is consumed by `std.sys.read_exact`.
  - `user_defined_writer_flows_through_stdlib_http_helper`: a custom `AcceptAll` with a `write` method is consumed by `std.http.write_status_line`.

Together with the already-landed parser/semantic/IR/codegen work and the `Reader`/`Writer`/`Stringer`/`Payload` stdlib adoption, this closes out the Go-style interface feature described in #219, including the doc follow-ups raised in that issue's comments (Stringer and generic bounds).

## Test plan

- [x] `cargo fmt`
- [x] `cargo test --release` — all tests pass (245 codegen tests, including the 2 new e2e tests)
- [x] `npx docusaurus build` (in `website/`) — builds clean

## Related

- #240, #244 (the Reader/Writer interface work and stdlib generalization being documented here)