### PR TITLE
fix: bake runtime RPATH on Linux, plus install.py groundwork for external packagers

### DIFF
--- a/compiler/common/src/lib.rs
+++ b/compiler/common/src/lib.rs
@@ -52,10 +52,6 @@ pub fn kaede_autoload_dir() -> PathBuf {
 }
 
 pub fn kaede_runtime_linker_flags() -> Vec<OsString> {
-    if !cfg!(target_os = "macos") {
-        return Vec::new();
-    }
-
     let mut flags = Vec::new();
 
     for lib_dir in std::iter::once(kaede_lib_dir()).chain(kaede_third_party_lib_dirs()) {

--- a/install.py
+++ b/install.py
@@ -1,15 +1,39 @@
 #!/usr/bin/env python3
 
+import argparse
 import os
-import sys
 import library
 import shutil
 
 
-unexpanded_kaede_dir = "$HOME/.kaede"
+def parse_args():
+    parser = argparse.ArgumentParser(description="Install the Kaede toolchain.")
+    parser.add_argument(
+        "--prefix",
+        default=None,
+        help="Install directory (default: $HOME/.kaede). When set, the env "
+        "activation script is not written and shell init files are not "
+        "touched — the caller is expected to wire up the environment.",
+    )
+    parser.add_argument(
+        "--no-setenv",
+        action="store_true",
+        help="Write the env activation script but don't modify shell init files.",
+    )
+    return parser.parse_args()
+
+
+args = parse_args()
+
+if args.prefix is not None:
+    kaede_dir = os.path.abspath(args.prefix)
+    unexpanded_kaede_dir = kaede_dir
+else:
+    unexpanded_kaede_dir = "$HOME/.kaede"
+    kaede_dir = os.path.expandvars(unexpanded_kaede_dir)
+
 unexpanded_kaede_bin_dir = os.path.join(unexpanded_kaede_dir, "bin")
-kaede_dir = os.path.expandvars(unexpanded_kaede_dir)
-kaede_bin_dir = os.path.expandvars(unexpanded_kaede_bin_dir)
+kaede_bin_dir = os.path.join(kaede_dir, "bin")
 
 
 def shell_initialize_file():
@@ -37,7 +61,7 @@ def install_compiler():
     print("Installing compiler...")
 
     # Binary was already built by `cargo run --release` invocations in library.install.
-    shutil.move("target/release/kaede", os.path.join(kaede_dir, "bin"))
+    shutil.move("target/release/kaede", os.path.join(kaede_bin_dir, "kaede"))
 
     print("Done!")
 
@@ -48,6 +72,11 @@ def install():
 
 
 def create_shell_script_for_setting_env():
+    # When --prefix is set, the caller (e.g. a packaging system) is expected
+    # to handle environment wiring on its own.
+    if args.prefix is not None:
+        return
+
     import platform
 
     lib_extension = (
@@ -67,7 +96,7 @@ def create_shell_script_for_setting_env():
             ]
         )
 
-    if "--no-setenv" in sys.argv:
+    if args.no_setenv:
         return
 
     shell_init_file = shell_initialize_file()
@@ -97,14 +126,17 @@ def create_shell_script_for_setting_env():
 
 
 if __name__ == "__main__":
-    if os.path.exists(kaede_dir):
+    # Auto-clean only the default location. When --prefix is supplied, the
+    # caller owns the directory's lifecycle and may have already populated
+    # it (e.g. a packaging system staging files under its build prefix).
+    if args.prefix is None and os.path.exists(kaede_dir):
         print(
             "Existing installation found at '%s'. Removing and reinstalling..."
             % kaede_dir
         )
         shutil.rmtree(kaede_dir)
 
-    os.makedirs(kaede_bin_dir)
+    os.makedirs(kaede_bin_dir, exist_ok=True)
 
     install()
 

--- a/install.py
+++ b/install.py
@@ -77,13 +77,6 @@ def create_shell_script_for_setting_env():
     if args.prefix is not None:
         return
 
-    import platform
-
-    lib_extension = (
-        "DYLD_LIBRARY_PATH" if platform.system() == "Darwin" else "LD_LIBRARY_PATH"
-    )
-    bdwgc_lib_path = os.path.join(unexpanded_kaede_dir, "third_party", "bdwgc", "lib")
-
     env_script_path = os.path.join(unexpanded_kaede_dir, "env")
     with open(os.path.expandvars(env_script_path), "w+") as f:
         f.writelines(
@@ -91,8 +84,6 @@ def create_shell_script_for_setting_env():
                 "#!/bin/sh\n",
                 "\n",
                 'export PATH="%s:$PATH"\n' % unexpanded_kaede_bin_dir,
-                "\n",
-                'export %s="%s:$%s"\n' % (lib_extension, bdwgc_lib_path, lib_extension),
             ]
         )
 

