### PR TITLE
docs(modules): formalize sibling-file module layout

### DIFF
--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -487,3 +487,162 @@ fn import_mutual_recursive_functions() -> anyhow::Result<()> {
     }
     .run()
 }
+
+// Sibling-file module layout: `net.kd` defines module `net`, and `net/*.kd`
+// define its submodules. They can coexist. These tests pin the behavior so it
+// cannot regress silently.
+
+#[test]
+fn sibling_layout_body_and_submodule() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "sibling_layout_body_and_submodule",
+        modules: HashMap::from([
+            ("net", "export fun root_fn() -> i32 { return 1 }"),
+            ("net/tcp", "export fun tcp_fn() -> i32 { return 2 }"),
+        ]),
+        main_content: r#"
+            import net
+            import net.tcp
+            fun main() -> i32 {
+                return net.root_fn() + net.tcp.tcp_fn()
+            }
+        "#,
+        expected_min_top_levels: 3,
+        should_fail: false,
+    }
+    .run()
+}
+
+#[test]
+fn sibling_layout_submodule_only_succeeds() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "sibling_layout_submodule_only_succeeds",
+        modules: HashMap::from([("net/tcp", "export fun tcp_fn() -> i32 { return 7 }")]),
+        main_content: r#"
+            import net.tcp
+            fun main() -> i32 {
+                return net.tcp.tcp_fn()
+            }
+        "#,
+        expected_min_top_levels: 2,
+        should_fail: false,
+    }
+    .run()
+}
+
+#[test]
+fn sibling_layout_body_missing_import_fails() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "sibling_layout_body_missing_import_fails",
+        modules: HashMap::from([("net/tcp", "export fun tcp_fn() -> i32 { return 7 }")]),
+        main_content: r#"
+            import net
+            fun main() -> i32 {
+                return 0
+            }
+        "#,
+        expected_min_top_levels: 0,
+        should_fail: true,
+    }
+    .run()
+}
+
+#[test]
+fn sibling_layout_nested_hierarchy() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "sibling_layout_nested_hierarchy",
+        modules: HashMap::from([
+            ("net", "export fun root_fn() -> i32 { return 1 }"),
+            ("net/http", "export fun http_fn() -> i32 { return 10 }"),
+            (
+                "net/http/request",
+                "export fun request_fn() -> i32 { return 100 }",
+            ),
+        ]),
+        main_content: r#"
+            import net
+            import net.http
+            import net.http.request
+            fun main() -> i32 {
+                return net.root_fn() + net.http.http_fn() + net.http.request.request_fn()
+            }
+        "#,
+        expected_min_top_levels: 4,
+        should_fail: false,
+    }
+    .run()
+}
+
+#[test]
+fn sibling_layout_body_imports_own_submodule() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "sibling_layout_body_imports_own_submodule",
+        modules: HashMap::from([
+            (
+                "net",
+                r#"
+                import net.tcp
+                export fun root_fn() -> i32 { return net.tcp.tcp_fn() + 1 }
+            "#,
+            ),
+            ("net/tcp", "export fun tcp_fn() -> i32 { return 41 }"),
+        ]),
+        main_content: r#"
+            import net
+            fun main() -> i32 {
+                return net.root_fn()
+            }
+        "#,
+        expected_min_top_levels: 3,
+        should_fail: false,
+    }
+    .run()
+}
+
+#[test]
+fn sibling_layout_use_from_body() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "sibling_layout_use_from_body",
+        modules: HashMap::from([
+            ("net", "export fun root_fn() -> i32 { return 17 }"),
+            ("net/tcp", "export fun tcp_fn() -> i32 { return 25 }"),
+        ]),
+        main_content: r#"
+            import net
+            use net.root_fn
+            fun main() -> i32 {
+                return root_fn()
+            }
+        "#,
+        expected_min_top_levels: 2,
+        should_fail: false,
+    }
+    .run()
+}
+
+// Observational test: when `net.kd` exports an item with the same name as a
+// sibling submodule `net/tcp.kd`, expression-position `net.tcp` resolves to the
+// item in `net.kd`, not the submodule. The submodule can still be loaded (and
+// its own imported symbols used via `use`), but the dotted path cannot reach
+// into it because the item in the parent module shadows the submodule name.
+// This test pins the current behavior so any future change is intentional.
+#[test]
+fn sibling_layout_item_shadows_submodule_in_expr_position() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "sibling_layout_item_shadows_submodule_in_expr_position",
+        modules: HashMap::from([
+            ("net", "export fun tcp() -> i32 { return 5 }"),
+            ("net/tcp", "export fun inner() -> i32 { return 3 }"),
+        ]),
+        main_content: r#"
+            import net
+            import net.tcp
+            fun main() -> i32 {
+                return net.tcp()
+            }
+        "#,
+        expected_min_top_levels: 3,
+        should_fail: false,
+    }
+    .run()
+}

--- a/website/docs/language/overview.md
+++ b/website/docs/language/overview.md
@@ -26,6 +26,25 @@ Qualified names use `::`:
 mut app := std.http.App::new()
 ```
 
+### Module layout
+
+A module can be a single file or a file plus a sibling directory of submodules.
+
+- `net.kd` defines module `net`.
+- `net/tcp.kd` defines module `net.tcp`.
+- The two coexist: `net.kd` holds the body of `net`, and `net/*.kd` add submodules under the same `net.*` namespace.
+- A directory without a sibling same-name file has no module body; only its submodules are importable. `import net.tcp` works, but `import net` errors.
+- If an item in the body shares a name with a sibling submodule (e.g. `net.kd` exports `fun tcp()` and `net/tcp.kd` also exists), the body item takes precedence in expression position. Avoid the clash.
+
+```text
+src/
+├── net.kd            # module: net  (optional body)
+├── net/
+│   ├── tcp.kd        # module: net.tcp
+│   └── http.kd       # module: net.http
+└── main.kd
+```
+
 ## Bindings
 
 Kaede supports both the short declaration form and `let` bindings:


### PR DESCRIPTION
## Summary

Pin the sibling-file module layout that the current resolver already supports, by adding tests and docs. No compiler changes — this is purely a spec-freeze step so the convention can be relied on without risk of silent regression, ahead of reorganizing the standard library into a deeper hierarchy.

Current behavior (discovered, now documented):
- `net.kd` defines module `net`; `net/*.kd` define its submodules.
- The two coexist: the body file and the sibling directory share the `net.*` namespace.
- If only the directory exists (no `net.kd`), `import net.tcp` still works but `import net` errors.
- If an item in the body and a sibling submodule share a name, the body item takes precedence in expression position.

## Changes

- `compiler/semantic/tests/import.rs`: 7 new tests covering body + submodule coexistence, submodule-only layout, missing-body error, three-level nesting, body importing its own submodule, `use` from the body, and the same-name shadowing behavior.
- `website/docs/language/overview.md`: new "Module layout" subsection with a directory-tree example and a note on shadowing.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test -p kaede_semantic --release --no-fail-fast` — 41 passed, 0 failed (17 existing import tests + 7 new ones + 17 other semantic tests)
- [x] Smoke test: built a project with `src/foo.kd` (`root_fn`) + `src/foo/bar.kd` (`child_fn`) + `src/main.kd` that imports both; confirmed via `--display-llvm-ir` that both functions are emitted and `main` calls each.