### PR TITLE
ci(nix): add Magic Nix Cache to Linux and macOS jobs

### DIFF
--- a/.github/workflows/ci-nix-linux.yml
+++ b/.github/workflows/ci-nix-linux.yml
@@ -6,6 +6,9 @@ jobs:
   check-and-test:
     name: Check and test (Nix)
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -13,6 +16,9 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Set up Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Cache rust
         id: cache-rust

--- a/.github/workflows/ci-nix-macos.yml
+++ b/.github/workflows/ci-nix-macos.yml
@@ -6,6 +6,9 @@ jobs:
   check-and-test:
     name: Check and test (Nix)
     runs-on: macos-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -13,6 +16,9 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Set up Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Cache rust
         id: cache-rust


### PR DESCRIPTION
## Summary
- Add `DeterminateSystems/magic-nix-cache-action@main` after the Nix installer in both `ci-nix-linux.yml` and `ci-nix-macos.yml`. It backs the Nix store with the GitHub Actions cache so subsequent runs only re-fetch what changed in `flake.lock`, instead of pulling the entire dev-shell closure from `cache.nixos.org` every cold run.
- Grant each job `id-token: write` / `contents: read` so the action can opportunistically use FlakeHub OIDC (per [upstream README](https://github.com/DeterminateSystems/magic-nix-cache-action#usage)).

## Why
Per #271, cold macOS CI went from ~2m24s (brew) to ~8m26s (nix) after #267. The closure download dominates that gap. Picking option (1) from the issue (zero-config Magic Nix Cache) as the easiest first step; if it ever stops being free / supported we can migrate to a self-hosted Cachix.

Closes #271.

## Test plan
- [x] First post-merge run on each OS still succeeds (cache is empty — no speedup expected yet).
- [x] Second run on each OS shows the Magic Nix Cache step reporting cache hits and the overall wall-clock dropping noticeably (especially macOS).
- [ ] Confirm no `id-token` / permission errors in the action logs.