### PR TITLE
fix(website): center OGP content and square off corners

### DIFF
--- a/website/static/img/ogp.svg
+++ b/website/static/img/ogp.svg
@@ -15,18 +15,18 @@
     </radialGradient>
   </defs>
 
-  <rect width="1200" height="630" rx="28" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
   <circle cx="214" cy="486" r="222" fill="url(#glowLeft)"/>
   <circle cx="1024" cy="128" r="186" fill="url(#glowRight)"/>
 
-  <text x="188" y="346" fill="#23150E" font-size="172">
+  <text x="188" y="366" fill="#23150E" font-size="172">
     🍁
   </text>
 
-  <text x="430" y="316" fill="#23150E" font-family="Avenir Next, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="116" font-weight="700">
+  <text x="430" y="336" fill="#23150E" font-family="Avenir Next, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="116" font-weight="700">
     Kaede
   </text>
-  <text x="436" y="374" fill="#8E532F" font-family="Avenir Next, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="34" font-weight="600" letter-spacing="0.16em">
+  <text x="436" y="394" fill="#8E532F" font-family="Avenir Next, Segoe UI, Helvetica Neue, Arial, sans-serif" font-size="34" font-weight="600" letter-spacing="0.16em">
     PROGRAMMING LANGUAGE
   </text>
 </svg>


### PR DESCRIPTION
## Summary
- Shifted the three `<text>` baselines in `website/static/img/ogp.svg` down by 20px so the 🍁, "Kaede" wordmark, and "PROGRAMMING LANGUAGE" subtitle sit at the image's vertical center instead of ~20px above it.
- Removed the 28px rounded-corner `rx` from the background `<rect>`; OGP images render as plain rectangles on every social platform, so the radius had no effect on consumers and only showed up when viewing the SVG directly.

## Test plan
- [x] Open `http://localhost:<port>/kaede/img/ogp.svg` and verify the emoji + title look visually centered vertically.
- [x] Confirm the four corners are square.