### PR TITLE
docs(language): list f32/f64 in primitive types

### DIFF
--- a/website/docs/language/types.md
+++ b/website/docs/language/types.md
@@ -15,6 +15,8 @@ Examples in the repository use types such as:
 - `i32`
 - `i64`
 - `u64`
+- `f32`
+- `f64`
 - `bool`
 - `str`
 - `String`


### PR DESCRIPTION
## Summary
- Adds `f32` and `f64` to the primitive types listed in `website/docs/language/types.md`. They were missing after PR #253 added the types to the language but didn't update the docs.

## Test plan
- [x] No code changes — markdown only