### PR TITLE
ci: verify website install block in clean Ubuntu container

### DIFF
--- a/.github/workflows/ci-docs-install.yml
+++ b/.github/workflows/ci-docs-install.yml
@@ -1,0 +1,82 @@
+name: CI (docs install)
+
+# Runs the website install + first-program blocks verbatim in a clean
+# ubuntu:22.04 container so docs drift surfaces here before users hit it.
+# Block-for-block diffable against the docs - if you edit either, update both.
+
+on:
+  push:
+    paths:
+      - "website/docs/getting-started/installation.md"
+      - "website/docs/getting-started/first-program.md"
+      - "install.py"
+      - "library/**"
+      - ".github/workflows/ci-docs-install.yml"
+  pull_request:
+    paths:
+      - "website/docs/getting-started/installation.md"
+      - "website/docs/getting-started/first-program.md"
+      - "install.py"
+      - "library/**"
+      - ".github/workflows/ci-docs-install.yml"
+  schedule:
+    - cron: "0 6 * * 1" # weekly: catches upstream apt.llvm.org / rustup drift
+  workflow_dispatch:
+
+jobs:
+  ubuntu-install-from-docs:
+    name: Ubuntu install block (verbatim)
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:22.04
+    steps:
+      - name: Bootstrap container (sudo + git for checkout)
+        run: |
+          apt-get update
+          apt-get install -y sudo git ca-certificates
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Run Ubuntu install block from website/docs/getting-started/installation.md
+        shell: bash
+        run: |
+          set -euxo pipefail
+          # === BEGIN verbatim copy of installation.md "Ubuntu / Debian" block ===
+          sudo apt update
+          sudo apt install -y build-essential cmake python3 pkg-config libssl-dev curl wget git
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 17
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          . "$HOME/.cargo/env"
+
+          # NOTE: docs say `git clone --recursive ... && cd kaede` here. Skipped
+          # because actions/checkout already provided the source. This is the
+          # one and only intentional deviation from verbatim.
+
+          export LLVM_SYS_170_PREFIX=/usr/lib/llvm-17
+          ./install.py
+          . "$HOME/.kaede/env"
+          kaede -h
+          # === END verbatim ===
+
+      - name: Run first-program block and assert hello, world!
+        shell: bash
+        run: |
+          set -euxo pipefail
+          . "$HOME/.cargo/env"
+          . "$HOME/.kaede/env"
+          cd "$(mktemp -d)"
+
+          # === BEGIN verbatim copy of first-program.md commands ===
+          kaede new hello_kaede
+          cd hello_kaede
+          # === END verbatim ===
+
+          # `kaede run` prints build progress ("Compiling...", "Linking...",
+          # "Build completed") to stdout before the program output, so an exact
+          # equality check would not work. Require "hello, world!" as a line.
+          kaede run | tee /tmp/kaede-run.log
+          grep -Fxq 'hello, world!' /tmp/kaede-run.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,4 @@
 - If clippy cannot be run or reports warnings/errors, report it explicitly and do not claim lint checks passed.
 - Ensure CI parity locally (`cargo fmt`, `cargo clippy`, `cargo test --release`); mention deviations or flaky areas in the PR.
 - Prefer small, reviewable commits; keep generated artifacts (e.g., `target/`, build outputs) out of git.
+- If you edit the Ubuntu install block in `website/docs/getting-started/installation.md` or the first-program commands in `website/docs/getting-started/first-program.md`, mirror the change in `.github/workflows/ci-docs-install.yml` (which runs those blocks verbatim in CI).


### PR DESCRIPTION
## Summary

Closes #238.

Adds `.github/workflows/ci-docs-install.yml` — a CI job that runs the website's
install + first-program command blocks **verbatim** inside a clean
`ubuntu:22.04` container, then asserts that a fresh `kaede new hello_kaede &&
kaede run` prints `hello, world!`.

Today, neither `ci-linux.yml` nor `ci-macos.yml` exercises the documented
install path — `ci-linux.yml` installs LLVM via `KyleMayes/install-llvm-action`
and skips the apt package list entirely, and neither workflow ever invokes
`kaede new` or `kaede run`. So if `installation.md` or `first-program.md`
drifts (apt package rename, `LLVM_SYS_170_PREFIX` path change upstream,
template wording change in `kaede new`, etc.), no test fails — new users get a
broken first experience and we likely only hear about it eventually.

## How it works

- `runs-on: ubuntu-latest`, `container: ubuntu:22.04` — matches the docs
  target (Ubuntu 22.04, not the GH-hosted runner image which already has many
  packages preinstalled).
- Bootstrap step installs `sudo`, `git`, `ca-certificates` because the
  minimal `ubuntu:22.04` image lacks them and `actions/checkout@v4` needs
  `git`.
- Install step is a **verbatim copy** of the markdown's `Ubuntu / Debian`
  fenced block, with one intentional deviation: the `git clone --recursive
  ... && cd kaede` lines are dropped because `actions/checkout` already
  provided the source.
- First-program step is a **verbatim copy** of `first-program.md`'s `kaede
  new hello_kaede && kaede run`, then `grep -Fxq 'hello, world!'` against
  the captured stdout. Equality check would not work because `kaede run`
  emits build progress ("🔨 Compiling...", "🔗 Linking...",
  "✅ Build completed!") to the same stdout as the program.

## Triggers

- Push / PR on changes to `installation.md`, `first-program.md`, `install.py`,
  `library/**`, or this workflow file.
- Weekly cron (Mon 06:00 UTC) — catches upstream drift (e.g. `apt.llvm.org`
  changing the `/usr/lib/llvm-17` path, rustup changing its installer) even
  when nothing in the repo changed.
- `workflow_dispatch` for manual reruns.

## Sync rule

Per the new line in `AGENTS.md`: editing either docs block requires updating
the workflow's verbatim copy in the same PR. Cheap to enforce, leaves the
diff trivially reviewable.

## Out of scope (follow-ups)

- macOS docs-install workflow (`macos-latest`, Homebrew block). Issue #238
  marks this as optional. Existing `ci-macos.yml` already exercises
  `install.py` end-to-end (just not via the website block), and runner
  minutes are nontrivial. Easy follow-up if drift surfaces specifically on
  macOS.
- Rust interop (`kaede new --rust`) verification. #238 lists this as an
  optional follow-up.

## Test plan

- [x] Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] Smoke run on this PR — new job goes green end-to-end.
- [ ] Negative test 1: temporarily mutate the workflow's verbatim
      `LLVM_SYS_170_PREFIX=/usr/lib/llvm-17` to a wrong path, confirm CI
      fails at `./install.py`, revert.
- [ ] Negative test 2: temporarily change `compiler/driver/src/new.rs`
      template to a different greeting, confirm CI fails at the
      `grep -Fxq` step, revert.