### PR TITLE
chore: clean up install.py / library and fix macOS Homebrew docs env

### DIFF
--- a/install.py
+++ b/install.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import library
-import subprocess
 import shutil
 
 
@@ -13,27 +12,21 @@ kaede_dir = os.path.expandvars(unexpanded_kaede_dir)
 kaede_bin_dir = os.path.expandvars(unexpanded_kaede_bin_dir)
 
 
-def shell_initianlize_file():
-    shell = os.environ.get("SHELL")
+def shell_initialize_file():
+    shell_name = os.path.basename(os.environ.get("SHELL", ""))
 
-    if shell == "/bin/bash":
+    if shell_name == "bash":
         profile = "~/.bash_profile"
         login = "~/.bash_login"
-    elif shell == "/bin/zsh":
+    elif shell_name == "zsh":
         profile = "~/.zprofile"
         login = "~/.zlogin"
-    elif shell == "/bin/fish":
-        profile = "~/.config/fish/config.fish"
-        login = None
     else:
-        # Not supported
         return None
 
-    # If shell profile file exists, use it
     if os.path.exists(os.path.expanduser(profile)):
         return profile
 
-    # If shell login file exists, use it
     if os.path.exists(os.path.expanduser(login)):
         return login
 
@@ -43,9 +36,7 @@ def shell_initianlize_file():
 def install_compiler():
     print("Installing compiler...")
 
-    os.environ["KAEDE_DIR"] = kaede_dir
-    subprocess.run(["cargo", "build", "--release"]).check_returncode()
-    # Move builded binary
+    # Binary was already built by `cargo run --release` invocations in library.install.
     shutil.move("target/release/kaede", os.path.join(kaede_dir, "bin"))
 
     print("Done!")
@@ -79,28 +70,30 @@ def create_shell_script_for_setting_env():
     if "--no-setenv" in sys.argv:
         return
 
-    shell_init_file = shell_initianlize_file()
+    shell_init_file = shell_initialize_file()
 
     if shell_init_file is None:
-        print("This script is not compatible with your shell!")
+        shell_name = os.path.basename(os.environ.get("SHELL", "")) or "unknown"
+        print(
+            "Auto-config skipped: shell '%s' is not supported (only bash/zsh)."
+            % shell_name
+        )
         print("Please add the following to your shell init file:")
-        print('. "%s"' % env_script_path)
-    else:
-        shell_init_file_path = os.path.expanduser(shell_init_file)
-        line_to_add = '. "%s"\n' % env_script_path
+        print('  . "%s"' % env_script_path)
+        return
 
-        # Check if the line already exists
-        if os.path.exists(shell_init_file_path):
-            with open(shell_init_file_path, "r") as f:
-                if line_to_add in f.read():
-                    # Line already exists, skip
-                    return
+    shell_init_file_path = os.path.expanduser(shell_init_file)
+    line_to_add = '. "%s"\n' % env_script_path
 
-        # Append the line if it doesn't exist
-        with open(shell_init_file_path, "a+") as f:
-            f.write(line_to_add)
-        print("Please enter the following command:")
-        print("source %s" % shell_init_file)
+    if os.path.exists(shell_init_file_path):
+        with open(shell_init_file_path, "r") as f:
+            if line_to_add in f.read():
+                return
+
+    with open(shell_init_file_path, "a+") as f:
+        f.write(line_to_add)
+    print("Please enter the following command:")
+    print("source %s" % shell_init_file)
 
 
 if __name__ == "__main__":
@@ -111,10 +104,7 @@ if __name__ == "__main__":
         )
         shutil.rmtree(kaede_dir)
 
-    if not os.path.exists(kaede_dir):
-        os.mkdir(kaede_dir)
-    if not os.path.exists(kaede_bin_dir):
-        os.mkdir(kaede_bin_dir)
+    os.makedirs(kaede_bin_dir)
 
     install()
 

--- a/library/__init__.py
+++ b/library/__init__.py
@@ -47,29 +47,23 @@ def install_bdwgc(third_party_dir):
     print("Installing garbage collector...")
 
     install_dir = os.path.join(third_party_dir, "bdwgc")
-
     bdwgc_dir = os.path.join(this_dir, "bdwgc")
     bdwgc_build_dir = os.path.join(this_dir, "bdwgc_build")
 
-    def build_bdwgc():
-        subprocess.run(
-            [
-                "cmake",
-                "-DCMAKE_BUILD_TYPE=Release",
-                "-DCMAKE_INSTALL_PREFIX='%s'" % install_dir,
-                "-S",
-                bdwgc_dir,
-                "-B",
-                bdwgc_build_dir,
-            ]
-        ).check_returncode()
-        subprocess.run(["cmake", "--build", bdwgc_build_dir, "-j"]).check_returncode()
-
-    def install_bdwgc():
-        build_bdwgc()
-        subprocess.run(["cmake", "--install", bdwgc_build_dir]).check_returncode()
-
-    install_bdwgc()
+    subprocess.run(
+        [
+            "cmake",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DCMAKE_INSTALL_PREFIX='%s'" % install_dir,
+            "-S",
+            bdwgc_dir,
+            "-B",
+            bdwgc_build_dir,
+        ],
+        check=True,
+    )
+    subprocess.run(["cmake", "--build", bdwgc_build_dir, "-j"], check=True)
+    subprocess.run(["cmake", "--install", bdwgc_build_dir], check=True)
 
     print("Done!")
 
