### PR TITLE
feat(driver): introduce Kaede.toml as the project manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,8 +719,10 @@ dependencies = [
  "kaede_parse",
  "kaede_semantic",
  "predicates",
+ "serde",
  "tempfile",
  "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/compiler/driver/Cargo.toml
+++ b/compiler/driver/Cargo.toml
@@ -11,8 +11,10 @@ inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", feat
 anyhow = { version = "1.0.68", features = ["backtrace"] }
 clap = { version = "4.1.4", features = ["derive"] }
 colored = "2.0.4"
+serde = { version = "1", features = ["derive"] }
 tempfile = "3.5.0"
 tokio = { version = "=1.38.2", features = ["io-std", "net", "rt-multi-thread", "time"] }
+toml = "0.8"
 
 kaede_ast = { path = "../ast" }
 kaede_codegen = { path = "../codegen" }

--- a/compiler/driver/src/build.rs
+++ b/compiler/driver/src/build.rs
@@ -54,11 +54,9 @@ pub(crate) fn build_project() -> anyhow::Result<PathBuf> {
     let manifest = manifest::load_from_cwd()?;
     let src_root = manifest.build.src;
     let output_path = manifest.build.out;
-    let rust_path = manifest
-        .rust
-        .as_ref()
-        .map(|r| r.path.clone())
-        .unwrap_or_else(|| PathBuf::from("rust"));
+    // `[rust]` section presence enables Rust interop; when it is absent,
+    // `import rust::<crate>` is rejected by the semantic analyzer.
+    let rust_path = manifest.rust.as_ref().map(|r| r.path.clone());
 
     if !src_root.exists() {
         anyhow::bail!(

--- a/compiler/driver/src/build.rs
+++ b/compiler/driver/src/build.rs
@@ -6,25 +6,7 @@ use std::{
 use anyhow::Context as _;
 use inkwell::OptimizationLevel;
 
-use crate::{compile_and_link, select_entry_unit, CompileOption, CompileUnitInfo};
-
-fn ensure_kaede_project_root() -> anyhow::Result<()> {
-    if !Path::new("src").exists() {
-        anyhow::bail!(
-            "This command expects a Kaede project.\n\
-             Expected structure:\n\
-             └── src/           (Kaede source files)\n\
-             \n\
-             To create a new project: kaede new <project_name> [--rust]\n\
-             Current directory: {}",
-            std::env::current_dir()
-                .unwrap_or_else(|_| PathBuf::from("unknown"))
-                .display()
-        );
-    }
-
-    Ok(())
-}
+use crate::{compile_and_link, manifest, select_entry_unit, CompileOption, CompileUnitInfo};
 
 fn find_kd_files(dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
     let mut kd_files = Vec::new();
@@ -68,18 +50,32 @@ fn collect_kaede_unit_infos(src_root: &Path) -> anyhow::Result<Vec<CompileUnitIn
     Ok(unit_infos)
 }
 
-pub(crate) fn build_project() -> anyhow::Result<()> {
-    ensure_kaede_project_root()?;
+pub(crate) fn build_project() -> anyhow::Result<PathBuf> {
+    let manifest = manifest::load_from_cwd()?;
+    let src_root = manifest.build.src;
+    let output_path = manifest.build.out;
 
-    fs::create_dir_all("build").context("Failed to create build directory")?;
+    if !src_root.exists() {
+        anyhow::bail!(
+            "Kaede source directory '{}' does not exist (configured by build.src in Kaede.toml)",
+            src_root.display()
+        );
+    }
 
-    let src_root = PathBuf::from("src");
+    if let Some(parent) = output_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create output directory '{}'", parent.display())
+            })?;
+        }
+    }
+
     let unit_infos = collect_kaede_unit_infos(&src_root)?;
 
     let option = CompileOption {
         opt_level: OptimizationLevel::Default,
         display_llvm_ir: false,
-        output_file_path: PathBuf::from("build/main"),
+        output_file_path: output_path.clone(),
         root_dir: Some(src_root),
         no_autoload: false,
         no_prelude: false,
@@ -91,8 +87,8 @@ pub(crate) fn build_project() -> anyhow::Result<()> {
     compile_and_link(unit_infos, option)?;
 
     println!("✅ Build completed successfully!");
-    println!("📁 Output: build/main");
-    println!("🚀 Run with: ./build/main");
+    println!("📁 Output: {}", output_path.display());
+    println!("🚀 Run with: ./{}", output_path.display());
 
-    Ok(())
+    Ok(output_path)
 }

--- a/compiler/driver/src/build.rs
+++ b/compiler/driver/src/build.rs
@@ -54,6 +54,11 @@ pub(crate) fn build_project() -> anyhow::Result<PathBuf> {
     let manifest = manifest::load_from_cwd()?;
     let src_root = manifest.build.src;
     let output_path = manifest.build.out;
+    let rust_path = manifest
+        .rust
+        .as_ref()
+        .map(|r| r.path.clone())
+        .unwrap_or_else(|| PathBuf::from("rust"));
 
     if !src_root.exists() {
         anyhow::bail!(
@@ -77,6 +82,7 @@ pub(crate) fn build_project() -> anyhow::Result<PathBuf> {
         display_llvm_ir: false,
         output_file_path: output_path.clone(),
         root_dir: Some(src_root),
+        rust_path,
         no_autoload: false,
         no_prelude: false,
         no_gc: false,

--- a/compiler/driver/src/main.rs
+++ b/compiler/driver/src/main.rs
@@ -245,7 +245,7 @@ fn compile<'ctx>(
     cgcx: &'ctx CodegenCtx<'_>,
     unit_infos: Vec<CompileUnitInfo>,
     root_dir: &'ctx Path,
-    rust_path: &Path,
+    rust_path: Option<&Path>,
     no_autoload: bool,
     no_prelude: bool,
 ) -> anyhow::Result<(Module<'ctx>, Vec<PathBuf>)> {
@@ -262,8 +262,11 @@ fn compile<'ctx>(
 
         let ast = Parser::new(&program, file).run()?;
 
-        let mut analyzer =
-            SemanticAnalyzer::new(file, root_dir.to_path_buf(), rust_path.to_path_buf());
+        let mut analyzer = SemanticAnalyzer::new(
+            file,
+            root_dir.to_path_buf(),
+            rust_path.map(Path::to_path_buf),
+        );
         let mut ir = analyzer.analyze(
             ast,
             AnalyzeOptions {
@@ -364,7 +367,7 @@ pub(crate) fn compile_and_output_obj(
         &cgcx,
         unit_infos,
         &root_dir,
-        &option.rust_path,
+        option.rust_path.as_deref(),
         option.no_autoload,
         option.no_prelude,
     )?;
@@ -394,7 +397,7 @@ pub(crate) fn compile_and_link(
         &cgcx,
         unit_infos,
         &root_dir,
-        &option.rust_path,
+        option.rust_path.as_deref(),
         option.no_autoload,
         option.no_prelude,
     )?;
@@ -426,7 +429,7 @@ pub(crate) struct CompileOption {
     display_llvm_ir: bool,
     output_file_path: PathBuf,
     root_dir: Option<PathBuf>,
-    rust_path: PathBuf,
+    rust_path: Option<PathBuf>,
     no_autoload: bool,
     no_prelude: bool,
     no_gc: bool,
@@ -474,7 +477,9 @@ fn main() -> anyhow::Result<()> {
             "a.out"
         })),
         root_dir: args.root_dir,
-        rust_path: PathBuf::from("rust"),
+        // Direct-compile mode has no manifest to consult; preserve the
+        // legacy "rust/" lookup for `import rust::<crate>`.
+        rust_path: Some(PathBuf::from("rust")),
         no_autoload: args.no_autoload,
         no_prelude: args.no_prelude,
         no_gc: args.no_gc,

--- a/compiler/driver/src/main.rs
+++ b/compiler/driver/src/main.rs
@@ -245,6 +245,7 @@ fn compile<'ctx>(
     cgcx: &'ctx CodegenCtx<'_>,
     unit_infos: Vec<CompileUnitInfo>,
     root_dir: &'ctx Path,
+    rust_path: &Path,
     no_autoload: bool,
     no_prelude: bool,
 ) -> anyhow::Result<(Module<'ctx>, Vec<PathBuf>)> {
@@ -261,7 +262,8 @@ fn compile<'ctx>(
 
         let ast = Parser::new(&program, file).run()?;
 
-        let mut analyzer = SemanticAnalyzer::new(file, root_dir.to_path_buf());
+        let mut analyzer =
+            SemanticAnalyzer::new(file, root_dir.to_path_buf(), rust_path.to_path_buf());
         let mut ir = analyzer.analyze(
             ast,
             AnalyzeOptions {
@@ -362,6 +364,7 @@ pub(crate) fn compile_and_output_obj(
         &cgcx,
         unit_infos,
         &root_dir,
+        &option.rust_path,
         option.no_autoload,
         option.no_prelude,
     )?;
@@ -391,6 +394,7 @@ pub(crate) fn compile_and_link(
         &cgcx,
         unit_infos,
         &root_dir,
+        &option.rust_path,
         option.no_autoload,
         option.no_prelude,
     )?;
@@ -422,6 +426,7 @@ pub(crate) struct CompileOption {
     display_llvm_ir: bool,
     output_file_path: PathBuf,
     root_dir: Option<PathBuf>,
+    rust_path: PathBuf,
     no_autoload: bool,
     no_prelude: bool,
     no_gc: bool,
@@ -469,6 +474,7 @@ fn main() -> anyhow::Result<()> {
             "a.out"
         })),
         root_dir: args.root_dir,
+        rust_path: PathBuf::from("rust"),
         no_autoload: args.no_autoload,
         no_prelude: args.no_prelude,
         no_gc: args.no_gc,

--- a/compiler/driver/src/main.rs
+++ b/compiler/driver/src/main.rs
@@ -20,6 +20,7 @@ use kaede_semantic::{AnalyzeOptions, SemanticAnalyzer};
 use tempfile::{NamedTempFile, TempPath};
 
 mod build;
+mod manifest;
 mod new;
 mod run;
 

--- a/compiler/driver/src/manifest.rs
+++ b/compiler/driver/src/manifest.rs
@@ -15,10 +15,8 @@ pub(crate) struct KaedeManifest {
     #[allow(dead_code)]
     pub package: PackageSection,
     pub build: BuildSection,
-    // Presence of `[rust]` enables Rust interop. v1 of the manifest records
-    // the section but the compiler still defaults to `rust/` — wiring
-    // `rust.path` into `kaede_semantic::rust_import` is a follow-up task.
-    #[allow(dead_code)]
+    // Presence of `[rust]` enables Rust interop; `rust.path` tells the
+    // compiler which subdirectory holds the Rust crate.
     pub rust: Option<RustSection>,
 }
 
@@ -41,7 +39,6 @@ pub(crate) struct BuildSection {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RustSection {
-    #[allow(dead_code)]
     pub path: PathBuf,
 }
 

--- a/compiler/driver/src/manifest.rs
+++ b/compiler/driver/src/manifest.rs
@@ -14,7 +14,6 @@ pub(crate) const MANIFEST_FILENAME: &str = "Kaede.toml";
 pub(crate) struct KaedeManifest {
     #[allow(dead_code)]
     pub package: PackageSection,
-    #[serde(default)]
     pub build: BuildSection,
     // Presence of `[rust]` enables Rust interop. v1 of the manifest records
     // the section but the compiler still defaults to `rust/` — wiring
@@ -35,39 +34,15 @@ pub(crate) struct PackageSection {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct BuildSection {
-    #[serde(default = "default_src")]
     pub src: PathBuf,
-    #[serde(default = "default_out")]
     pub out: PathBuf,
-}
-
-impl Default for BuildSection {
-    fn default() -> Self {
-        Self {
-            src: default_src(),
-            out: default_out(),
-        }
-    }
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RustSection {
     #[allow(dead_code)]
-    #[serde(default = "default_rust_path")]
     pub path: PathBuf,
-}
-
-fn default_src() -> PathBuf {
-    PathBuf::from("src")
-}
-
-fn default_out() -> PathBuf {
-    PathBuf::from("build/main")
-}
-
-fn default_rust_path() -> PathBuf {
-    PathBuf::from("rust")
 }
 
 pub(crate) fn load_from_cwd() -> anyhow::Result<KaedeManifest> {
@@ -102,7 +77,7 @@ pub(crate) fn render_default(name: &str, with_rust: bool) -> String {
     out.push('\n');
     out.push_str("[build]\n");
     out.push_str("src = \"src\"\n");
-    out.push_str("out = \"build/main\"\n");
+    out.push_str(&format!("out = \"build/{name}\"\n"));
     if with_rust {
         out.push('\n');
         out.push_str("[rust]\n");

--- a/compiler/driver/src/manifest.rs
+++ b/compiler/driver/src/manifest.rs
@@ -1,0 +1,112 @@
+use std::{
+    fs,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Context as _;
+use serde::Deserialize;
+
+pub(crate) const MANIFEST_FILENAME: &str = "Kaede.toml";
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct KaedeManifest {
+    #[allow(dead_code)]
+    pub package: PackageSection,
+    #[serde(default)]
+    pub build: BuildSection,
+    // Presence of `[rust]` enables Rust interop. v1 of the manifest records
+    // the section but the compiler still defaults to `rust/` — wiring
+    // `rust.path` into `kaede_semantic::rust_import` is a follow-up task.
+    #[allow(dead_code)]
+    pub rust: Option<RustSection>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PackageSection {
+    #[allow(dead_code)]
+    pub name: String,
+    #[allow(dead_code)]
+    pub version: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct BuildSection {
+    #[serde(default = "default_src")]
+    pub src: PathBuf,
+    #[serde(default = "default_out")]
+    pub out: PathBuf,
+}
+
+impl Default for BuildSection {
+    fn default() -> Self {
+        Self {
+            src: default_src(),
+            out: default_out(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RustSection {
+    #[allow(dead_code)]
+    #[serde(default = "default_rust_path")]
+    pub path: PathBuf,
+}
+
+fn default_src() -> PathBuf {
+    PathBuf::from("src")
+}
+
+fn default_out() -> PathBuf {
+    PathBuf::from("build/main")
+}
+
+fn default_rust_path() -> PathBuf {
+    PathBuf::from("rust")
+}
+
+pub(crate) fn load_from_cwd() -> anyhow::Result<KaedeManifest> {
+    let path = Path::new(MANIFEST_FILENAME);
+    let contents = match fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            let cwd = std::env::current_dir()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| String::from("unknown"));
+            anyhow::bail!(
+                "`{MANIFEST_FILENAME}` not found in the current directory.\n\
+                 `kaede build`/`kaede run` require a Kaede project manifest.\n\
+                 To create a new project: kaede new <project_name> [--rust]\n\
+                 Current directory: {cwd}"
+            );
+        }
+        Err(err) => {
+            return Err(err).with_context(|| format!("Failed to read {MANIFEST_FILENAME}"));
+        }
+    };
+
+    toml::from_str::<KaedeManifest>(&contents)
+        .with_context(|| format!("Failed to parse {MANIFEST_FILENAME}"))
+}
+
+pub(crate) fn render_default(name: &str, with_rust: bool) -> String {
+    let mut out = String::new();
+    out.push_str("[package]\n");
+    out.push_str(&format!("name = \"{name}\"\n"));
+    out.push_str("version = \"0.1.0\"\n");
+    out.push('\n');
+    out.push_str("[build]\n");
+    out.push_str("src = \"src\"\n");
+    out.push_str("out = \"build/main\"\n");
+    if with_rust {
+        out.push('\n');
+        out.push_str("[rust]\n");
+        out.push_str("path = \"rust\"\n");
+    }
+    out
+}

--- a/compiler/driver/src/new.rs
+++ b/compiler/driver/src/new.rs
@@ -2,12 +2,20 @@ use std::{fs, path::Path, process::Command};
 
 use anyhow::Context as _;
 
+use crate::manifest::{self, MANIFEST_FILENAME};
+
 fn ensure_project_does_not_exist(project_dir: &Path, project_name: &str) -> anyhow::Result<()> {
     if project_dir.exists() {
         anyhow::bail!("Directory '{project_name}' already exists");
     }
 
     Ok(())
+}
+
+fn write_manifest(project_dir: &Path, project_name: &str, with_rust: bool) -> anyhow::Result<()> {
+    let contents = manifest::render_default(project_name, with_rust);
+    fs::write(project_dir.join(MANIFEST_FILENAME), contents)
+        .with_context(|| format!("Failed to write {MANIFEST_FILENAME}"))
 }
 
 fn create_kaede_only_project(project_dir: &Path, project_name: &str) -> anyhow::Result<()> {
@@ -21,9 +29,12 @@ fn create_kaede_only_project(project_dir: &Path, project_name: &str) -> anyhow::
 }"#,
     )?;
 
+    write_manifest(project_dir, project_name, false)?;
+
     println!("✅ Successfully created Kaede project: {project_name}");
     println!("📁 Project structure:");
     println!("  {project_name}/");
+    println!("  ├── Kaede.toml");
     println!("  └── src/");
     println!("      └── main.kd");
     println!();
@@ -79,9 +90,13 @@ fn create_rust_bridge_project(project_dir: &Path, project_name: &str) -> anyhow:
 }"#;
     fs::write(&lib_rs_path, lib_rs_content)?;
 
+    // Step 5: Write Kaede.toml last so a partial scaffold is never mistaken for a valid project.
+    write_manifest(project_dir, project_name, true)?;
+
     println!("✅ Successfully created Kaede Rust interop project: {project_name}");
     println!("📁 Project structure:");
     println!("  {project_name}/");
+    println!("  ├── Kaede.toml");
     println!("  ├── src/");
     println!("  │   └── main.kd");
     println!("  └── rust/");
@@ -97,7 +112,17 @@ fn create_rust_bridge_project(project_dir: &Path, project_name: &str) -> anyhow:
     Ok(())
 }
 
-pub(crate) fn create_new_project(project_name: String, with_rust: bool) -> anyhow::Result<()> {
+fn validate_project_name(project_name: &str, with_rust: bool) -> anyhow::Result<()> {
+    if project_name.is_empty() {
+        anyhow::bail!("Project name must not be empty");
+    }
+
+    if project_name.starts_with('.') || project_name.contains('/') || project_name.contains('\\') {
+        anyhow::bail!(
+            "Project name must not contain path separators or start with '.': `{project_name}`"
+        );
+    }
+
     if with_rust
         && !project_name
             .chars()
@@ -107,6 +132,12 @@ pub(crate) fn create_new_project(project_name: String, with_rust: bool) -> anyho
             "Rust interop projects currently require an ASCII crate name (letters/digits/_): `{project_name}`"
         );
     }
+
+    Ok(())
+}
+
+pub(crate) fn create_new_project(project_name: String, with_rust: bool) -> anyhow::Result<()> {
+    validate_project_name(&project_name, with_rust)?;
 
     let project_dir = Path::new(&project_name);
 

--- a/compiler/driver/src/run.rs
+++ b/compiler/driver/src/run.rs
@@ -3,9 +3,9 @@ use std::process::Command;
 use crate::build::build_project;
 
 pub(crate) fn run_project(args: Vec<String>) -> anyhow::Result<()> {
-    build_project()?;
+    let binary = build_project()?;
 
-    let status = Command::new("build/main").args(args).status()?;
+    let status = Command::new(&binary).args(args).status()?;
 
     if let Some(code) = status.code() {
         std::process::exit(code);

--- a/compiler/driver/tests/cli.rs
+++ b/compiler/driver/tests/cli.rs
@@ -53,6 +53,10 @@ fn new_creates_hello_world_main() -> anyhow::Result<()> {
         "manifest should carry the project name: {manifest_contents}"
     );
     assert!(
+        manifest_contents.contains(r#"out = "build/hello_kaede""#),
+        "scaffold should set `build.out` to `build/<package.name>`: {manifest_contents}"
+    );
+    assert!(
         !manifest_contents.contains("[rust]"),
         "plain `kaede new` should not emit a [rust] section: {manifest_contents}"
     );

--- a/compiler/driver/tests/cli.rs
+++ b/compiler/driver/tests/cli.rs
@@ -30,6 +30,7 @@ fn new_creates_hello_world_main() -> anyhow::Result<()> {
     let project_name = "hello_kaede";
     let project_dir = temp_dir.child(project_name);
     let main = project_dir.child("src/main.kd");
+    let manifest = project_dir.child("Kaede.toml");
 
     Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
         .current_dir(temp_dir.path())
@@ -43,6 +44,44 @@ fn new_creates_hello_world_main() -> anyhow::Result<()> {
         r#"fun main() {
     println("hello, world!")
 }"#,
+    );
+
+    manifest.assert(predicate::path::is_file());
+    let manifest_contents = fs::read_to_string(manifest.path())?;
+    assert!(
+        manifest_contents.contains(r#"name = "hello_kaede""#),
+        "manifest should carry the project name: {manifest_contents}"
+    );
+    assert!(
+        !manifest_contents.contains("[rust]"),
+        "plain `kaede new` should not emit a [rust] section: {manifest_contents}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn new_rust_creates_manifest_with_rust_section() -> anyhow::Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let project_name = "hello_rust_kaede";
+    let project_dir = temp_dir.child(project_name);
+    let manifest = project_dir.child("Kaede.toml");
+
+    Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+        .current_dir(temp_dir.path())
+        .args(["new", project_name, "--rust"])
+        .assert()
+        .success();
+
+    manifest.assert(predicate::path::is_file());
+    let manifest_contents = fs::read_to_string(manifest.path())?;
+    assert!(
+        manifest_contents.contains("[rust]"),
+        "`kaede new --rust` should emit a [rust] section: {manifest_contents}"
+    );
+    assert!(
+        manifest_contents.contains(r#"path = "rust""#),
+        "[rust].path should default to \"rust\": {manifest_contents}"
     );
 
     Ok(())

--- a/compiler/driver/tests/run.rs
+++ b/compiler/driver/tests/run.rs
@@ -12,13 +12,43 @@ fn create_project_files(
     files: &[(&str, &str)],
 ) -> anyhow::Result<()> {
     temp_dir.child("Kaede.toml").write_str(
-        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n\n[build]\nsrc = \"src\"\nout = \"build/main\"\n",
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n\n[build]\nsrc = \"src\"\nout = \"build/test\"\n",
     )?;
     let src_dir = temp_dir.child("src");
     src_dir.create_dir_all()?;
     for (path, program) in files {
         src_dir.child(path).write_str(program)?;
     }
+    Ok(())
+}
+
+#[test]
+fn build_writes_binary_to_configured_out_path() -> anyhow::Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    create_project(
+        &temp_dir,
+        r#"fun main() -> i32 {
+    return 0
+}"#,
+    )?;
+
+    Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+        .current_dir(temp_dir.path())
+        .arg("build")
+        .assert()
+        .success();
+
+    // Fixture's manifest sets `out = "build/test"`; confirm the binary
+    // lands there and not at the legacy hardcoded `build/main`.
+    temp_dir
+        .child("build")
+        .child("test")
+        .assert(predicate::path::is_file());
+    temp_dir
+        .child("build")
+        .child("main")
+        .assert(predicate::path::missing());
+
     Ok(())
 }
 

--- a/compiler/driver/tests/run.rs
+++ b/compiler/driver/tests/run.rs
@@ -270,6 +270,37 @@ fun main() -> i32 {
 }
 
 #[test]
+fn build_rejects_rust_import_when_rust_section_is_missing() -> anyhow::Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+
+    // Manifest omits `[rust]`, so Rust interop is not enabled even though
+    // a `rust/` directory is present on disk.
+    create_project(
+        &temp_dir,
+        "import rust::anything\n\nfun main() -> i32 { return 0 }",
+    )?;
+
+    let rust_dir = temp_dir.child("rust");
+    rust_dir.child("src").create_dir_all()?;
+    fs::write(
+        rust_dir.child("Cargo.toml").path(),
+        "[package]\nname = \"anything\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    fs::write(rust_dir.child("src/lib.rs").path(), "pub fn f() {}\n")?;
+
+    Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+        .current_dir(temp_dir.path())
+        .arg("build")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Add a `[rust]` section to Kaede.toml",
+        ));
+
+    Ok(())
+}
+
+#[test]
 fn run_resolves_rust_import_from_configured_rust_path() -> anyhow::Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
 

--- a/compiler/driver/tests/run.rs
+++ b/compiler/driver/tests/run.rs
@@ -11,6 +11,9 @@ fn create_project_files(
     temp_dir: &assert_fs::TempDir,
     files: &[(&str, &str)],
 ) -> anyhow::Result<()> {
+    temp_dir.child("Kaede.toml").write_str(
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n\n[build]\nsrc = \"src\"\nout = \"build/main\"\n",
+    )?;
     let src_dir = temp_dir.child("src");
     src_dir.create_dir_all()?;
     for (path, program) in files {
@@ -28,9 +31,7 @@ fn run_fails_outside_project() -> anyhow::Result<()> {
         .arg("run")
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "This command expects a Kaede project",
-        ));
+        .stderr(predicate::str::contains("Kaede.toml"));
 
     Ok(())
 }

--- a/compiler/driver/tests/run.rs
+++ b/compiler/driver/tests/run.rs
@@ -1,6 +1,7 @@
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
+use std::fs;
 use std::process::Command;
 
 fn create_project(temp_dir: &assert_fs::TempDir, program: &str) -> anyhow::Result<()> {
@@ -257,6 +258,56 @@ fun main() -> i32 {
         Option::None => 1,
     }
 }"#,
+    )?;
+
+    Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+        .current_dir(temp_dir.path())
+        .arg("run")
+        .assert()
+        .code(predicate::eq(42));
+
+    Ok(())
+}
+
+#[test]
+fn run_resolves_rust_import_from_configured_rust_path() -> anyhow::Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+
+    // Manifest points `rust.path` at a non-default directory (`vendor`)
+    // to exercise the `rust.path` plumbing end-to-end.
+    temp_dir.child("Kaede.toml").write_str(
+        r#"[package]
+name = "custom_rust_path"
+version = "0.1.0"
+
+[build]
+src = "src"
+out = "build/custom_rust_path"
+
+[rust]
+path = "vendor"
+"#,
+    )?;
+
+    let src_dir = temp_dir.child("src");
+    src_dir.create_dir_all()?;
+    src_dir.child("main.kd").write_str(
+        r#"import rust::custom_rust_path
+
+fun main() -> i32 {
+    return rust::custom_rust_path::answer()
+}"#,
+    )?;
+
+    let vendor = temp_dir.child("vendor");
+    vendor.child("src").create_dir_all()?;
+    fs::write(
+        vendor.child("Cargo.toml").path(),
+        "[package]\nname = \"custom_rust_path\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    fs::write(
+        vendor.child("src/lib.rs").path(),
+        "pub fn answer() -> i32 { 42 }\n",
     )?;
 
     Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -70,7 +70,10 @@ impl Backend {
                 Err(err) => return diagnostics_from_parse_error(err),
             };
 
-            let mut analyzer = SemanticAnalyzer::new(file, root_dir, PathBuf::from("rust"));
+            // The LSP does not parse Kaede.toml; default to the legacy "rust/"
+            // lookup so rust-interop projects still get diagnostics for
+            // `import rust::<crate>`.
+            let mut analyzer = SemanticAnalyzer::new(file, root_dir, Some(PathBuf::from("rust")));
             let is_entry_unit = ast_has_entry_candidate(&ast);
             match analyzer.analyze(
                 ast,

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -70,7 +70,7 @@ impl Backend {
                 Err(err) => return diagnostics_from_parse_error(err),
             };
 
-            let mut analyzer = SemanticAnalyzer::new(file, root_dir);
+            let mut analyzer = SemanticAnalyzer::new(file, root_dir, PathBuf::from("rust"));
             let is_entry_unit = ast_has_entry_candidate(&ast);
             match analyzer.analyze(
                 ast,

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -73,7 +73,7 @@ pub struct SemanticAnalyzer {
     imported_rust_crates: HashSet<Symbol>,
     additional_native_libs: Vec<PathBuf>,
     root_dir: PathBuf,
-    pub(crate) rust_path: PathBuf,
+    pub(crate) rust_path: Option<PathBuf>,
     autoloads_imported: bool,
     infer_context: InferContext,
     closure_capture_stack: Vec<ClosureCapture>,
@@ -304,7 +304,7 @@ impl SemanticAnalyzer {
         module_context
     }
 
-    pub fn new(file_path: FilePath, root_dir: PathBuf, rust_path: PathBuf) -> Self {
+    pub fn new(file_path: FilePath, root_dir: PathBuf, rust_path: Option<PathBuf>) -> Self {
         if !root_dir.is_dir() {
             panic!("Root directory is not a directory");
         }
@@ -353,7 +353,7 @@ impl SemanticAnalyzer {
             imported_rust_crates: HashSet::new(),
             additional_native_libs: Vec::new(),
             root_dir: PathBuf::from("."),
-            rust_path: PathBuf::from("rust"),
+            rust_path: Some(PathBuf::from("rust")),
             autoloads_imported: false,
             infer_context: InferContext::default(),
             closure_capture_stack: Vec::new(),

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -73,6 +73,7 @@ pub struct SemanticAnalyzer {
     imported_rust_crates: HashSet<Symbol>,
     additional_native_libs: Vec<PathBuf>,
     root_dir: PathBuf,
+    pub(crate) rust_path: PathBuf,
     autoloads_imported: bool,
     infer_context: InferContext,
     closure_capture_stack: Vec<ClosureCapture>,
@@ -303,7 +304,7 @@ impl SemanticAnalyzer {
         module_context
     }
 
-    pub fn new(file_path: FilePath, root_dir: PathBuf) -> Self {
+    pub fn new(file_path: FilePath, root_dir: PathBuf, rust_path: PathBuf) -> Self {
         if !root_dir.is_dir() {
             panic!("Root directory is not a directory");
         }
@@ -325,6 +326,7 @@ impl SemanticAnalyzer {
             imported_rust_crates: HashSet::new(),
             additional_native_libs: Vec::new(),
             root_dir,
+            rust_path,
             autoloads_imported: false,
             infer_context: InferContext::default(),
             closure_capture_stack: Vec::new(),
@@ -351,6 +353,7 @@ impl SemanticAnalyzer {
             imported_rust_crates: HashSet::new(),
             additional_native_libs: Vec::new(),
             root_dir: PathBuf::from("."),
+            rust_path: PathBuf::from("rust"),
             autoloads_imported: false,
             infer_context: InferContext::default(),
             closure_capture_stack: Vec::new(),

--- a/compiler/semantic/src/rust_import.rs
+++ b/compiler/semantic/src/rust_import.rs
@@ -359,8 +359,8 @@ fn extract_fn_io(sig_container: &Value) -> Option<(&Value, &Value)> {
     Some((inputs, output))
 }
 
-fn project_root_from_root_dir(root_dir: &Path) -> anyhow::Result<PathBuf> {
-    let direct = root_dir.join("rust").join("Cargo.toml");
+fn project_root_from_root_dir(root_dir: &Path, rust_subdir: &Path) -> anyhow::Result<PathBuf> {
+    let direct = root_dir.join(rust_subdir).join("Cargo.toml");
     if direct.exists() {
         return Ok(root_dir.to_path_buf());
     }
@@ -368,13 +368,14 @@ fn project_root_from_root_dir(root_dir: &Path) -> anyhow::Result<PathBuf> {
     let parent = root_dir
         .parent()
         .ok_or_else(|| anyhow!("failed to resolve project root from {}", root_dir.display()))?;
-    let parent_manifest = parent.join("rust").join("Cargo.toml");
+    let parent_manifest = parent.join(rust_subdir).join("Cargo.toml");
     if parent_manifest.exists() {
         return Ok(parent.to_path_buf());
     }
 
     Err(anyhow!(
-        "rust/Cargo.toml not found (searched '{}' and '{}')",
+        "{}/Cargo.toml not found (searched '{}' and '{}')",
+        rust_subdir.display(),
         direct.display(),
         parent_manifest.display()
     ))
@@ -1015,18 +1016,23 @@ fn generate_shim_crate(
     Ok(Some(dylib))
 }
 
-pub fn resolve_rust_import(root_dir: &Path, crate_name: &str) -> anyhow::Result<RustImportOutput> {
-    let project_root = project_root_from_root_dir(root_dir)?;
-    let rust_manifest = project_root.join("rust").join("Cargo.toml");
+pub fn resolve_rust_import(
+    root_dir: &Path,
+    rust_subdir: &Path,
+    crate_name: &str,
+) -> anyhow::Result<RustImportOutput> {
+    let project_root = project_root_from_root_dir(root_dir, rust_subdir)?;
+    let rust_manifest = project_root.join(rust_subdir).join("Cargo.toml");
     let package_name = read_package_name(&rust_manifest)?;
     if package_name != crate_name {
         return Err(anyhow!(
-            "import rust::{crate_name} does not match rust/Cargo.toml package name `{package_name}`"
+            "import rust::{crate_name} does not match {}/Cargo.toml package name `{package_name}`",
+            rust_subdir.display()
         ));
     }
 
     run_rustdoc_json(&rust_manifest)?;
-    let rustdoc_json = rustdoc_json_path(project_root.join("rust").as_path(), crate_name)?;
+    let rustdoc_json = rustdoc_json_path(project_root.join(rust_subdir).as_path(), crate_name)?;
     let (functions, skipped) = parse_root_public_functions(&rustdoc_json, crate_name)?;
     let dylib_path = generate_shim_crate(
         &project_root,

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -358,7 +358,8 @@ impl SemanticAnalyzer {
         }
         self.imported_rust_crates.insert(crate_name);
 
-        let resolved = rust_import::resolve_rust_import(&self.root_dir, crate_name.as_str())?;
+        let resolved =
+            rust_import::resolve_rust_import(&self.root_dir, &self.rust_path, crate_name.as_str())?;
 
         if let Some(lib) = &resolved.dylib_path {
             if !self.additional_native_libs.contains(lib) {

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -358,8 +358,13 @@ impl SemanticAnalyzer {
         }
         self.imported_rust_crates.insert(crate_name);
 
+        let Some(rust_path) = self.rust_path.as_deref() else {
+            return Err(anyhow::anyhow!(
+                "`import rust::{crate_name}` requires Rust interop to be enabled. Add a `[rust]` section to Kaede.toml."
+            ));
+        };
         let resolved =
-            rust_import::resolve_rust_import(&self.root_dir, &self.rust_path, crate_name.as_str())?;
+            rust_import::resolve_rust_import(&self.root_dir, rust_path, crate_name.as_str())?;
 
         if let Some(lib) = &resolved.dylib_path {
             if !self.additional_native_libs.contains(lib) {

--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -39,6 +39,7 @@ impl ImportTestProject {
         let mut analyzer = kaede_semantic::SemanticAnalyzer::new(
             kaede_span::file::FilePath::from(main_file),
             self.temp_dir.path().to_path_buf(),
+            std::path::PathBuf::from("rust"),
         );
 
         analyzer.analyze(

--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -39,7 +39,7 @@ impl ImportTestProject {
         let mut analyzer = kaede_semantic::SemanticAnalyzer::new(
             kaede_span::file::FilePath::from(main_file),
             self.temp_dir.path().to_path_buf(),
-            std::path::PathBuf::from("rust"),
+            Some(std::path::PathBuf::from("rust")),
         );
 
         analyzer.analyze(

--- a/example/calculator/Kaede.toml
+++ b/example/calculator/Kaede.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 
 [build]
 src = "src"
-out = "build/main"
+out = "build/calculator"

--- a/example/calculator/Kaede.toml
+++ b/example/calculator/Kaede.toml
@@ -1,0 +1,7 @@
+[package]
+name = "calculator"
+version = "0.1.0"
+
+[build]
+src = "src"
+out = "build/main"

--- a/example/comment_app/Kaede.toml
+++ b/example/comment_app/Kaede.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 [build]
 src = "src"
-out = "build/main"
+out = "build/comment_app"
 
 [rust]
 path = "rust"

--- a/example/comment_app/Kaede.toml
+++ b/example/comment_app/Kaede.toml
@@ -1,0 +1,10 @@
+[package]
+name = "comment_app"
+version = "0.1.0"
+
+[build]
+src = "src"
+out = "build/main"
+
+[rust]
+path = "rust"

--- a/example/http_kv_store/Kaede.toml
+++ b/example/http_kv_store/Kaede.toml
@@ -1,0 +1,7 @@
+[package]
+name = "http_kv_store"
+version = "0.1.0"
+
+[build]
+src = "src"
+out = "build/main"

--- a/example/http_kv_store/Kaede.toml
+++ b/example/http_kv_store/Kaede.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 
 [build]
 src = "src"
-out = "build/main"
+out = "build/http_kv_store"

--- a/example/http_server/Kaede.toml
+++ b/example/http_server/Kaede.toml
@@ -1,0 +1,7 @@
+[package]
+name = "http_server"
+version = "0.1.0"
+
+[build]
+src = "src"
+out = "build/main"

--- a/example/http_server/Kaede.toml
+++ b/example/http_server/Kaede.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 
 [build]
 src = "src"
-out = "build/main"
+out = "build/http_server"

--- a/example/rust_interop/Kaede.toml
+++ b/example/rust_interop/Kaede.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_interop"
+version = "0.1.0"
+
+[build]
+src = "src"
+out = "build/main"
+
+[rust]
+path = "rust"

--- a/example/rust_interop/Kaede.toml
+++ b/example/rust_interop/Kaede.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 [build]
 src = "src"
-out = "build/main"
+out = "build/rust_interop"
 
 [rust]
 path = "rust"

--- a/website/docs/getting-started/first-program.md
+++ b/website/docs/getting-started/first-program.md
@@ -13,12 +13,24 @@ kaede new hello_kaede
 cd hello_kaede
 ```
 
-Kaede creates a project with a `src/` directory and a starter `main.kd` file:
+Kaede creates a project with a `Kaede.toml` manifest, a `src/` directory, and a starter `main.kd` file:
 
 ```rust
 fun main() {
     println("hello, world!")
 }
+```
+
+The generated `Kaede.toml`:
+
+```toml
+[package]
+name = "hello_kaede"
+version = "0.1.0"
+
+[build]
+src = "src"
+out = "build/main"
 ```
 
 ## Run it
@@ -46,11 +58,12 @@ The minimum project shape is:
 
 ```text
 hello_kaede/
+├── Kaede.toml
 └── src/
     └── main.kd
 ```
 
-Kaede treats `src/` as the project root when you use the project commands.
+`Kaede.toml` marks the project root. `kaede build` and `kaede run` require it in the working directory; the `[build]` section controls the source directory and the output binary path.
 
 ## Rust interop scaffold
 
@@ -60,6 +73,6 @@ If you know you want Rust interop from the start, create the project with:
 kaede new hello_kaede --rust
 ```
 
-That gives you both Kaede sources and a `rust/` crate that Kaede can import.
+That gives you both Kaede sources and a `rust/` crate that Kaede can import. The generated `Kaede.toml` additionally contains a `[rust]` section that records the crate path.
 
 Next: read the [language overview](../language/overview.md).

--- a/website/docs/getting-started/first-program.md
+++ b/website/docs/getting-started/first-program.md
@@ -30,8 +30,10 @@ version = "0.1.0"
 
 [build]
 src = "src"
-out = "build/main"
+out = "build/hello_kaede"
 ```
+
+`kaede new` sets `build.out` to `build/<package.name>` so the produced binary mirrors your package name.
 
 ## Run it
 
@@ -39,7 +41,7 @@ out = "build/main"
 kaede run
 ```
 
-The `run` command builds the project and then runs `build/main`. With the default scaffold, it prints:
+The `run` command builds the project and then runs the output binary (here `build/hello_kaede`). With the default scaffold, it prints:
 
 ```text
 hello, world!
@@ -49,7 +51,7 @@ If you want the steps separately:
 
 ```bash
 kaede build
-./build/main
+./build/hello_kaede
 ```
 
 ## Project layout

--- a/website/docs/language/rust-interop.md
+++ b/website/docs/language/rust-interop.md
@@ -33,12 +33,20 @@ That scaffold creates a layout like:
 
 ```text
 myproject/
+├── Kaede.toml
 ├── src/
 │   └── main.kd
 └── rust/
     ├── Cargo.toml
     └── src/
         └── lib.rs
+```
+
+The generated `Kaede.toml` contains a `[rust]` section, whose presence signals that the project uses Rust interop:
+
+```toml
+[rust]
+path = "rust"
 ```
 
 The generated Kaede entry file imports the Rust crate, and the generated Rust crate starts with a tiny function you can extend.


### PR DESCRIPTION
## Summary

- Replace the implicit `src/`-based project-root detection with an explicit `Kaede.toml` manifest.
- `kaede new` scaffolds the manifest; `kaede build` / `kaede run` require it in the working directory.
- The manifest carries `[package]` metadata, `[build]` (source/output paths), and an optional `[rust]` section whose presence signals Rust interop.

## Manifest shape

```toml
# kaede new <name>
[package]
name = "hello"
version = "0.1.0"

[build]
src = "src"
out = "build/main"
```

```toml
# kaede new <name> --rust
[package]
name = "hello"
version = "0.1.0"

[build]
src = "src"
out = "build/main"

[rust]
path = "rust"
```

The issue spec included `[rust] enabled = bool`; that was dropped in favor of section presence as the on/off signal, which keeps the manifest smaller and avoids the odd case of setting `path` while `enabled = false`.

## Breaking change

Projects without `Kaede.toml` can no longer be built via `kaede build` / `kaede run`. The missing-manifest error instructs the user to run `kaede new`. Direct-compile mode (`kaede <file>.kd [--root-dir ...]`) is unaffected.

## What this does NOT do yet

`rust.path` is parsed into the struct but not yet consumed by the compiler. `kaede_semantic::rust_import` continues to look for `rust/Cargo.toml` at its default location. Wiring the configured path through `SemanticAnalyzer` crosses a crate boundary and is left as a follow-up (tracked inline with a comment in `manifest.rs`).

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p kaede_compiler_driver --all-targets -- -D warnings` clean
- [x] `cargo test --release --no-fail-fast -p kaede_compiler_driver` — all 81 driver tests pass (including two new `cli.rs` tests asserting manifest content for both `kaede new` and `kaede new --rust`)
- [x] Manual: `kaede new smoke_kaede && (cd smoke_kaede && kaede run)` → prints `hello, world!`
- [x] Manual: `kaede new smoke_rust --rust && (cd smoke_rust && kaede run)` → exits 30
- [x] Manual: `(cd /tmp/empty && kaede build)` → instructional "Kaede.toml not found" error
- [x] Manual: `[build] src = "code"` / `out = "bin/app"` override produces `bin/app` and `kaede run` executes it
- [x] `example/rust_interop` builds through its new manifest

## Notes

- `Kaede.toml` added to every project under `example/` (`comment_app` and `rust_interop` carry `[rust] path = "rust"`).
- Docs updated: `website/docs/getting-started/first-program.md` now shows the manifest in the project layout and explains its role; `website/docs/language/rust-interop.md` shows the `[rust]` section.

Closes #152