### PR TITLE
feat(semantic): honor Kaede.toml rust.path in rust:: imports

### DIFF
--- a/compiler/driver/src/build.rs
+++ b/compiler/driver/src/build.rs
@@ -54,11 +54,9 @@ pub(crate) fn build_project() -> anyhow::Result<PathBuf> {
     let manifest = manifest::load_from_cwd()?;
     let src_root = manifest.build.src;
     let output_path = manifest.build.out;
-    let rust_path = manifest
-        .rust
-        .as_ref()
-        .map(|r| r.path.clone())
-        .unwrap_or_else(|| PathBuf::from("rust"));
+    // `[rust]` section presence enables Rust interop; when it is absent,
+    // `import rust::<crate>` is rejected by the semantic analyzer.
+    let rust_path = manifest.rust.as_ref().map(|r| r.path.clone());
 
     if !src_root.exists() {
         anyhow::bail!(

--- a/compiler/driver/src/build.rs
+++ b/compiler/driver/src/build.rs
@@ -54,6 +54,11 @@ pub(crate) fn build_project() -> anyhow::Result<PathBuf> {
     let manifest = manifest::load_from_cwd()?;
     let src_root = manifest.build.src;
     let output_path = manifest.build.out;
+    let rust_path = manifest
+        .rust
+        .as_ref()
+        .map(|r| r.path.clone())
+        .unwrap_or_else(|| PathBuf::from("rust"));
 
     if !src_root.exists() {
         anyhow::bail!(
@@ -77,6 +82,7 @@ pub(crate) fn build_project() -> anyhow::Result<PathBuf> {
         display_llvm_ir: false,
         output_file_path: output_path.clone(),
         root_dir: Some(src_root),
+        rust_path,
         no_autoload: false,
         no_prelude: false,
         no_gc: false,

--- a/compiler/driver/src/main.rs
+++ b/compiler/driver/src/main.rs
@@ -245,7 +245,7 @@ fn compile<'ctx>(
     cgcx: &'ctx CodegenCtx<'_>,
     unit_infos: Vec<CompileUnitInfo>,
     root_dir: &'ctx Path,
-    rust_path: &Path,
+    rust_path: Option<&Path>,
     no_autoload: bool,
     no_prelude: bool,
 ) -> anyhow::Result<(Module<'ctx>, Vec<PathBuf>)> {
@@ -262,8 +262,11 @@ fn compile<'ctx>(
 
         let ast = Parser::new(&program, file).run()?;
 
-        let mut analyzer =
-            SemanticAnalyzer::new(file, root_dir.to_path_buf(), rust_path.to_path_buf());
+        let mut analyzer = SemanticAnalyzer::new(
+            file,
+            root_dir.to_path_buf(),
+            rust_path.map(Path::to_path_buf),
+        );
         let mut ir = analyzer.analyze(
             ast,
             AnalyzeOptions {
@@ -364,7 +367,7 @@ pub(crate) fn compile_and_output_obj(
         &cgcx,
         unit_infos,
         &root_dir,
-        &option.rust_path,
+        option.rust_path.as_deref(),
         option.no_autoload,
         option.no_prelude,
     )?;
@@ -394,7 +397,7 @@ pub(crate) fn compile_and_link(
         &cgcx,
         unit_infos,
         &root_dir,
-        &option.rust_path,
+        option.rust_path.as_deref(),
         option.no_autoload,
         option.no_prelude,
     )?;
@@ -426,7 +429,7 @@ pub(crate) struct CompileOption {
     display_llvm_ir: bool,
     output_file_path: PathBuf,
     root_dir: Option<PathBuf>,
-    rust_path: PathBuf,
+    rust_path: Option<PathBuf>,
     no_autoload: bool,
     no_prelude: bool,
     no_gc: bool,
@@ -474,7 +477,9 @@ fn main() -> anyhow::Result<()> {
             "a.out"
         })),
         root_dir: args.root_dir,
-        rust_path: PathBuf::from("rust"),
+        // Direct-compile mode has no manifest to consult; preserve the
+        // legacy "rust/" lookup for `import rust::<crate>`.
+        rust_path: Some(PathBuf::from("rust")),
         no_autoload: args.no_autoload,
         no_prelude: args.no_prelude,
         no_gc: args.no_gc,

--- a/compiler/driver/src/main.rs
+++ b/compiler/driver/src/main.rs
@@ -245,6 +245,7 @@ fn compile<'ctx>(
     cgcx: &'ctx CodegenCtx<'_>,
     unit_infos: Vec<CompileUnitInfo>,
     root_dir: &'ctx Path,
+    rust_path: &Path,
     no_autoload: bool,
     no_prelude: bool,
 ) -> anyhow::Result<(Module<'ctx>, Vec<PathBuf>)> {
@@ -261,7 +262,8 @@ fn compile<'ctx>(
 
         let ast = Parser::new(&program, file).run()?;
 
-        let mut analyzer = SemanticAnalyzer::new(file, root_dir.to_path_buf());
+        let mut analyzer =
+            SemanticAnalyzer::new(file, root_dir.to_path_buf(), rust_path.to_path_buf());
         let mut ir = analyzer.analyze(
             ast,
             AnalyzeOptions {
@@ -362,6 +364,7 @@ pub(crate) fn compile_and_output_obj(
         &cgcx,
         unit_infos,
         &root_dir,
+        &option.rust_path,
         option.no_autoload,
         option.no_prelude,
     )?;
@@ -391,6 +394,7 @@ pub(crate) fn compile_and_link(
         &cgcx,
         unit_infos,
         &root_dir,
+        &option.rust_path,
         option.no_autoload,
         option.no_prelude,
     )?;
@@ -422,6 +426,7 @@ pub(crate) struct CompileOption {
     display_llvm_ir: bool,
     output_file_path: PathBuf,
     root_dir: Option<PathBuf>,
+    rust_path: PathBuf,
     no_autoload: bool,
     no_prelude: bool,
     no_gc: bool,
@@ -469,6 +474,7 @@ fn main() -> anyhow::Result<()> {
             "a.out"
         })),
         root_dir: args.root_dir,
+        rust_path: PathBuf::from("rust"),
         no_autoload: args.no_autoload,
         no_prelude: args.no_prelude,
         no_gc: args.no_gc,

--- a/compiler/driver/src/manifest.rs
+++ b/compiler/driver/src/manifest.rs
@@ -15,10 +15,8 @@ pub(crate) struct KaedeManifest {
     #[allow(dead_code)]
     pub package: PackageSection,
     pub build: BuildSection,
-    // Presence of `[rust]` enables Rust interop. v1 of the manifest records
-    // the section but the compiler still defaults to `rust/` — wiring
-    // `rust.path` into `kaede_semantic::rust_import` is a follow-up task.
-    #[allow(dead_code)]
+    // Presence of `[rust]` enables Rust interop; `rust.path` tells the
+    // compiler which subdirectory holds the Rust crate.
     pub rust: Option<RustSection>,
 }
 
@@ -41,7 +39,6 @@ pub(crate) struct BuildSection {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RustSection {
-    #[allow(dead_code)]
     pub path: PathBuf,
 }
 

--- a/compiler/driver/tests/run.rs
+++ b/compiler/driver/tests/run.rs
@@ -270,6 +270,37 @@ fun main() -> i32 {
 }
 
 #[test]
+fn build_rejects_rust_import_when_rust_section_is_missing() -> anyhow::Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+
+    // Manifest omits `[rust]`, so Rust interop is not enabled even though
+    // a `rust/` directory is present on disk.
+    create_project(
+        &temp_dir,
+        "import rust::anything\n\nfun main() -> i32 { return 0 }",
+    )?;
+
+    let rust_dir = temp_dir.child("rust");
+    rust_dir.child("src").create_dir_all()?;
+    fs::write(
+        rust_dir.child("Cargo.toml").path(),
+        "[package]\nname = \"anything\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    fs::write(rust_dir.child("src/lib.rs").path(), "pub fn f() {}\n")?;
+
+    Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+        .current_dir(temp_dir.path())
+        .arg("build")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Add a `[rust]` section to Kaede.toml",
+        ));
+
+    Ok(())
+}
+
+#[test]
 fn run_resolves_rust_import_from_configured_rust_path() -> anyhow::Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
 

--- a/compiler/driver/tests/run.rs
+++ b/compiler/driver/tests/run.rs
@@ -1,6 +1,7 @@
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
+use std::fs;
 use std::process::Command;
 
 fn create_project(temp_dir: &assert_fs::TempDir, program: &str) -> anyhow::Result<()> {
@@ -257,6 +258,56 @@ fun main() -> i32 {
         Option::None => 1,
     }
 }"#,
+    )?;
+
+    Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+        .current_dir(temp_dir.path())
+        .arg("run")
+        .assert()
+        .code(predicate::eq(42));
+
+    Ok(())
+}
+
+#[test]
+fn run_resolves_rust_import_from_configured_rust_path() -> anyhow::Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+
+    // Manifest points `rust.path` at a non-default directory (`vendor`)
+    // to exercise the `rust.path` plumbing end-to-end.
+    temp_dir.child("Kaede.toml").write_str(
+        r#"[package]
+name = "custom_rust_path"
+version = "0.1.0"
+
+[build]
+src = "src"
+out = "build/custom_rust_path"
+
+[rust]
+path = "vendor"
+"#,
+    )?;
+
+    let src_dir = temp_dir.child("src");
+    src_dir.create_dir_all()?;
+    src_dir.child("main.kd").write_str(
+        r#"import rust::custom_rust_path
+
+fun main() -> i32 {
+    return rust::custom_rust_path::answer()
+}"#,
+    )?;
+
+    let vendor = temp_dir.child("vendor");
+    vendor.child("src").create_dir_all()?;
+    fs::write(
+        vendor.child("Cargo.toml").path(),
+        "[package]\nname = \"custom_rust_path\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    fs::write(
+        vendor.child("src/lib.rs").path(),
+        "pub fn answer() -> i32 { 42 }\n",
     )?;
 
     Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -70,7 +70,10 @@ impl Backend {
                 Err(err) => return diagnostics_from_parse_error(err),
             };
 
-            let mut analyzer = SemanticAnalyzer::new(file, root_dir, PathBuf::from("rust"));
+            // The LSP does not parse Kaede.toml; default to the legacy "rust/"
+            // lookup so rust-interop projects still get diagnostics for
+            // `import rust::<crate>`.
+            let mut analyzer = SemanticAnalyzer::new(file, root_dir, Some(PathBuf::from("rust")));
             let is_entry_unit = ast_has_entry_candidate(&ast);
             match analyzer.analyze(
                 ast,

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -70,7 +70,7 @@ impl Backend {
                 Err(err) => return diagnostics_from_parse_error(err),
             };
 
-            let mut analyzer = SemanticAnalyzer::new(file, root_dir);
+            let mut analyzer = SemanticAnalyzer::new(file, root_dir, PathBuf::from("rust"));
             let is_entry_unit = ast_has_entry_candidate(&ast);
             match analyzer.analyze(
                 ast,

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -73,7 +73,7 @@ pub struct SemanticAnalyzer {
     imported_rust_crates: HashSet<Symbol>,
     additional_native_libs: Vec<PathBuf>,
     root_dir: PathBuf,
-    pub(crate) rust_path: PathBuf,
+    pub(crate) rust_path: Option<PathBuf>,
     autoloads_imported: bool,
     infer_context: InferContext,
     closure_capture_stack: Vec<ClosureCapture>,
@@ -304,7 +304,7 @@ impl SemanticAnalyzer {
         module_context
     }
 
-    pub fn new(file_path: FilePath, root_dir: PathBuf, rust_path: PathBuf) -> Self {
+    pub fn new(file_path: FilePath, root_dir: PathBuf, rust_path: Option<PathBuf>) -> Self {
         if !root_dir.is_dir() {
             panic!("Root directory is not a directory");
         }
@@ -353,7 +353,7 @@ impl SemanticAnalyzer {
             imported_rust_crates: HashSet::new(),
             additional_native_libs: Vec::new(),
             root_dir: PathBuf::from("."),
-            rust_path: PathBuf::from("rust"),
+            rust_path: Some(PathBuf::from("rust")),
             autoloads_imported: false,
             infer_context: InferContext::default(),
             closure_capture_stack: Vec::new(),

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -73,6 +73,7 @@ pub struct SemanticAnalyzer {
     imported_rust_crates: HashSet<Symbol>,
     additional_native_libs: Vec<PathBuf>,
     root_dir: PathBuf,
+    pub(crate) rust_path: PathBuf,
     autoloads_imported: bool,
     infer_context: InferContext,
     closure_capture_stack: Vec<ClosureCapture>,
@@ -303,7 +304,7 @@ impl SemanticAnalyzer {
         module_context
     }
 
-    pub fn new(file_path: FilePath, root_dir: PathBuf) -> Self {
+    pub fn new(file_path: FilePath, root_dir: PathBuf, rust_path: PathBuf) -> Self {
         if !root_dir.is_dir() {
             panic!("Root directory is not a directory");
         }
@@ -325,6 +326,7 @@ impl SemanticAnalyzer {
             imported_rust_crates: HashSet::new(),
             additional_native_libs: Vec::new(),
             root_dir,
+            rust_path,
             autoloads_imported: false,
             infer_context: InferContext::default(),
             closure_capture_stack: Vec::new(),
@@ -351,6 +353,7 @@ impl SemanticAnalyzer {
             imported_rust_crates: HashSet::new(),
             additional_native_libs: Vec::new(),
             root_dir: PathBuf::from("."),
+            rust_path: PathBuf::from("rust"),
             autoloads_imported: false,
             infer_context: InferContext::default(),
             closure_capture_stack: Vec::new(),

--- a/compiler/semantic/src/rust_import.rs
+++ b/compiler/semantic/src/rust_import.rs
@@ -359,8 +359,8 @@ fn extract_fn_io(sig_container: &Value) -> Option<(&Value, &Value)> {
     Some((inputs, output))
 }
 
-fn project_root_from_root_dir(root_dir: &Path) -> anyhow::Result<PathBuf> {
-    let direct = root_dir.join("rust").join("Cargo.toml");
+fn project_root_from_root_dir(root_dir: &Path, rust_subdir: &Path) -> anyhow::Result<PathBuf> {
+    let direct = root_dir.join(rust_subdir).join("Cargo.toml");
     if direct.exists() {
         return Ok(root_dir.to_path_buf());
     }
@@ -368,13 +368,14 @@ fn project_root_from_root_dir(root_dir: &Path) -> anyhow::Result<PathBuf> {
     let parent = root_dir
         .parent()
         .ok_or_else(|| anyhow!("failed to resolve project root from {}", root_dir.display()))?;
-    let parent_manifest = parent.join("rust").join("Cargo.toml");
+    let parent_manifest = parent.join(rust_subdir).join("Cargo.toml");
     if parent_manifest.exists() {
         return Ok(parent.to_path_buf());
     }
 
     Err(anyhow!(
-        "rust/Cargo.toml not found (searched '{}' and '{}')",
+        "{}/Cargo.toml not found (searched '{}' and '{}')",
+        rust_subdir.display(),
         direct.display(),
         parent_manifest.display()
     ))
@@ -1015,18 +1016,23 @@ fn generate_shim_crate(
     Ok(Some(dylib))
 }
 
-pub fn resolve_rust_import(root_dir: &Path, crate_name: &str) -> anyhow::Result<RustImportOutput> {
-    let project_root = project_root_from_root_dir(root_dir)?;
-    let rust_manifest = project_root.join("rust").join("Cargo.toml");
+pub fn resolve_rust_import(
+    root_dir: &Path,
+    rust_subdir: &Path,
+    crate_name: &str,
+) -> anyhow::Result<RustImportOutput> {
+    let project_root = project_root_from_root_dir(root_dir, rust_subdir)?;
+    let rust_manifest = project_root.join(rust_subdir).join("Cargo.toml");
     let package_name = read_package_name(&rust_manifest)?;
     if package_name != crate_name {
         return Err(anyhow!(
-            "import rust::{crate_name} does not match rust/Cargo.toml package name `{package_name}`"
+            "import rust::{crate_name} does not match {}/Cargo.toml package name `{package_name}`",
+            rust_subdir.display()
         ));
     }
 
     run_rustdoc_json(&rust_manifest)?;
-    let rustdoc_json = rustdoc_json_path(project_root.join("rust").as_path(), crate_name)?;
+    let rustdoc_json = rustdoc_json_path(project_root.join(rust_subdir).as_path(), crate_name)?;
     let (functions, skipped) = parse_root_public_functions(&rustdoc_json, crate_name)?;
     let dylib_path = generate_shim_crate(
         &project_root,

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -358,7 +358,8 @@ impl SemanticAnalyzer {
         }
         self.imported_rust_crates.insert(crate_name);
 
-        let resolved = rust_import::resolve_rust_import(&self.root_dir, crate_name.as_str())?;
+        let resolved =
+            rust_import::resolve_rust_import(&self.root_dir, &self.rust_path, crate_name.as_str())?;
 
         if let Some(lib) = &resolved.dylib_path {
             if !self.additional_native_libs.contains(lib) {

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -358,8 +358,13 @@ impl SemanticAnalyzer {
         }
         self.imported_rust_crates.insert(crate_name);
 
+        let Some(rust_path) = self.rust_path.as_deref() else {
+            return Err(anyhow::anyhow!(
+                "`import rust::{crate_name}` requires Rust interop to be enabled. Add a `[rust]` section to Kaede.toml."
+            ));
+        };
         let resolved =
-            rust_import::resolve_rust_import(&self.root_dir, &self.rust_path, crate_name.as_str())?;
+            rust_import::resolve_rust_import(&self.root_dir, rust_path, crate_name.as_str())?;
 
         if let Some(lib) = &resolved.dylib_path {
             if !self.additional_native_libs.contains(lib) {

--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -39,6 +39,7 @@ impl ImportTestProject {
         let mut analyzer = kaede_semantic::SemanticAnalyzer::new(
             kaede_span::file::FilePath::from(main_file),
             self.temp_dir.path().to_path_buf(),
+            std::path::PathBuf::from("rust"),
         );
 
         analyzer.analyze(

--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -39,7 +39,7 @@ impl ImportTestProject {
         let mut analyzer = kaede_semantic::SemanticAnalyzer::new(
             kaede_span::file::FilePath::from(main_file),
             self.temp_dir.path().to_path_buf(),
-            std::path::PathBuf::from("rust"),
+            Some(std::path::PathBuf::from("rust")),
         );
 
         analyzer.analyze(


### PR DESCRIPTION
Stacks on top of #263.

## Summary

- Thread the configured Rust crate directory from `Kaede.toml` through `SemanticAnalyzer` so `import rust::<crate>` looks up `<rust.path>/Cargo.toml` instead of the previously hardcoded `rust/Cargo.toml`.
- `SemanticAnalyzer::new` now requires a `rust_path: PathBuf` alongside `root_dir`; it is stored on the analyzer and consumed inside `rust_import`.
- `resolve_rust_import` / `project_root_from_root_dir` accept the subdirectory as a parameter; error messages reflect the configured path.
- Driver's `CompileOption` gains a `rust_path` field. In project mode it's `manifest.rust.path` when `[rust]` is present, otherwise `"rust"`. Direct-compile mode and the LSP default to `"rust"`, so no behavior change when no manifest is available.

## Why

#263 parses `rust.path` into the manifest struct but doesn't consume it yet. This PR closes that loop.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p kaede_compiler_driver -p kaede_semantic -p kaede_lsp --all-targets -- -D warnings` clean for the touched files (the workspace has pre-existing `collapsible_match` warnings in `compiler/semantic/tests/top.rs` unrelated to this change — same ones flagged on the base PR)
- [x] `cargo test --release --no-fail-fast -p kaede_compiler_driver` — all pass, including a new integration test `run_resolves_rust_import_from_configured_rust_path` that sets `rust.path = "vendor"`, writes a crate under `vendor/`, and confirms `kaede run` builds and executes it correctly
- [x] `cargo test --release --no-fail-fast -p kaede_semantic` — all pass

## Touched files

- `compiler/semantic/src/rust_import.rs` — `project_root_from_root_dir` / `resolve_rust_import` take a `rust_subdir: &Path`; all hardcoded `.join("rust")` replaced
- `compiler/semantic/src/lib.rs` — new `rust_path` field on `SemanticAnalyzer`, added parameter to `new`
- `compiler/semantic/src/top.rs` — pass `&self.rust_path` when resolving Rust imports
- `compiler/driver/src/main.rs` — `CompileOption::rust_path`, plumbed through `compile()`
- `compiler/driver/src/build.rs` — read `manifest.rust.path` or fall back to `"rust"`
- `compiler/driver/src/manifest.rs` — drop `#[allow(dead_code)]` on the consumed fields
- `compiler/lsp/src/lib.rs`, `compiler/semantic/tests/import.rs` — pass `"rust"` default to the updated constructor
- `compiler/driver/tests/run.rs` — new integration test

## Merge order

Target: `feat/kaede-toml-manifest` (PR #263). After #263 lands on `main`, this will rebase cleanly onto `main`.