### PR TITLE
fix(driver): end scaffolded files with a trailing newline

### DIFF
--- a/compiler/driver/src/new.rs
+++ b/compiler/driver/src/new.rs
@@ -16,9 +16,7 @@ fn create_kaede_only_project(project_dir: &Path, project_name: &str) -> anyhow::
     fs::create_dir_all(&src_dir)?;
     fs::write(
         src_dir.join("main.kd"),
-        r#"fun main() {
-    println("hello, world!")
-}"#,
+        "fun main() {\n    println(\"hello, world!\")\n}\n",
     )?;
 
     println!("✅ Successfully created Kaede project: {project_name}");
@@ -68,15 +66,13 @@ fn create_rust_bridge_project(project_dir: &Path, project_name: &str) -> anyhow:
     fs::write(
         src_dir.join("main.kd"),
         format!(
-            "import rust::{project_name}\n\nfun main() -> i32 {{\n    return rust::{project_name}::add(10, 20)\n}}"
+            "import rust::{project_name}\n\nfun main() -> i32 {{\n    return rust::{project_name}::add(10, 20)\n}}\n"
         ),
     )?;
 
     // Step 4: Create lib.rs file
     let lib_rs_path = rust_dir.join("src/lib.rs");
-    let lib_rs_content = r#"pub fn add(a: i32, b: i32) -> i32 {
-    a + b
-}"#;
+    let lib_rs_content = "pub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n";
     fs::write(&lib_rs_path, lib_rs_content)?;
 
     println!("✅ Successfully created Kaede Rust interop project: {project_name}");

--- a/compiler/driver/tests/cli.rs
+++ b/compiler/driver/tests/cli.rs
@@ -40,9 +40,7 @@ fn new_creates_hello_world_main() -> anyhow::Result<()> {
     main.assert(predicate::path::is_file());
     assert_eq!(
         fs::read_to_string(main.path())?,
-        r#"fun main() {
-    println("hello, world!")
-}"#,
+        "fun main() {\n    println(\"hello, world!\")\n}\n",
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- `kaede new` wrote `src/main.kd` (and `rust/src/lib.rs` for `--rust`) without a final `\n`.
- Git shows "No newline at end of file" the moment a user edits them, and rustfmt silently rewrites `lib.rs` on first save.
- Align with the POSIX convention so the generated files are a good starting point, not something tooling immediately corrects.

## Change

- Replace the raw-string literals / `format!` template with explicit `"..\n"` strings that end in a newline.
- Update the `new_creates_hello_world_main` test assertion to match.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p kaede_compiler_driver --all-targets -- -D warnings`
- [x] `cargo test --release -p kaede_compiler_driver --test cli`