### PR TITLE
fix(semantic): respect use-directive visibility

### DIFF
--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -80,15 +80,16 @@ impl SemanticAnalyzer {
                 })?;
 
             let current_module_path = analyzer.current_module_path().clone();
-            // TODO: Use the visibility of the use directive
-            // Why using public?
-            // Because generic structures, etc., are generated later,
-            // but if the module's use is not available at that time, an error will occur.
+            // Respect the declared visibility: a bare `use` is module-local (private),
+            // while `export use` re-exports the name. Generic bodies that reference a
+            // private `use` binding still resolve it because monomorphization re-enters
+            // the defining module via `with_defining_module`/`with_module`, and the
+            // module's private table is visible to same-module lookups.
             analyzer
                 .modules
                 .get_mut(&current_module_path)
                 .unwrap()
-                .bind_symbol(name, symbol, ast::top::Visibility::Public);
+                .bind_symbol(name, symbol, node.vis);
 
             Ok(())
         };

--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -646,3 +646,128 @@ fn sibling_layout_item_shadows_submodule_in_expr_position() -> anyhow::Result<()
     }
     .run()
 }
+
+// `use` visibility: a bare `use` is module-local (private), `export use`
+// re-exports the name. These tests pin both directions so the internal
+// bindings of stdlib/user modules do not silently leak to importers.
+
+#[test]
+fn private_use_is_not_visible_to_importers() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "private_use_is_not_visible_to_importers",
+        modules: HashMap::from([
+            ("provider", "export fun hidden() -> i32 { return 1 }"),
+            (
+                "middle",
+                r#"
+                import provider
+                use provider.hidden
+            "#,
+            ),
+        ]),
+        main_content: r#"
+            import middle
+            fun main() -> i32 {
+                return middle.hidden()
+            }
+        "#,
+        expected_min_top_levels: 0,
+        should_fail: true,
+    }
+    .run()
+}
+
+#[test]
+fn export_use_is_visible_to_importers() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "export_use_is_visible_to_importers",
+        modules: HashMap::from([
+            ("provider", "export fun exposed() -> i32 { return 2 }"),
+            (
+                "middle",
+                r#"
+                import provider
+                export use provider.exposed
+            "#,
+            ),
+        ]),
+        main_content: r#"
+            import middle
+            fun main() -> i32 {
+                return middle.exposed()
+            }
+        "#,
+        expected_min_top_levels: 2,
+        should_fail: false,
+    }
+    .run()
+}
+
+#[test]
+fn private_use_is_still_visible_locally() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "private_use_is_still_visible_locally",
+        modules: HashMap::from([
+            ("provider", "export fun local_use() -> i32 { return 3 }"),
+            (
+                "middle",
+                r#"
+                import provider
+                use provider.local_use
+
+                export fun wrap() -> i32 {
+                    return local_use()
+                }
+            "#,
+            ),
+        ]),
+        main_content: r#"
+            import middle
+            fun main() -> i32 {
+                return middle.wrap()
+            }
+        "#,
+        expected_min_top_levels: 2,
+        should_fail: false,
+    }
+    .run()
+}
+
+// Generic function defined in module `m` whose body references a symbol brought
+// in via a private `use`. When instantiated at a call site in another module,
+// monomorphization re-enters `m`'s context — so the private `use` binding must
+// still resolve. This guards against regressing the TODO removed from
+// `analyze_use` (the old code marked every `use` as Public to keep this path
+// working; the new code must rely on same-module private lookup instead).
+#[test]
+fn private_use_is_reachable_from_generic_body() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "private_use_is_reachable_from_generic_body",
+        modules: HashMap::from([
+            (
+                "helpers",
+                "export fun identity_i32(x: i32) -> i32 { return x }",
+            ),
+            (
+                "lib",
+                r#"
+                import helpers
+                use helpers.identity_i32
+
+                export fun wrap<T>(x: T) -> i32 {
+                    return identity_i32(11)
+                }
+            "#,
+            ),
+        ]),
+        main_content: r#"
+            import lib
+            fun main() -> i32 {
+                return lib.wrap<i32>(0)
+            }
+        "#,
+        expected_min_top_levels: 2,
+        should_fail: false,
+    }
+    .run()
+}


### PR DESCRIPTION
## Summary

`analyze_use` previously bound every `use` and `export use` as `Public`, so internal module-local bindings leaked to importers. For example, `std/http.kd` uses `use std.sys.Fd`, `use std.string.String`, `use std.collections.Vector` as internal details, but callers of `import std.http` could also reach those as `std.http.Fd`, `std.http.String`, etc.

This patch makes `analyze_use` bind with the directive's declared `node.vis` — a bare `use` becomes module-local (private), `export use` remains public. The existing `PrivateItemAccess` guard in `analyze_cross_module_rhs` then rejects cross-module access to bindings that end up in the module's private table.

The TODO removed from `analyze_use` justified the Public override by worrying that generic structures generated later would fail to resolve names brought in via `use`. That concern no longer applies: monomorphization re-enters the defining module via `with_defining_module` / `with_module`, and same-module lookup sees the module's private table.

## Why this is a (small) breaking change

Any code that was reaching into a stdlib module's internal `use` binding (e.g. `std.http.Fd`, `std.http.Vector`) will now fail with `PrivateItemAccess`. Our own `example/` tree only references genuinely-exported items from `std.http` (`App`, `Request`, `Status`, …) and `std.collections` / `std.sync`, so the examples are unaffected. The prelude's `export use` paths (`Vector`, `Option`, `Result`, `String`, `HashMap`, `Channel`, `print*`) continue to work.

## Tests

Four new cases in `compiler/semantic/tests/import.rs`:
- `private_use_is_not_visible_to_importers` — `use foo.X` in middle module, `main.X` access errors.
- `export_use_is_visible_to_importers` — `export use foo.X` is reachable.
- `private_use_is_still_visible_locally` — within the defining module, private `use` is usable.
- `private_use_is_reachable_from_generic_body` — monomorphization of a generic that references a privately-`use`d helper still resolves.

Also confirmed by smoke test: a three-file project with a middle module that does `use provider.hidden_fn` privately compiles cleanly when the middle module calls `hidden_fn()` internally, and fails with `hidden_fn is private to module middle` when main tries `middle.hidden_fn()`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test -p kaede_semantic --release --no-fail-fast` — 144 passed, 0 failed (10 lib + 67 expr + 21 import + 5 stmt + 41 top; 4 new in import)
- [x] Smoke test (sibling project) showing local private `use` works and cross-module access errors