### PR TITLE
feat(lang): add f32/f64 fundamental floating-point types

### DIFF
--- a/compiler/ast/src/expr.rs
+++ b/compiler/ast/src/expr.rs
@@ -117,6 +117,33 @@ impl Int {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct Float {
+    pub kind: FloatKind,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
+/// Float literals are always non-negative.
+/// Negative numbers like `-3.14` are represented as unary minus applied to `3.14`.
+/// Type suffixes are not yet supported; all literals have inferred types.
+pub enum FloatKind {
+    /// Float literal with inferred type (defaults to f64 if unconstrained)
+    Unsuffixed(f64),
+}
+
+impl Float {
+    pub fn as_f64(&self) -> f64 {
+        let FloatKind::Unsuffixed(n) = self.kind;
+        n
+    }
+
+    pub fn get_type(&self) -> Ty {
+        // Unsuffixed float literals default to f64 if unconstrained
+        make_fundamental_type(FundamentalTypeKind::F64, Mutability::Not, self.span)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub enum BinaryKind {
     // Addition
@@ -346,6 +373,7 @@ impl Expr {
 #[derive(Debug, Clone)]
 pub enum ExprKind {
     Int(Int),
+    Float(Float),
     StringLiteral(StringLiteral),
     ByteStringLiteral(ByteStringLiteral),
     ByteLiteral(ByteLiteral),

--- a/compiler/ast_type/src/lib.rs
+++ b/compiler/ast_type/src/lib.rs
@@ -165,9 +165,17 @@ pub enum FundamentalTypeKind {
     U32,
     I64,
     U64,
+    F32,
+    F64,
     Char,
     Bool,
     Str,
+}
+
+impl FundamentalTypeKind {
+    pub fn is_float(&self) -> bool {
+        matches!(self, FundamentalTypeKind::F32 | FundamentalTypeKind::F64)
+    }
 }
 
 impl std::fmt::Display for FundamentalTypeKind {
@@ -183,6 +191,8 @@ impl std::fmt::Display for FundamentalTypeKind {
             U32 => write!(f, "u32"),
             I64 => write!(f, "i64"),
             U64 => write!(f, "u64"),
+            F32 => write!(f, "f32"),
+            F64 => write!(f, "f64"),
             Char => write!(f, "char"),
             Bool => write!(f, "bool"),
             Str => write!(f, "str"),
@@ -352,6 +362,8 @@ impl FundamentalType {
             U32 => context.i32_type().as_basic_type_enum(),
             I64 => context.i64_type().as_basic_type_enum(),
             U64 => context.i64_type().as_basic_type_enum(),
+            F32 => context.f32_type().as_basic_type_enum(),
+            F64 => context.f64_type().as_basic_type_enum(),
             Char => context.i8_type().as_basic_type_enum(),
             Bool => context.bool_type().as_basic_type_enum(),
             Str => {
@@ -371,6 +383,7 @@ impl FundamentalType {
         match self.kind {
             I8 | I16 | I32 | I64 => true,
             U8 | U16 | U32 | U64 => false,
+            F32 | F64 => true,
             Char => true,
             Bool => false,
             Str => false,
@@ -382,6 +395,7 @@ impl FundamentalType {
 
         match self.kind {
             I8 | U8 | I16 | U16 | I32 | U32 | I64 | U64 | Bool | Char => true,
+            F32 | F64 => false,
             Str => false,
         }
     }

--- a/compiler/codegen/src/error.rs
+++ b/compiler/codegen/src/error.rs
@@ -28,6 +28,9 @@ pub enum CodegenError {
     #[error("integer inference should have been resolved before codegen")]
     UnresolvedInferInt,
 
+    #[error("float inference should have been resolved before codegen")]
+    UnresolvedInferFloat,
+
     #[error("unknown callee: {}", name)]
     UnknownCallee { name: Symbol },
 

--- a/compiler/codegen/src/expr.rs
+++ b/compiler/codegen/src/expr.rs
@@ -8,17 +8,17 @@ use crate::{
 
 use inkwell::{
     module::Linkage,
-    types::{BasicType, StructType},
+    types::{BasicType, FloatType, StructType},
     values::{BasicValue, BasicValueEnum, FunctionValue, IntValue, PointerValue},
-    AddressSpace, IntPredicate,
+    AddressSpace, FloatPredicate, IntPredicate,
 };
 
 use kaede_ir::{
     expr::{
         ArrayLiteral, ArrayRepeat, Binary, BinaryKind, BitNot, BuiltinFnCall, BuiltinFnCallKind,
         ByteLiteral, ByteStringLiteral, Cast, CharLiteral, Closure, Else, EnumUnpack, EnumVariant,
-        Expr, ExprKind, FieldAccess, FnCall, FnPointer, FormatPart, ITable, If, Indexing, Int,
-        InterfaceBox, InterfaceMethodCall, LogicalNot, Loop, Slicing, Spawn, StringLiteral,
+        Expr, ExprKind, FieldAccess, Float, FnCall, FnPointer, FormatPart, ITable, If, Indexing,
+        Int, InterfaceBox, InterfaceMethodCall, LogicalNot, Loop, Slicing, Spawn, StringLiteral,
         StructLiteral, TupleIndexing, TupleLiteral, Variable,
     },
     stmt::Block,
@@ -30,6 +30,17 @@ use kaede_ir::{
 use kaede_symbol::Symbol;
 
 pub type Value<'ctx> = Option<BasicValueEnum<'ctx>>;
+
+fn float_bit_width(ty: &Ty) -> u32 {
+    match ty.kind.as_ref() {
+        TyKind::Fundamental(fty) => match fty.kind {
+            FundamentalTypeKind::F32 => 32,
+            FundamentalTypeKind::F64 => 64,
+            _ => 0,
+        },
+        _ => 0,
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 struct FormatArg<'ctx> {
@@ -133,6 +144,7 @@ impl<'ctx> CodeGenerator<'ctx> {
             ExprKind::Loop(loop_) => self.build_loop(loop_)?,
 
             ExprKind::Int(int) => self.build_int(int, &node.ty)?,
+            ExprKind::Float(float) => self.build_float(float, &node.ty)?,
 
             ExprKind::If(node) => self.build_if(node)?,
 
@@ -727,6 +739,31 @@ impl<'ctx> CodeGenerator<'ctx> {
                         .into(),
                 )),
                 _ => Err(CodegenError::UnresolvedInferInt.into()),
+            },
+        }
+    }
+
+    fn build_float(&self, float: &Float, ty: &Rc<Ty>) -> anyhow::Result<Value<'ctx>> {
+        use kaede_ir::expr::FloatKind::*;
+
+        match float.kind {
+            F32(n) => Ok(Some(self.context().f32_type().const_float(n as f64).into())),
+            F64(n) => Ok(Some(self.context().f64_type().const_float(n).into())),
+            Infer(n) => match ty.kind.as_ref() {
+                TyKind::Fundamental(fty) => match fty.kind {
+                    FundamentalTypeKind::F32 => Ok(Some(
+                        self.context()
+                            .f32_type()
+                            .const_float(n as f32 as f64)
+                            .into(),
+                    )),
+                    FundamentalTypeKind::F64 => {
+                        Ok(Some(self.context().f64_type().const_float(n).into()))
+                    }
+                    _ => Err(CodegenError::UnresolvedInferFloat.into()),
+                },
+                TyKind::Var(_) => Ok(Some(self.context().f64_type().const_float(n).into())),
+                _ => Err(CodegenError::UnresolvedInferFloat.into()),
             },
         }
     }
@@ -1759,7 +1796,9 @@ impl<'ctx> CodeGenerator<'ctx> {
         let value_ty = node.operand.ty.clone();
         let target_ty = node.target_ty.clone();
 
-        if value_ty.kind.is_int_or_bool() && target_ty.kind.is_int_or_bool() {
+        if value_ty.kind.is_float() || target_ty.kind.is_float() {
+            self.build_float_cast(value, &value_ty, target_ty.clone())
+        } else if value_ty.kind.is_int_or_bool() && target_ty.kind.is_int_or_bool() {
             self.build_int_cast(value, target_ty.clone())
         } else if matches!(
             value_ty.kind.as_ref(),
@@ -1776,6 +1815,67 @@ impl<'ctx> CodeGenerator<'ctx> {
                 target_ty.kind.to_string()
             );
         }
+    }
+
+    fn build_float_cast(
+        &mut self,
+        value: BasicValueEnum<'ctx>,
+        value_ty: &Rc<Ty>,
+        target_ty: Rc<Ty>,
+    ) -> anyhow::Result<Value<'ctx>> {
+        let target_llvm_ty = self.conv_to_llvm_type(&target_ty);
+
+        if value_ty.kind.is_float() && target_ty.kind.is_float() {
+            // float -> float: extend or truncate based on bit width.
+            let src = value.into_float_value();
+            let dst_ty: FloatType<'ctx> = target_llvm_ty.into_float_type();
+            let widening = float_bit_width(value_ty) < float_bit_width(&target_ty);
+            return Ok(Some(if widening {
+                self.builder
+                    .build_float_ext(src, dst_ty, "")?
+                    .as_basic_value_enum()
+            } else {
+                self.builder
+                    .build_float_trunc(src, dst_ty, "")?
+                    .as_basic_value_enum()
+            }));
+        }
+
+        if value_ty.kind.is_int_or_bool() && target_ty.kind.is_float() {
+            // int -> float
+            let src = value.into_int_value();
+            let dst_ty: FloatType<'ctx> = target_llvm_ty.into_float_type();
+            return Ok(Some(if value_ty.kind.is_signed() {
+                self.builder
+                    .build_signed_int_to_float(src, dst_ty, "")?
+                    .as_basic_value_enum()
+            } else {
+                self.builder
+                    .build_unsigned_int_to_float(src, dst_ty, "")?
+                    .as_basic_value_enum()
+            }));
+        }
+
+        if value_ty.kind.is_float() && target_ty.kind.is_int_or_bool() {
+            // float -> int
+            let src = value.into_float_value();
+            let dst_ty = target_llvm_ty.into_int_type();
+            return Ok(Some(if target_ty.kind.is_signed() {
+                self.builder
+                    .build_float_to_signed_int(src, dst_ty, "")?
+                    .as_basic_value_enum()
+            } else {
+                self.builder
+                    .build_float_to_unsigned_int(src, dst_ty, "")?
+                    .as_basic_value_enum()
+            }));
+        }
+
+        anyhow::bail!(
+            "unsupported cast from `{}` to `{}`",
+            value_ty.kind.to_string(),
+            target_ty.kind.to_string()
+        );
     }
 
     fn build_int_cast(
@@ -2089,6 +2189,14 @@ impl<'ctx> CodeGenerator<'ctx> {
             });
         }
 
+        if left_ty.kind.is_float() && right_ty.kind.is_float() {
+            return self.build_float_arithmetic_binary(
+                node.kind,
+                left.into_float_value(),
+                right.into_float_value(),
+            );
+        }
+
         // If operands are not int
         if !(left.is_int_value() && right.is_int_value()) {
             anyhow::bail!(
@@ -2231,6 +2339,58 @@ impl<'ctx> CodeGenerator<'ctx> {
                             .into(),
                     )
                 }
+            }
+        })
+    }
+
+    fn build_float_arithmetic_binary(
+        &mut self,
+        op: BinaryKind,
+        left: inkwell::values::FloatValue<'ctx>,
+        right: inkwell::values::FloatValue<'ctx>,
+    ) -> anyhow::Result<Value<'ctx>> {
+        use BinaryKind::*;
+
+        Ok(match op {
+            Add => Some(self.builder.build_float_add(left, right, "")?.into()),
+            Sub => Some(self.builder.build_float_sub(left, right, "")?.into()),
+            Mul => Some(self.builder.build_float_mul(left, right, "")?.into()),
+            Div => Some(self.builder.build_float_div(left, right, "")?.into()),
+            Rem => Some(self.builder.build_float_rem(left, right, "")?.into()),
+
+            Eq => Some(
+                self.builder
+                    .build_float_compare(FloatPredicate::OEQ, left, right, "")?
+                    .into(),
+            ),
+            Ne => Some(
+                self.builder
+                    .build_float_compare(FloatPredicate::ONE, left, right, "")?
+                    .into(),
+            ),
+            Lt => Some(
+                self.builder
+                    .build_float_compare(FloatPredicate::OLT, left, right, "")?
+                    .into(),
+            ),
+            Le => Some(
+                self.builder
+                    .build_float_compare(FloatPredicate::OLE, left, right, "")?
+                    .into(),
+            ),
+            Gt => Some(
+                self.builder
+                    .build_float_compare(FloatPredicate::OGT, left, right, "")?
+                    .into(),
+            ),
+            Ge => Some(
+                self.builder
+                    .build_float_compare(FloatPredicate::OGE, left, right, "")?
+                    .into(),
+            ),
+
+            LogicalOr | LogicalAnd | BitAnd | BitOr | BitXor | Shl | Shr => {
+                anyhow::bail!("unsupported operation for float type: {:?}", op);
             }
         })
     }

--- a/compiler/codegen/src/expr.rs
+++ b/compiler/codegen/src/expr.rs
@@ -1008,7 +1008,7 @@ impl<'ctx> CodeGenerator<'ctx> {
         }
 
         // Sort in ascending order based on offset
-        values.sort_by(|a, b| a.0.cmp(&b.0));
+        values.sort_by_key(|a| a.0);
         let values: Vec<_> = values.iter().map(|e| e.1).collect();
 
         let value = self.create_gc_struct(struct_llvm_ty.as_basic_type_enum(), &values)?;

--- a/compiler/codegen/src/expr.rs
+++ b/compiler/codegen/src/expr.rs
@@ -31,17 +31,6 @@ use kaede_symbol::Symbol;
 
 pub type Value<'ctx> = Option<BasicValueEnum<'ctx>>;
 
-fn float_bit_width(ty: &Ty) -> u32 {
-    match ty.kind.as_ref() {
-        TyKind::Fundamental(fty) => match fty.kind {
-            FundamentalTypeKind::F32 => 32,
-            FundamentalTypeKind::F64 => 64,
-            _ => 0,
-        },
-        _ => 0,
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 struct FormatArg<'ctx> {
     ptr: PointerValue<'ctx>,
@@ -751,12 +740,9 @@ impl<'ctx> CodeGenerator<'ctx> {
             F64(n) => Ok(Some(self.context().f64_type().const_float(n).into())),
             Infer(n) => match ty.kind.as_ref() {
                 TyKind::Fundamental(fty) => match fty.kind {
-                    FundamentalTypeKind::F32 => Ok(Some(
-                        self.context()
-                            .f32_type()
-                            .const_float(n as f32 as f64)
-                            .into(),
-                    )),
+                    FundamentalTypeKind::F32 => {
+                        Ok(Some(self.context().f32_type().const_float(n).into()))
+                    }
                     FundamentalTypeKind::F64 => {
                         Ok(Some(self.context().f64_type().const_float(n).into()))
                     }
@@ -1829,7 +1815,8 @@ impl<'ctx> CodeGenerator<'ctx> {
             // float -> float: extend or truncate based on bit width.
             let src = value.into_float_value();
             let dst_ty: FloatType<'ctx> = target_llvm_ty.into_float_type();
-            let widening = float_bit_width(value_ty) < float_bit_width(&target_ty);
+            // Both sides are floats (gated above), so `float_bit_width` is `Some`.
+            let widening = value_ty.kind.float_bit_width() < target_ty.kind.float_bit_width();
             return Ok(Some(if widening {
                 self.builder
                     .build_float_ext(src, dst_ty, "")?

--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -5319,3 +5319,98 @@ fn generic_method_rejects_unsatisfied_bound() {
         SemanticError::GenericBoundNotSatisfied { .. }
     ));
 }
+
+#[test]
+fn float_add() -> anyhow::Result<()> {
+    assert_eq!(exec("fun main() -> i32 { return (3.5 + 1.5) as i32 }")?, 5,);
+    Ok(())
+}
+
+#[test]
+fn float_sub_mul_div_rem() -> anyhow::Result<()> {
+    assert_eq!(exec("fun main() -> i32 { return (10.0 - 4.5) as i32 }")?, 5,);
+    assert_eq!(exec("fun main() -> i32 { return (2.5 * 4.0) as i32 }")?, 10,);
+    assert_eq!(exec("fun main() -> i32 { return (9.0 / 3.0) as i32 }")?, 3,);
+    assert_eq!(exec("fun main() -> i32 { return (10.0 % 3.0) as i32 }")?, 1,);
+    Ok(())
+}
+
+#[test]
+fn float_compare() -> anyhow::Result<()> {
+    // `if cond { return X } else { return Y }` hits an unrelated cont_bb
+    // terminator bug, so we use a mutable flag instead.
+    let cmp = |op: &str, lhs: &str, rhs: &str| {
+        format!(
+            "fun main() -> i32 {{\n    mut r := 0\n    if {lhs} {op} {rhs} {{ r = 1 }}\n    return r\n}}"
+        )
+    };
+    assert_eq!(exec(&cmp("<", "3.14", "3.15"))?, 1);
+    assert_eq!(exec(&cmp("==", "3.14", "3.14"))?, 1);
+    assert_eq!(exec(&cmp("!=", "3.14", "3.15"))?, 1);
+    assert_eq!(exec(&cmp(">", "3.15", "3.14"))?, 1);
+    assert_eq!(exec(&cmp("<=", "3.14", "3.14"))?, 1);
+    assert_eq!(exec(&cmp(">=", "3.14", "3.14"))?, 1);
+    assert_eq!(exec(&cmp(">", "3.14", "3.15"))?, 0);
+    assert_eq!(exec(&cmp("==", "3.14", "3.15"))?, 0);
+    Ok(())
+}
+
+#[test]
+fn float_unary_minus() -> anyhow::Result<()> {
+    // `-3.14` is parser-desugared to `0.0 - 3.14`; the zero literal must be
+    // typed to match the operand or type inference fails.
+    assert_eq!(
+        exec("fun main() -> i32 { let x: f64 = -3.14; return (x * -1.0) as i32 }")?,
+        3,
+    );
+    Ok(())
+}
+
+#[test]
+fn float_default_to_f64() -> anyhow::Result<()> {
+    assert_eq!(
+        exec("fun main() -> i32 { x := 1.5 + 2.5; return x as i32 }")?,
+        4,
+    );
+    Ok(())
+}
+
+#[test]
+fn cast_int_to_float_to_int() -> anyhow::Result<()> {
+    assert_eq!(
+        exec("fun main() -> i32 { let x: f64 = 7 as f64; return (x / 2.0) as i32 }")?,
+        3,
+    );
+    Ok(())
+}
+
+#[test]
+fn f32_to_f64_widening() -> anyhow::Result<()> {
+    assert_eq!(
+        exec("fun main() -> i32 { let x: f32 = 1.5; let y: f64 = x as f64; return (y * 4.0) as i32 }")?,
+        6,
+    );
+    Ok(())
+}
+
+#[test]
+fn f64_to_f32_truncation() -> anyhow::Result<()> {
+    assert_eq!(
+        exec("fun main() -> i32 { let x: f64 = 1.5; let y: f32 = x as f32; return (y * 4.0) as i32 }")?,
+        6,
+    );
+    Ok(())
+}
+
+#[test]
+fn float_to_string_round_trip() -> anyhow::Result<()> {
+    let program = r#"fun main() -> i32 {
+        let v: f64 = 3.14
+        if v.to_string().as_str() == "3.14" {
+            return 1
+        }
+        return 0
+    }"#;
+    assert_eq!(exec(program)?, 1);
+    Ok(())
+}

--- a/compiler/ir/src/expr.rs
+++ b/compiler/ir/src/expr.rs
@@ -105,6 +105,32 @@ impl Int {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct Float {
+    pub kind: FloatKind,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub enum FloatKind {
+    F32(f32),
+    F64(f64),
+    /// Float literal with inferred type (value stored as f64)
+    Infer(f64),
+}
+
+impl Float {
+    pub fn as_f64(&self) -> f64 {
+        use FloatKind::*;
+
+        match self.kind {
+            F32(n) => n as f64,
+            F64(n) => n,
+            Infer(n) => n,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub enum BinaryKind {
     // Addition
@@ -346,6 +372,7 @@ pub struct InterfaceMethodCall {
 #[derive(Debug, Clone)]
 pub enum ExprKind {
     Int(Int),
+    Float(Float),
     StringLiteral(StringLiteral),
     ByteStringLiteral(ByteStringLiteral),
     ByteLiteral(ByteLiteral),

--- a/compiler/ir/src/ty.rs
+++ b/compiler/ir/src/ty.rs
@@ -335,6 +335,8 @@ pub enum FundamentalTypeKind {
     U32,
     I64,
     U64,
+    F32,
+    F64,
     Bool,
     Str,
     Char,
@@ -353,6 +355,9 @@ impl std::fmt::Display for FundamentalTypeKind {
             U32 => write!(f, "u32"),
             I64 => write!(f, "i64"),
             U64 => write!(f, "u64"),
+
+            F32 => write!(f, "f32"),
+            F64 => write!(f, "f64"),
 
             Bool => write!(f, "bool"),
             Str => write!(f, "str"),
@@ -376,10 +381,17 @@ impl FundamentalTypeKind {
             | FundamentalTypeKind::U64 => true,
 
             // Non-integer types
-            FundamentalTypeKind::Bool | FundamentalTypeKind::Str | FundamentalTypeKind::Char => {
-                false
-            }
+            FundamentalTypeKind::F32
+            | FundamentalTypeKind::F64
+            | FundamentalTypeKind::Bool
+            | FundamentalTypeKind::Str
+            | FundamentalTypeKind::Char => false,
         }
+    }
+
+    /// Returns true if this type is a floating-point type
+    pub fn is_float(&self) -> bool {
+        matches!(self, FundamentalTypeKind::F32 | FundamentalTypeKind::F64)
     }
 }
 
@@ -594,6 +606,24 @@ impl TyKind {
             Self::Var(_) => unreachable!(),
         }
     }
+
+    pub fn is_float(&self) -> bool {
+        match &self {
+            Self::Fundamental(fty) => fty.kind.is_float(),
+            Self::Reference(ty) => ty.refee_ty.kind.is_float(),
+
+            Self::UserDefined(_)
+            | Self::Closure(_)
+            | Self::Array(_)
+            | Self::Slice(_)
+            | Self::Tuple(_)
+            | Self::Pointer(_)
+            | Self::Unit
+            | Self::Never => false,
+
+            Self::Var(_) => false,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
@@ -647,6 +677,8 @@ impl FundamentalType {
             U32 => context.i32_type().as_basic_type_enum(),
             I64 => context.i64_type().as_basic_type_enum(),
             U64 => context.i64_type().as_basic_type_enum(),
+            F32 => context.f32_type().as_basic_type_enum(),
+            F64 => context.f64_type().as_basic_type_enum(),
             Char => context.i32_type().as_basic_type_enum(),
             Bool => context.bool_type().as_basic_type_enum(),
             Str => Self::create_llvm_str_type(context),
@@ -659,6 +691,7 @@ impl FundamentalType {
         match self.kind {
             I8 | I16 | I32 | I64 => true,
             U8 | U16 | U32 | U64 => false,
+            F32 | F64 => true,
             Bool => false,
             Str => false,
             Char => false,
@@ -670,6 +703,7 @@ impl FundamentalType {
 
         match self.kind {
             I8 | U8 | I16 | U16 | I32 | U32 | I64 | U64 | Bool | Char => true,
+            F32 | F64 => false,
             Str => false,
         }
     }
@@ -679,6 +713,7 @@ impl FundamentalType {
 
         match self.kind {
             I8 | U8 | I16 | U16 | I32 | U32 | I64 | U64 | Char => true,
+            F32 | F64 => true,
             Bool => true,
             Str => false,
         }

--- a/compiler/ir/src/ty.rs
+++ b/compiler/ir/src/ty.rs
@@ -396,6 +396,15 @@ impl FundamentalTypeKind {
     pub fn is_float(&self) -> bool {
         matches!(self, FundamentalTypeKind::F32 | FundamentalTypeKind::F64)
     }
+
+    /// Bit width of this floating-point type, or `None` for non-floats.
+    pub fn float_bit_width(&self) -> Option<u32> {
+        match self {
+            FundamentalTypeKind::F32 => Some(32),
+            FundamentalTypeKind::F64 => Some(64),
+            _ => None,
+        }
+    }
 }
 
 pub fn make_fundamental_type(kind: FundamentalTypeKind, mutability: Mutability) -> Ty {
@@ -625,6 +634,15 @@ impl TyKind {
             | Self::Never => false,
 
             Self::Var(_) => false,
+        }
+    }
+
+    /// Bit width of this floating-point type, or `None` for non-floats.
+    pub fn float_bit_width(&self) -> Option<u32> {
+        match self {
+            Self::Fundamental(fty) => fty.kind.float_bit_width(),
+            Self::Reference(ty) => ty.refee_ty.kind.float_bit_width(),
+            _ => None,
         }
     }
 }

--- a/compiler/lex/src/cursor.rs
+++ b/compiler/lex/src/cursor.rs
@@ -7,6 +7,10 @@ pub const EOF_CHAR: char = '\0';
 pub struct Cursor<'a> {
     chars: Chars<'a>,
     pub span_builder: SpanBuilder,
+    /// Set when the most recently emitted significant token was `Dot`. Used
+    /// by `number()` to suppress float-literal lexing in tuple-index chains
+    /// like `tup.0.1`.
+    pub(crate) prev_was_dot: bool,
 }
 
 impl<'a> Cursor<'a> {
@@ -14,6 +18,7 @@ impl<'a> Cursor<'a> {
         Self {
             chars: input.chars(),
             span_builder: SpanBuilder::new(file),
+            prev_was_dot: false,
         }
     }
 

--- a/compiler/lex/src/lib.rs
+++ b/compiler/lex/src/lib.rs
@@ -32,6 +32,7 @@ impl<'a> Lexer<'a> {
 
         loop {
             let token = cursor.advance_token();
+            cursor.prev_was_dot = matches!(token.kind, TokenKind::Dot);
 
             match token.kind {
                 TokenKind::Eoi => {
@@ -134,8 +135,12 @@ impl Cursor<'_> {
 
             // Number
             c @ '0'..='9' => {
-                let n = self.number(c);
-                self.create_token(TokenKind::Int(n))
+                let (n, is_float) = self.number(c);
+                if is_float {
+                    self.create_token(TokenKind::Float(n))
+                } else {
+                    self.create_token(TokenKind::Int(n))
+                }
             }
 
             // Byte string literal or byte literal
@@ -519,7 +524,7 @@ impl Cursor<'_> {
         result
     }
 
-    fn number(&mut self, first_digit: char) -> String {
+    fn number(&mut self, first_digit: char) -> (String, bool) {
         assert!(first_digit.is_ascii_digit());
 
         let mut result = first_digit.to_string();
@@ -534,7 +539,7 @@ impl Cursor<'_> {
                     result.push(c);
                     self.bump().unwrap();
                 } else {
-                    return result;
+                    return (result, false);
                 }
             }
         }
@@ -546,9 +551,29 @@ impl Cursor<'_> {
                 result.push(c);
                 self.bump().unwrap();
             } else {
-                return result;
+                break;
             }
         }
+
+        // Optional fractional part: only consume the '.' if a digit follows it
+        // and we are not in a tuple-index chain (e.g. `tup.0.1`). The
+        // `prev_was_dot` flag is set by the outer loop after emitting a Dot
+        // token. This also preserves method-call tokenization like `1.foo()`.
+        if !self.prev_was_dot && self.first() == '.' && self.second().is_ascii_digit() {
+            result.push(self.bump().unwrap()); // '.'
+            loop {
+                let c = self.first();
+                if c.is_ascii_digit() {
+                    result.push(c);
+                    self.bump().unwrap();
+                } else {
+                    break;
+                }
+            }
+            return (result, true);
+        }
+
+        (result, false)
     }
 
     fn ident(&mut self, first: char) -> String {

--- a/compiler/lex/src/semi.rs
+++ b/compiler/lex/src/semi.rs
@@ -45,6 +45,7 @@ fn is_semi_insertable(token: &TokenKind) -> bool {
     matches!(
         token,
         Int(_)
+            | Float(_)
             | Ident(_)
             | Self_
             | StringLiteral(_)

--- a/compiler/lex/src/tests.rs
+++ b/compiler/lex/src/tests.rs
@@ -38,6 +38,72 @@ fn hex_number() {
 }
 
 #[test]
+fn float_literal() {
+    lex_test("3.14", vec![Float("3.14".to_string()), Semi, Eoi]);
+}
+
+#[test]
+fn multi_floats() {
+    lex_test(
+        "1.5 2.0 0.125",
+        vec![
+            Float("1.5".to_string()),
+            Float("2.0".to_string()),
+            Float("0.125".to_string()),
+            Semi,
+            Eoi,
+        ],
+    );
+}
+
+#[test]
+fn int_dot_ident_is_method_call() {
+    // `1.foo` must remain `Int Dot Ident` so method calls on integer literals
+    // keep tokenizing correctly.
+    lex_test(
+        "1.foo",
+        vec![
+            Int("1".to_string()),
+            Dot,
+            Ident("foo".to_string()),
+            Semi,
+            Eoi,
+        ],
+    );
+}
+
+#[test]
+fn tuple_index_chain_is_not_float() {
+    // `tup.0.1` must tokenize as `Ident Dot Int Dot Int`, not `Ident Dot Float`.
+    lex_test(
+        "tup.0.1",
+        vec![
+            Ident("tup".to_string()),
+            Dot,
+            Int("0".to_string()),
+            Dot,
+            Int("1".to_string()),
+            Semi,
+            Eoi,
+        ],
+    );
+}
+
+#[test]
+fn hex_does_not_become_float() {
+    lex_test(
+        "0x80.5",
+        vec![
+            Int("0x80".to_string()),
+            Dot,
+            Int("5".to_string()),
+            Semi,
+            Eoi,
+        ],
+    );
+}
+
+#[test]
 fn skip_whitespaces() {
     lex_test("  \n  ", vec![Eoi]);
 

--- a/compiler/lex/src/token.rs
+++ b/compiler/lex/src/token.rs
@@ -9,6 +9,7 @@ pub struct Token {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TokenKind {
     Int(String),
+    Float(String),
     Ident(String),
     StringLiteral(String),
     ByteStringLiteral(Vec<u8>),
@@ -174,6 +175,7 @@ impl std::fmt::Display for TokenKind {
             "{}",
             match self {
                 Int(_) => "integer",
+                Float(_) => "float",
                 Ident(_) => "identifier",
                 StringLiteral(_) => "string literal",
                 ByteStringLiteral(_) => "byte string literal",

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -241,6 +241,7 @@ fn parse_error_span(err: &ParseError) -> Option<Span> {
         ParseError::ExpectedError { span, .. }
         | ParseError::OutOfRangeForI32(span)
         | ParseError::OutOfRangeForU32(span)
+        | ParseError::InvalidFloatLiteral(span)
         | ParseError::UnsupportedForeignUse { span } => Some(*span),
     }
 }
@@ -336,6 +337,7 @@ fn type_infer_error_span(err: &TypeInferError) -> Option<Span> {
         | TypeInferError::CannotInferVariableType { span }
         | TypeInferError::CannotInferGenericArguments { span, .. }
         | TypeInferError::InvalidIntegerLiteralType { span, .. }
+        | TypeInferError::InvalidFloatLiteralType { span, .. }
         | TypeInferError::ExpectedIntegerTypeForBitOp { span, .. }
         | TypeInferError::ExpectedIntegerTypeForBitNot { span, .. }
         | TypeInferError::EnumEqRequiresUnitVariants { span, .. }

--- a/compiler/monomorphize/src/lib.rs
+++ b/compiler/monomorphize/src/lib.rs
@@ -158,6 +158,7 @@ mod tests {
                     || call.args.0.iter().any(contains_generic_call)
             }
             ExprKind::Int(_)
+            | ExprKind::Float(_)
             | ExprKind::StringLiteral(_)
             | ExprKind::ByteStringLiteral(_)
             | ExprKind::ByteLiteral(_)
@@ -526,6 +527,7 @@ impl Monomorphizer {
                 }
             }
             ExprKind::Int(_)
+            | ExprKind::Float(_)
             | ExprKind::StringLiteral(_)
             | ExprKind::ByteStringLiteral(_)
             | ExprKind::ByteLiteral(_)

--- a/compiler/parse/src/error.rs
+++ b/compiler/parse/src/error.rs
@@ -16,6 +16,9 @@ pub enum ParseError {
     #[error("{}:{}:{} Out of range for 'u32'", .0.file, .0.start.line, .0.start.column)]
     OutOfRangeForU32(Span),
 
+    #[error("{}:{}:{} Invalid float literal", .0.file, .0.start.line, .0.start.column)]
+    InvalidFloatLiteral(Span),
+
     #[error("{}:{}:{} `use rust::<crate>::...` is not supported yet", span.file, span.start.line, span.start.column)]
     UnsupportedForeignUse { span: Span },
 }

--- a/compiler/parse/src/expr.rs
+++ b/compiler/parse/src/expr.rs
@@ -2,9 +2,9 @@ use std::{collections::VecDeque, rc::Rc};
 
 use kaede_ast::expr::{
     Arg, Args, ArrayLiteral, ArrayRepeat, Binary, BinaryKind, BitNot, Break, ByteLiteral,
-    ByteStringLiteral, ChannelRecv, ChannelSend, CharLiteral, Closure, Else, Expr, ExprKind,
-    FnCall, If, Indexing, Int, IntKind, LogicalNot, Loop, Match, MatchArm, Return, Slicing, Spawn,
-    StringLiteral, StructLiteral, Try, TupleLiteral, While,
+    ByteStringLiteral, ChannelRecv, ChannelSend, CharLiteral, Closure, Else, Expr, ExprKind, Float,
+    FloatKind, FnCall, If, Indexing, Int, IntKind, LogicalNot, Loop, Match, MatchArm, Return,
+    Slicing, Spawn, StringLiteral, StructLiteral, Try, TupleLiteral, While,
 };
 use kaede_ast_type::{GenericArgs, Ty, TyKind};
 use kaede_lex::token::TokenKind;
@@ -13,7 +13,7 @@ use kaede_symbol::{Ident, Symbol};
 
 use crate::{
     error::{ParseError, ParseResult},
-    parse_int_literal_u64, Parser,
+    parse_float_literal_f64, parse_int_literal_u64, Parser,
 };
 
 impl Parser {
@@ -312,17 +312,26 @@ impl Parser {
         }
 
         if let Ok(span) = self.consume(&TokenKind::Minus) {
-            // Subtracting a number from 0 inverts the sign
+            // Subtracting a number from 0 inverts the sign.
+            // Pick the zero literal kind based on the operand so that float
+            // operands get a `Float(0.0)` zero (avoids an int/float type clash).
+            let e = self.cast()?;
+
             let zero = Expr {
-                kind: ExprKind::Int(Int {
-                    kind: IntKind::Unsuffixed(0),
-                    span,
-                }),
+                kind: if matches!(e.kind, ExprKind::Float(_)) {
+                    ExprKind::Float(Float {
+                        kind: FloatKind::Unsuffixed(0.0),
+                        span,
+                    })
+                } else {
+                    ExprKind::Int(Int {
+                        kind: IntKind::Unsuffixed(0),
+                        span,
+                    })
+                },
                 span,
             }
             .into();
-
-            let e = self.cast()?;
 
             return Ok(Expr {
                 span: self.new_span(span.start, e.span.finish),
@@ -591,6 +600,15 @@ impl Parser {
             return Ok(Expr {
                 span: int.span,
                 kind: ExprKind::Int(int),
+            });
+        }
+
+        // Float
+        if matches!(self.first().kind, TokenKind::Float(_)) {
+            let float = self.float()?;
+            return Ok(Expr {
+                span: float.span,
+                kind: ExprKind::Float(float),
             });
         }
 
@@ -1299,6 +1317,27 @@ impl Parser {
 
             _ => Err(ParseError::ExpectedError {
                 expected: "integer".to_string(),
+                but: token.kind.to_string(),
+                span: token.span,
+            }
+            .into()),
+        }
+    }
+
+    pub fn float(&mut self) -> ParseResult<Float> {
+        let token = self.bump().unwrap();
+
+        match token.kind {
+            TokenKind::Float(float_s) => match parse_float_literal_f64(&float_s) {
+                Some(n) => Ok(Float {
+                    kind: FloatKind::Unsuffixed(n),
+                    span: token.span,
+                }),
+                None => Err(ParseError::InvalidFloatLiteral(token.span).into()),
+            },
+
+            _ => Err(ParseError::ExpectedError {
+                expected: "float".to_string(),
                 but: token.kind.to_string(),
                 span: token.span,
             }

--- a/compiler/parse/src/lib.rs
+++ b/compiler/parse/src/lib.rs
@@ -231,3 +231,7 @@ pub(crate) fn parse_int_literal_u32(literal: &str) -> Option<u32> {
 
     Some(value as u32)
 }
+
+pub(crate) fn parse_float_literal_f64(literal: &str) -> Option<f64> {
+    literal.parse().ok().filter(|v: &f64| v.is_finite())
+}

--- a/compiler/parse/src/ty.rs
+++ b/compiler/parse/src/ty.rs
@@ -172,6 +172,8 @@ impl Parser {
             "u32" => make_fundamental_type(U32, Mutability::Not, span),
             "i64" => make_fundamental_type(I64, Mutability::Not, span),
             "u64" => make_fundamental_type(U64, Mutability::Not, span),
+            "f32" => make_fundamental_type(F32, Mutability::Not, span),
+            "f64" => make_fundamental_type(F64, Mutability::Not, span),
             "bool" => make_fundamental_type(Bool, Mutability::Not, span),
             "char" => make_fundamental_type(Char, Mutability::Not, span),
             "str" => wrap_in_reference(make_fundamental_type(Str, Mutability::Not, span)),

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -187,6 +187,7 @@ impl SemanticAnalyzer {
             ExprKind::ArrayLiteral(node) => self.analyze_array_literal(node, span),
             ExprKind::ArrayRepeat(node) => self.analyze_array_repeat(node, span),
             ExprKind::Int(node) => self.analyze_int(node),
+            ExprKind::Float(node) => self.analyze_float(node),
             ExprKind::True => self.analyze_boolean_literal(true, span),
             ExprKind::False => self.analyze_boolean_literal(false, span),
             ExprKind::Block(node) => self.analyze_block_expr(node),
@@ -2676,6 +2677,21 @@ impl SemanticAnalyzer {
             ty: self.infer_context.fresh(),
             kind: ir::expr::ExprKind::Int(ir::expr::Int {
                 kind: ir::expr::IntKind::Infer(n as i64),
+                span: node.span,
+            }),
+            span: node.span,
+        })
+    }
+
+    fn analyze_float(&mut self, node: &ast::expr::Float) -> anyhow::Result<ir::expr::Expr> {
+        // Float literals are always non-negative; negative is unary minus.
+        // Type can be inferred to f32 or f64 (defaults to f64 if unconstrained).
+        let ast::expr::FloatKind::Unsuffixed(n) = node.kind;
+
+        Ok(ir::expr::Expr {
+            ty: self.infer_context.fresh(),
+            kind: ir::expr::ExprKind::Float(ir::expr::Float {
+                kind: ir::expr::FloatKind::Infer(n),
                 span: node.span,
             }),
             span: node.span,

--- a/compiler/semantic/src/rust_import.rs
+++ b/compiler/semantic/src/rust_import.rs
@@ -76,6 +76,8 @@ fn fundamental_kind_from_rustdoc_primitive(name: &str) -> Option<ir_type::Fundam
         "u32" => Some(ir_type::FundamentalTypeKind::U32),
         "i64" => Some(ir_type::FundamentalTypeKind::I64),
         "u64" => Some(ir_type::FundamentalTypeKind::U64),
+        "f32" => Some(ir_type::FundamentalTypeKind::F32),
+        "f64" => Some(ir_type::FundamentalTypeKind::F64),
         "bool" => Some(ir_type::FundamentalTypeKind::Bool),
         _ => None,
     }
@@ -681,6 +683,8 @@ fn rust_ty_to_shim_rs(ty: &ir_type::Ty, position: ShimTyPosition) -> anyhow::Res
             ir_type::FundamentalTypeKind::U32 => Ok("u32"),
             ir_type::FundamentalTypeKind::I64 => Ok("i64"),
             ir_type::FundamentalTypeKind::U64 => Ok("u64"),
+            ir_type::FundamentalTypeKind::F32 => Ok("f32"),
+            ir_type::FundamentalTypeKind::F64 => Ok("f64"),
             ir_type::FundamentalTypeKind::Bool => Ok("bool"),
             ir_type::FundamentalTypeKind::Char => Ok("u32"),
             ir_type::FundamentalTypeKind::Str => Err(anyhow!("unsupported shim type: {}", ty.kind)),

--- a/compiler/semantic/src/subst.rs
+++ b/compiler/semantic/src/subst.rs
@@ -265,6 +265,7 @@ impl<'a> GenericSubstituter<'a> {
                 call.method.return_ty = self.apply_ty(&call.method.return_ty);
             }
             ir::expr::ExprKind::Int(_)
+            | ir::expr::ExprKind::Float(_)
             | ir::expr::ExprKind::StringLiteral(_)
             | ir::expr::ExprKind::ByteStringLiteral(_)
             | ir::expr::ExprKind::ByteLiteral(_)

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -280,6 +280,8 @@ impl SemanticAnalyzer {
             ast_type::FundamentalTypeKind::U32 => make(ir_type::FundamentalTypeKind::U32),
             ast_type::FundamentalTypeKind::I64 => make(ir_type::FundamentalTypeKind::I64),
             ast_type::FundamentalTypeKind::U64 => make(ir_type::FundamentalTypeKind::U64),
+            ast_type::FundamentalTypeKind::F32 => make(ir_type::FundamentalTypeKind::F32),
+            ast_type::FundamentalTypeKind::F64 => make(ir_type::FundamentalTypeKind::F64),
             ast_type::FundamentalTypeKind::Char => make(ir_type::FundamentalTypeKind::Char),
         }
     }

--- a/compiler/type_infer/src/error.rs
+++ b/compiler/type_infer/src/error.rs
@@ -85,6 +85,9 @@ pub enum TypeInferError {
     #[error("{}:{}:{} integer literal cannot have type {:?}", span.file, span.start.line, span.start.column, ty)]
     InvalidIntegerLiteralType { ty: String, span: Span },
 
+    #[error("{}:{}:{} float literal cannot have type {:?}", span.file, span.start.line, span.start.column, ty)]
+    InvalidFloatLiteralType { ty: String, span: Span },
+
     #[error("{}:{}:{} bitwise operators require integer operands, got {:?}", span.file, span.start.line, span.start.column, actual)]
     ExpectedIntegerTypeForBitOp { actual: String, span: Span },
 

--- a/compiler/type_infer/src/lib.rs
+++ b/compiler/type_infer/src/lib.rs
@@ -15,8 +15,8 @@ use crate::{context::SharedTypeVarAllocator, env::Env};
 use kaede_ir::{
     expr::{
         Binary, BinaryKind, BitNot, BuiltinFnCall, BuiltinFnCallKind, Cast, EnumVariant, Expr,
-        ExprKind, FieldAccess, FnCall, If, Indexing, Int, IntKind, LogicalNot, Loop, Slicing,
-        Spawn, TupleIndexing, UnresolvedFieldAccess,
+        ExprKind, FieldAccess, Float, FloatKind, FnCall, If, Indexing, Int, IntKind, LogicalNot,
+        Loop, Slicing, Spawn, TupleIndexing, UnresolvedFieldAccess,
     },
     qualified_symbol::QualifiedSymbol,
     stmt::{Assign, Block, Let, Stmt, TupleUnpack},
@@ -38,6 +38,20 @@ pub struct TypeInferrer {
     specialized_enums: HashMap<QualifiedSymbol, Rc<IrEnum>>,
     generic_fn_substitutions:
         HashMap<kaede_ir::qualified_symbol::QualifiedSymbol, HashMap<VarId, Rc<Ty>>>,
+}
+
+/// True when `expr` is a direct unsuffixed integer literal — used to gate the
+/// "cast operand inherits the target type" shortcut in `infer_cast` (e.g.
+/// `let c = 3; let d = c as i8` would not work without it for the literal `3`
+/// when cast directly).
+fn expr_is_int_literal(expr: &Expr) -> bool {
+    matches!(expr.kind, ExprKind::Int(_))
+}
+
+/// True when `expr` is a direct unsuffixed float literal — same purpose as
+/// `expr_is_int_literal` but for the float side.
+fn expr_is_float_literal(expr: &Expr) -> bool {
+    matches!(expr.kind, ExprKind::Float(_))
 }
 
 impl TypeInferrer {
@@ -412,6 +426,7 @@ impl TypeInferrer {
         let inferred_ty = match &expr.kind {
             // Literals
             Int(int_lit) => self.infer_int(int_lit),
+            Float(float_lit) => self.infer_float(float_lit),
             StringLiteral(_) => Ok(Rc::new(Ty::new_str(Mutability::Not))),
             ByteStringLiteral(_) => {
                 let elem_ty = Rc::new(make_fundamental_type(
@@ -685,6 +700,19 @@ impl TypeInferrer {
                 // Type will be inferred from context
                 // The expression already has a type variable assigned during semantic analysis
                 // We'll return a fresh type variable here, but it will be unified with the expression's type
+                return Ok(self.context.fresh());
+            }
+        };
+        Ok(Rc::new(ty))
+    }
+
+    fn infer_float(&mut self, float_lit: &Float) -> Result<Rc<Ty>, TypeInferError> {
+        let ty = match float_lit.kind {
+            FloatKind::F32(_) => make_fundamental_type(FundamentalTypeKind::F32, Mutability::Not),
+            FloatKind::F64(_) => make_fundamental_type(FundamentalTypeKind::F64, Mutability::Not),
+            FloatKind::Infer(_) => {
+                // Type will be inferred from context; defaults to f64 if unconstrained
+                // (handled in `apply_expr`).
                 return Ok(self.context.fresh());
             }
         };
@@ -1065,9 +1093,21 @@ impl TypeInferrer {
             TyKind::Fundamental(fty) if fty.kind.is_int()
         );
 
-        // If operand is a type variable and target is an integer, unify them
-        if matches!(operand_ty.kind.as_ref(), TyKind::Var(_)) && target_is_int {
-            // Unify operand with target type to propagate type information
+        // Check if target is a floating-point type
+        let target_is_float = matches!(
+            target_ty.kind.as_ref(),
+            TyKind::Fundamental(fty) if fty.kind.is_float()
+        );
+
+        // Only propagate the cast target back into the operand when the
+        // operand is a direct literal of the *matching* flavor. This keeps
+        // `let c = 3; let d = c as i8` — the literal-narrowing shortcut —
+        // working, while preventing cross-flavor leakage like a float-typed
+        // expression being eagerly unified with an `i32` cast target (which
+        // would corrupt nested float literals).
+        let matching_literal_cast = (target_is_int && expr_is_int_literal(&cast.operand))
+            || (target_is_float && expr_is_float_literal(&cast.operand));
+        if matching_literal_cast && matches!(operand_ty.kind.as_ref(), TyKind::Var(_)) {
             self.context.unify(&operand_ty, target_ty, cast.span)?;
         }
 
@@ -1664,6 +1704,21 @@ impl TypeInferrer {
             expr.ty = default_ty;
         }
 
+        // If this is a float literal with an unconstrained type, default to f64
+        if matches!(expr.kind, ExprKind::Float(_))
+            && let TyKind::Var(id) = expr.ty.kind.as_ref()
+        {
+            let default_ty = Rc::new(Ty {
+                kind: TyKind::Fundamental(kaede_ir::ty::FundamentalType {
+                    kind: FundamentalTypeKind::F64,
+                })
+                .into(),
+                mutability: kaede_ir::ty::Mutability::Not,
+            });
+            self.context.bind_var(*id, default_ty.clone());
+            expr.ty = default_ty;
+        }
+
         // Recursively apply to child expressions
         match &mut expr.kind {
             // Integer literals need type conversion based on inferred type
@@ -1692,6 +1747,34 @@ impl TypeInferrer {
                         }
                         _ => {
                             return Err(TypeInferError::InvalidIntegerLiteralType {
+                                ty: expr.ty.kind.to_string(),
+                                span: expr.span,
+                            });
+                        }
+                    };
+                }
+            }
+
+            // Float literals need type conversion based on inferred type
+            Float(float) => {
+                if let FloatKind::Infer(value) = float.kind {
+                    float.kind = match expr.ty.kind.as_ref() {
+                        TyKind::Fundamental(fty) => match fty.kind {
+                            FundamentalTypeKind::F32 => FloatKind::F32(value as f32),
+                            FundamentalTypeKind::F64 => FloatKind::F64(value),
+                            _ => {
+                                return Err(TypeInferError::InvalidFloatLiteralType {
+                                    ty: fty.kind.to_string(),
+                                    span: expr.span,
+                                });
+                            }
+                        },
+                        TyKind::Never => {
+                            // Unreachable contexts default float literals to f64
+                            FloatKind::F64(value)
+                        }
+                        _ => {
+                            return Err(TypeInferError::InvalidFloatLiteralType {
                                 ty: expr.ty.kind.to_string(),
                                 span: expr.span,
                             });

--- a/example/rust_interop/rust/Cargo.lock
+++ b/example/rust_interop/rust/Cargo.lock
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/library/ffi/sys/sys.c
+++ b/library/ffi/sys/sys.c
@@ -4,6 +4,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -328,4 +329,15 @@ int kaede_sys_somaxconn(void) {
 #else
   return 128;
 #endif
+}
+
+uint64_t kaede_f64_to_string(double value, unsigned char *buf, uint64_t cap) {
+  if (cap == 0)
+    return 0;
+  int n = snprintf((char *)buf, (size_t)cap, "%g", value);
+  if (n < 0)
+    return 0;
+  if ((uint64_t)n >= cap)
+    return cap - 1;
+  return (uint64_t)n;
 }

--- a/library/ffi/sys/sys.h
+++ b/library/ffi/sys/sys.h
@@ -35,6 +35,11 @@ uint32_t kaede_utf8_char_at(const unsigned char *s, uint64_t len, uint64_t index
 uint64_t kaede_utf8_char_count(const unsigned char *s, uint64_t len);
 uint64_t kaede_utf8_byte_index_of_char(const unsigned char *s, uint64_t len, uint64_t index);
 
+/* Format a double into the caller-provided buffer using "%g" and return the
+ * number of bytes written (excluding the NUL terminator). The byte count is
+ * clamped to `cap - 1` if the formatted output would not fit. */
+uint64_t kaede_f64_to_string(double value, unsigned char *buf, uint64_t cap);
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/src/std/ffi/sys.kd
+++ b/library/src/std/ffi/sys.kd
@@ -11,6 +11,7 @@ export extern "C" fun kaede_sys_close(fd: i32) -> i32
 export extern "C" fun kaede_sys_sleep_ms(ms: u64) -> i32
 export extern "C" fun kaede_sys_errno() -> i32
 export extern "C" fun kaede_sys_somaxconn() -> i32
+export extern "C" fun kaede_f64_to_string(value: f64, buf: *u8, cap: u64) -> u64
 
 export fun __sys_socket_tcp4() -> i32 {
     return kaede_sys_socket_tcp4()

--- a/library/src/std/string.kd
+++ b/library/src/std/string.kd
@@ -7,6 +7,7 @@ use std.option.Option
 extern "C" fun kaede_utf8_char_at(s: *u8, len: u64, index: u64) -> char
 extern "C" fun kaede_utf8_char_count(s: *u8, len: u64) -> u64
 extern "C" fun kaede_utf8_byte_index_of_char(s: *u8, len: u64, index: u64) -> u64
+extern "C" fun kaede_f64_to_string(value: f64, buf: *u8, cap: u64) -> u64
 
 export struct String {
     bytes: Vector<u8>,
@@ -217,6 +218,19 @@ fun u64_to_string(n: u64) -> String {
     return out
 }
 
+fun f64_to_string(n: f64) -> String {
+    // 32 bytes covers any "%g"-formatted f64 with room to spare.
+    mut buf := Vector<u8>::new()
+    mut i := 0
+    while i < 32 {
+        buf.push(0 as u8)
+        i += 1
+    }
+
+    written := kaede_f64_to_string(n, buf.as_ptr(), 32)
+    return String::from_bytes(__slice_from_raw_parts(buf.as_ptr(), written))
+}
+
 fun i64_to_string(n: i64) -> String {
     if n < 0 {
         let mut out = String::new()
@@ -350,6 +364,18 @@ impl i16 {
 impl i32 {
     export fun to_string(self) -> String {
         return i64_to_string(self as i64)
+    }
+}
+
+impl f64 {
+    export fun to_string(self) -> String {
+        return f64_to_string(self)
+    }
+}
+
+impl f32 {
+    export fun to_string(self) -> String {
+        return f64_to_string(self as f64)
     }
 }
 


### PR DESCRIPTION
Closes #236.

## Summary
- Adds `f32` and `f64` as first-class fundamental types end-to-end: lexer → parser → AST → semantic → IR → type-inference → LLVM codegen → stdlib.
- Float literals (`3.14`, `1.0e-3`-style decimal-notation only for now) tokenize as a new `Float` token; `tup.0.1` keeps tokenizing as `Ident Dot Int Dot Int` and `1.foo()` as `Int Dot Ident` (suppressed via a `prev_was_dot` flag in the lexer cursor).
- Type inference defaults unconstrained float literals to `f64`. `infer_cast` only propagates the cast target back into the operand when the operand is a *direct literal of the matching flavor*, preventing cross-flavor leakage like `(3.14 + 1.5) as i32` corrupting the float literals into `i32`.
- LLVM codegen wires `fadd`/`fsub`/`fmul`/`fdiv`/`frem`, ordered `RealPredicate` comparisons (matches Rust IEEE semantics), and `sitofp`/`uitofp`/`fptosi`/`fptoui`/`fpext`/`fptrunc` casts.
- `impl f64 { to_string }` / `impl f32 { to_string }` use a new `kaede_f64_to_string` C helper (`snprintf("%g", …)` into a caller-allocated buffer) following the existing `library/ffi/sys` pattern.

## Out of scope
- Literal suffixes like `3.14f32`.
- Implicit int↔float coercion (explicit `as` casts only, mirroring current int behavior).
- Saturating float→int semantics (raw `fptosi`/`fptoui` matches the codebase's existing posture for int casts).
- `NaN`/`Infinity` literal syntax.

## Pre-existing bug surfaced
`if cond { return X } else { return Y }` leaves the `ifcont` block without a terminator; `float_compare` test uses a mutable flag to work around this. Not float-specific (an int-only version reproduces it).

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 254 codegen tests + all crates green; 5 new lexer tests + 10 new codegen e2e tests covering arithmetic, comparison, casts, widening/truncation, unary-minus, default-to-f64, and to_string round-trip
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `./install.py` for stdlib + binary install (required so the test harness's `~/.kaede/lib/src/` reads the updated `string.kd`)