### PR TITLE
ci(nix): disable FlakeHub upload in Magic Nix Cache

### DIFF
--- a/.github/workflows/ci-nix-linux.yml
+++ b/.github/workflows/ci-nix-linux.yml
@@ -6,9 +6,6 @@ jobs:
   check-and-test:
     name: Check and test (Nix)
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,6 +16,8 @@ jobs:
 
       - name: Set up Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
 
       - name: Cache rust
         id: cache-rust

--- a/.github/workflows/ci-nix-macos.yml
+++ b/.github/workflows/ci-nix-macos.yml
@@ -6,9 +6,6 @@ jobs:
   check-and-test:
     name: Check and test (Nix)
     runs-on: macos-latest
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,6 +16,8 @@ jobs:
 
       - name: Set up Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
 
       - name: Cache rust
         id: cache-rust


### PR DESCRIPTION
## Summary
Pin `use-flakehub: false` on the `magic-nix-cache-action` step in both Nix CI workflows, and drop the now-unused `id-token: write` / `contents: read` job permissions.

## Why
After #276 merged, every CI run logs a red error from the cache step:

\`\`\`
ERROR magic_nix_cache: FlakeHub: cache initialized failed: Unauthenticated: Cannot find netrc credentials for https://api.flakehub.com/
Error: Unable to authenticate to FlakeHub. Individuals must register at FlakeHub.com; ...
\`\`\`

The action defaults to opportunistically uploading to FlakeHub Cache *in addition to* the GitHub Actions cache. We don't have a FlakeHub account, so that auth always fails. The action still falls back to the GHA cache (which is the part we actually want), but the noisy ERROR is misleading.

Disabling FlakeHub silences the error and removes the need for the OIDC permission grant.

## Test plan
- [x] First post-merge run on each OS still passes, with no FlakeHub error in the Magic Nix Cache step.
- [x] Second run shows GHA cache hits and a noticeable wall-clock drop, same as #271 expected.