@@ -87,6 +81,7 @@ def install_standard_library(
     env = os.environ.copy()
     env["KAEDE_DIR"] = os.path.dirname(kaede_lib_dir)
     openssl_cflags, openssl_libs = resolve_openssl_flags()
+    cc = os.environ.get("CC", "cc")
 
     # Copy standard library source files
     kaede_lib_src_dir = os.path.join(kaede_lib_dir, "src")
@@ -127,7 +122,8 @@ def install_standard_library(
             *autoload_files,
         ],
         env=env,
-    ).check_returncode()
+        check=True,
+    )
     subprocess.run(
         [
             "cargo",
@@ -143,10 +139,11 @@ def install_standard_library(
             *std_lib_files,
         ],
         env=env,
-    ).check_returncode()
+        check=True,
+    )
     subprocess.run(
         [
-            "gcc",
+            cc,
             "-shared",
             "-fPIC",
             "-I",
@@ -162,8 +159,9 @@ def install_standard_library(
             runtime_lib_path,
             bdwgc_lib_path,
             *openssl_libs,
-        ]
-    ).check_returncode()
+        ],
+        check=True,
+    )
 
     print("Done!")
 
@@ -186,9 +184,10 @@ def install_runtime(kaede_lib_dir):
             runtime_src_dir,
             "-B",
             runtime_build_dir,
-        ]
-    ).check_returncode()
-    subprocess.run(["cmake", "--build", runtime_build_dir, "-j"]).check_returncode()
+        ],
+        check=True,
+    )
+    subprocess.run(["cmake", "--build", runtime_build_dir, "-j"], check=True)
 
     shutil.copy(os.path.join(runtime_build_dir, "libkaede_runtime.a"), runtime_lib_path)
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -34,8 +34,12 @@ brew install git llvm@17 cmake python pkg-config openssl@3
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 . "$HOME/.cargo/env"
 
-echo 'export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib"' >> ~/.profile
-. ~/.profile
+case "$(basename "$SHELL")" in
+  zsh)  PROFILE=~/.zprofile ;;
+  *)    PROFILE=~/.profile ;;
+esac
+echo 'export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib"' >> "$PROFILE"
+. "$PROFILE"
 
 git clone --recursive https://github.com/itto-hiramoto/kaede.git
 cd kaede


### PR DESCRIPTION
## Summary

Audit pass over `install.py`, `library/__init__.py`, and the website install
docs that surfaced real bugs and dead code. Done as a separate, small PR before
adding CI verification of the website install blocks (#238 follow-up), so the
new CI doesn't lock in the old broken behavior.

### `install.py`

- **Shell detection rewrite.** Previously compared `$SHELL` against absolute
  paths like `/bin/bash`, missing Homebrew bash (`/opt/homebrew/bin/bash`),
  Linux `/usr/bin/zsh`, custom installs, etc. Now compares
  `basename($SHELL)`. Supported shells for auto-config: bash and zsh.
- **Drop fish from auto-config.** It was crashing
  (`os.path.expanduser(None)` when `~/.config/fish/config.fish` was missing)
  and even on the happy path appended a POSIX-shell sourcing line to
  `config.fish`, which fish cannot parse. Unsupported shells (including
  fish) now fall through to a generic "auto-config skipped, add this line
  to your shell init file" hint pointing at the POSIX `env` script.
- **Drop redundant `cargo build --release` in `install_compiler`.**
  `library.install` runs `cargo run --release -- ...` twice before this is
  reached, so the binary already exists; a second `cargo build --release` was
  a no-op.
- **Drop dead `os.environ["KAEDE_DIR"] = kaede_dir`.** `KAEDE_DIR` is only
  read at runtime by `compiler/semantic/src/rust_import.rs`; nothing
  consumes it during `cargo build`.
- Minor: rename `shell_initianlize_file` → `shell_initialize_file`, drop
  redundant `if not exists` guard before `os.makedirs`, drop "builded"
  comment, drop unused `subprocess` import.

### `library/__init__.py`

- **Flatten `install_bdwgc`.** Previously had two same-named nested
  functions (`build_bdwgc` and a second `install_bdwgc`) for no reason.
  Flattened to a linear sequence of cmake calls.
- **`subprocess.run(...).check_returncode()` → `subprocess.run(..., check=True)`** everywhere.
- **Honor `$CC` for the stdlib link step.** Was hardcoded `gcc`; now reads
  `os.environ.get("CC", "cc")`. POSIX `cc` resolves to `gcc` on Ubuntu
  (`build-essential`) and `clang` on macOS (Xcode CLT), matching the
  documented "gcc or clang" prereq.

### `website/docs/getting-started/installation.md`

- The "macOS / Linux (Homebrew)" block appended `LIBRARY_PATH` to
  `~/.profile`. macOS default zsh does not read `~/.profile` (it reads
  `~/.zprofile`), so the env was lost in any new shell session — silent
  drift bug. Linux Homebrew bash users still need `~/.profile`. Added a
  `case "$(basename "$SHELL")"` to write to the right file for each shell.

## Out of scope

- Issue #238 itself (CI workflow that runs the website blocks verbatim) —
  separate PR on top of this.
- Reusing build dirs `library/bdwgc_build` / `library/runtime_build` across
  reinstalls. Currently fine via CMake incremental.
- Properly supporting fish (separate `set -gx`-syntax env file at
  `~/.config/fish/conf.d/kaede.fish`). Not added on purpose: there are no
  known fish users (auto-config has been crashing on fish for some time
  with no reports), so a fully working fish path is dead weight today.
  Easy to add later if there's demand.

## Test plan

- [x] `python3 -m py_compile install.py library/__init__.py`
- [x] Existing CI (`ci-linux.yml`, `ci-macos.yml`) runs `./install.py
      --no-setenv` end-to-end — relied on as the binding signal.
- [ ] Manual end-to-end inside `ubuntu:22.04` (full path including the new
      shell-init-file edit) — deferred to follow-up PR for #238 which adds
      this as a CI job.