--- a/library/__init__.py
+++ b/library/__init__.py
@@ -146,6 +146,7 @@ def install_standard_library(
         env=env,
         check=True,
     )
+    bdwgc_lib_dir = os.path.dirname(bdwgc_lib_path)
     subprocess.run(
         [
             cc,
@@ -158,6 +159,10 @@ def install_standard_library(
             *openssl_cflags,
             "-o",
             kaede_lib_path,
+            # Bake an RPATH pointing to the bdwgc dir so libkd.so resolves
+            # libgc.so.1 on its own. DT_RUNPATH is non-transitive, so the
+            # consumer binary's runpath does not cover libkd.so's deps.
+            "-Wl,-rpath,%s" % bdwgc_lib_dir,
             t1.name,
             t2.name,
             *ffi_c_files,

--- a/library/__init__.py
+++ b/library/__init__.py
@@ -55,6 +55,11 @@ def install_bdwgc(third_party_dir):
             "cmake",
             "-DCMAKE_BUILD_TYPE=Release",
             "-DCMAKE_INSTALL_PREFIX='%s'" % install_dir,
+            # Pin libdir to "lib" so we know where libgc lands. bdwgc's
+            # CMakeLists uses GNUInstallDirs, which picks lib64 on some
+            # 64-bit distros (e.g. Fedora) and breaks the rest of the
+            # install that hard-codes <prefix>/lib/libgc.{so,dylib}.
+            "-DCMAKE_INSTALL_LIBDIR=lib",
             "-S",
             bdwgc_dir,
             "-B",


### PR DESCRIPTION
## Summary

Originally this PR added `packages.default` to the flake to produce a full kaede toolchain, but `result/` from `nix build` references `/nix/store/...` paths and so isn't directly distributable to non-Nix users. Reverted the nix-bundling work and kept only the changes that stand on their own value, regardless of nix.

- **`fix(install): pin bdwgc CMAKE_INSTALL_LIBDIR to lib`** — bdwgc's CMakeLists uses `GNUInstallDirs`, which lands under `lib64` on some 64-bit distros (e.g. Fedora). The rest of `install.py` hard-codes `<prefix>/lib/libgc.{so,dylib}`, so without this pin the install silently lands in the wrong dir and the stdlib link step fails to find libgc. This is a real bug on those distros independent of nix.
- **`feat(install): add --prefix flag for external build systems`** — `install.py` learns `--prefix` and `--no-setenv`. With `--prefix`, the env activation script is not written and shell init files aren't touched (the caller handles environment wiring). `install_compiler` is also made idempotent so it doesn't fail when an external build system has already placed the binary at the destination. Useful for any future packaging effort (Homebrew, deb, etc.); not nix-specific.
- **`fix: bake runtime RPATH on Linux, drop LD_LIBRARY_PATH from env`** — `kaede_runtime_linker_flags()` previously short-circuited on non-macOS, so kaede-emitted binaries on Linux had no RPATH and relied on `LD_LIBRARY_PATH` from `~/.kaede/env` to locate `libgc.so.1`. Drop the macOS guard so Linux output binaries also get `$KAEDE_DIR/lib + third_party/<gc>/lib` in their RUNPATH. Also bake `-Wl,-rpath,$bdwgc_lib_dir` into `libkd.so` itself, since `DT_RUNPATH` is non-transitive on modern glibc and the consumer binary's runpath does not cover `libkd.so`'s own `NEEDED libgc.so.1`. With both pieces in place, `LD_LIBRARY_PATH` in the generated env script is dead weight, so drop it; the script now only sets PATH.

## Notes

- The original `packages.default` work (and `bdwgc-src` / `rust-overlay` flake inputs) is dropped. `devShells.default` is unchanged.
- The bdwgc libdir fix and the `--prefix` flag were originally motivated by the nix derivation, but they're independently useful for non-nix distributions and kept.
- #272 is left open — the original ask (nix-bundle distribution) wasn't actually solved, see follow-up comment there.

## Test plan

- [x] \`./install.py --no-setenv\` succeeds; \`~/.kaede/bin/kaede\` runs end-to-end
- [x] Output binary runs without \`LD_LIBRARY_PATH\` (\`env -u LD_LIBRARY_PATH ./build/...\`)
- [x] \`./install.py --help\` shows \`--prefix\` and \`--no-setenv\`
- [x] \`cargo test --release\` passes locally
- [x] CI green