### PR TITLE
feat(stdlib): migrate I/O failures from Option to Result<T, IoError>

### DIFF
--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -5116,7 +5116,8 @@ fn user_defined_reader_flows_through_stdlib_read_exact() -> anyhow::Result<()> {
         import std.sys
 
         use std.io.Reader
-        use std.option.Option
+        use std.io.IoError
+        use std.result.Result
         use std.io.read_exact
 
         struct ByteSource {
@@ -5124,13 +5125,13 @@ fn user_defined_reader_flows_through_stdlib_read_exact() -> anyhow::Result<()> {
         }
 
         impl ByteSource {
-            fun read(self, buf: mut [u8]) -> Option<u64> {
+            fun read(self, buf: mut [u8]) -> Result<u64, IoError> {
                 let mut i = 0
                 while i < buf.len() {
                     buf[i] = self.value
                     i += 1
                 }
-                return Option::Some(buf.len())
+                return Result::Ok(buf.len())
             }
         }
 
@@ -5138,8 +5139,8 @@ fn user_defined_reader_flows_through_stdlib_read_exact() -> anyhow::Result<()> {
             let src = ByteSource { value: 7 }
             let mut buf = [0; 4]
             let n = match read_exact(src, buf, 4) {
-                Option::Some(value) => value,
-                Option::None => return 1,
+                Result::Ok(value) => value,
+                Result::Err(_) => return 1,
             }
             if n != 4 { return 2 }
             if buf[0] != 7 { return 3 }
@@ -5164,15 +5165,16 @@ fn user_defined_writer_flows_through_stdlib_http_helper() -> anyhow::Result<()> 
         use std.net.http.Status
         use std.net.http.write_status_line
         use std.io.Writer
-        use std.option.Option
+        use std.io.IoError
+        use std.result.Result
 
         struct AcceptAll {
             tag: i32,
         }
 
         impl AcceptAll {
-            fun write(self, buf: [u8]) -> Option<u64> {
-                return Option::Some(buf.len())
+            fun write(self, buf: [u8]) -> Result<u64, IoError> {
+                return Result::Ok(buf.len())
             }
         }
 

--- a/compiler/driver/tests/runtime_netpoll.rs
+++ b/compiler/driver/tests/runtime_netpoll.rs
@@ -119,15 +119,15 @@ use std.sync.WaitGroup
 fun handle(conn: std.sys.Fd, wg: mut WaitGroup) {{
     let mut buf = [0; 1]
     let n = match conn.read(buf) {{
-        std.option.Option::Some(value) => value,
-        std.option.Option::None => {{
+        std.result.Result::Ok(value) => value,
+        std.result.Result::Err(_) => {{
             std.sys.close_quiet(conn)
             wg.done()
             return
         }}
     }}
 
-    if n > 0 && conn.write(b"ok").is_none() {{
+    if n > 0 && conn.write(b"ok").is_err() {{
         std.sys.close_quiet(conn)
         wg.done()
         return

--- a/library/src/std/fs.kd
+++ b/library/src/std/fs.kd
@@ -1,19 +1,22 @@
 import std.sys
+import std.io
+import std.result
 import std.ffi.sys
-import std.option
 
 use std.sys.Fd
-use std.option.Option
+use std.io.IoError
+use std.result.Result
 use std.ffi.sys.__sys_open_read
+use std.ffi.sys.__sys_errno
 use std.ffi.sys.__sys_is_regular_file
 
-export fun open_read(path: str) -> Option<Fd> {
+export fun open_read(path: str) -> Result<Fd, IoError> {
     let fd = __sys_open_read(path.as_ptr(), path.len())
     if fd < 0 {
-        return Option::None
+        return Result::Err(IoError::from_errno(__sys_errno()))
     }
 
-    return Option::Some(Fd::new(fd))
+    return Result::Ok(Fd::new(fd))
 }
 
 export fun is_regular_file(fd: Fd) -> bool {

--- a/library/src/std/io.kd
+++ b/library/src/std/io.kd
@@ -1,21 +1,70 @@
 import std.ffi.io
 import std.collections
-import std.option
+import std.result
 
 use std.ffi.io.write
 use std.collections.Vector
-use std.option.Option
+use std.result.Result
 
-// A source of bytes. Implementors populate `buf` and return how many bytes were
-// read, or `None` on failure. A return of `Some(0)` signals end-of-stream.
-export interface Reader {
-    fun read(self, buf: mut [u8]) -> Option<u64>
+// Coarse classification of an I/O failure. `from_errno` maps a few well-known
+// errnos to a kind so callers can branch without parsing errno themselves;
+// everything else falls through to `Other`. The numeric mapping is currently
+// Linux-flavored — macOS' EAGAIN (35) won't classify as `WouldBlock` until
+// we expose errno constants from the runtime.
+export enum IoErrorKind {
+    WouldBlock,
+    Interrupted,
+    BrokenPipe,
+    Other,
 }
 
-// A sink of bytes. Implementors consume `buf` and return how many bytes were
-// written, or `None` on failure.
+// Failure shape for the I/O surface. `errno` is the raw OS-level value at
+// the point of failure; `kind` is a best-effort classification for callers
+// that don't want to compare errno directly.
+export struct IoError {
+    kind: IoErrorKind,
+    errno: i32,
+}
+
+impl IoError {
+    export fun new(kind: IoErrorKind, errno: i32) -> IoError {
+        return IoError { kind, errno }
+    }
+
+    export fun from_errno(errno: i32) -> IoError {
+        let kind = if errno == 11 {
+            IoErrorKind::WouldBlock
+        } else if errno == 4 {
+            IoErrorKind::Interrupted
+        } else if errno == 32 {
+            IoErrorKind::BrokenPipe
+        } else {
+            IoErrorKind::Other
+        }
+        return IoError { kind, errno }
+    }
+
+    export fun kind(self) -> IoErrorKind {
+        return self.kind
+    }
+
+    export fun errno(self) -> i32 {
+        return self.errno
+    }
+}
+
+// A source of bytes. Implementors populate `buf` and return how many bytes
+// were read, or an `IoError` on failure. A return of `Ok(0)` signals
+// end-of-stream — the same convention as Rust's `io::Read` and the
+// underlying `read(2)` syscall.
+export interface Reader {
+    fun read(self, buf: mut [u8]) -> Result<u64, IoError>
+}
+
+// A sink of bytes. Implementors consume `buf` and return how many bytes
+// were written, or an `IoError` on failure.
 export interface Writer {
-    fun write(self, buf: [u8]) -> Option<u64>
+    fun write(self, buf: [u8]) -> Result<u64, IoError>
 }
 
 export fun print(msg: str) -> i32 {
@@ -37,30 +86,30 @@ export fun eprintln(msg: str) -> i32 {
 }
 
 // Read exactly `len` bytes unless EOF is hit; returns bytes read.
-export fun read_exact<R: Reader>(r: R, buf: mut [u8], len: u64) -> Option<u64> {
+export fun read_exact<R: Reader>(r: R, buf: mut [u8], len: u64) -> Result<u64, IoError> {
     let mut read_total = 0
     while read_total < len {
         let mut slice = buf[read_total:buf.len()]
         let n = match r.read(slice) {
-            Option::Some(value) => value,
-            Option::None => return Option::None,
+            Result::Ok(value) => value,
+            Result::Err(err) => return Result::Err(err),
         }
         if n == 0 {
             break
         }
         read_total += n
     }
-    return Option::Some(read_total)
+    return Result::Ok(read_total)
 }
 
-export fun read_all<R: Reader>(r: R, max_bytes: u64) -> Option<Vector<u8>> {
+export fun read_all<R: Reader>(r: R, max_bytes: u64) -> Result<Vector<u8>, IoError> {
     let mut out = Vector<u8>::new()
     let mut buf = [0; 4096]
 
     loop {
         let n = match r.read(buf) {
-            Option::Some(value) => value,
-            Option::None => return Option::None,
+            Result::Ok(value) => value,
+            Result::Err(err) => return Result::Err(err),
         }
 
         if n == 0 {
@@ -68,7 +117,9 @@ export fun read_all<R: Reader>(r: R, max_bytes: u64) -> Option<Vector<u8>> {
         }
 
         if out.len() + n > max_bytes {
-            return Option::None
+            // Buffer cap exceeded — surface as an Other error since we don't
+            // have a dedicated `BufferFull` kind yet.
+            return Result::Err(IoError::new(IoErrorKind::Other, 0))
         }
 
         let mut i = 0
@@ -78,10 +129,10 @@ export fun read_all<R: Reader>(r: R, max_bytes: u64) -> Option<Vector<u8>> {
         }
     }
 
-    return Option::Some(out)
+    return Result::Ok(out)
 }
 
-export fun read_until<R: Reader>(r: R, buf: mut [u8], delim: [u8]) -> Option<u64> {
+export fun read_until<R: Reader>(r: R, buf: mut [u8], delim: [u8]) -> Result<u64, IoError> {
     let mut filled = 0
 
     loop {
@@ -93,19 +144,19 @@ export fun read_until<R: Reader>(r: R, buf: mut [u8], delim: [u8]) -> Option<u64
         // bytes that belong to the next request on the same connection.
         let mut tail = buf[filled:(filled + 1)]
         let n = match r.read(tail) {
-            Option::Some(value) => value,
-            Option::None => return Option::None,
+            Result::Ok(value) => value,
+            Result::Err(err) => return Result::Err(err),
         }
         if n == 0 {
             // EOF: caller decides how to handle closed connection
-            return Option::Some(0)
+            return Result::Ok(0)
         }
 
         filled += n
 
         let p = find_subslice(buf[0:filled], delim)
         if p >= 0 {
-            return Option::Some((p as u64) + delim.len())
+            return Result::Ok((p as u64) + delim.len())
         }
     }
 

--- a/library/src/std/net/http.kd
+++ b/library/src/std/net/http.kd
@@ -3,6 +3,7 @@ import std.string
 import std.collections
 import std.io
 import std.option
+import std.result
 import std.fs
 import std.net.tcp
 import std.ffi.http
@@ -18,6 +19,7 @@ use std.io.read_exact
 use std.io.read_all
 use std.io.read_until
 use std.option.Option
+use std.result.Result
 use std.fs.open_read
 use std.fs.is_regular_file
 use std.net.tcp.accept
@@ -320,7 +322,7 @@ impl Response {
             self.mark_write_failed()
             return
         }
-        if self.close_conn && self.conn.write(b"Connection: close\r\n").is_none() {
+        if self.close_conn && self.conn.write(b"Connection: close\r\n").is_err() {
             self.mark_write_failed()
             return
         }
@@ -332,11 +334,11 @@ impl Response {
             self.mark_write_failed()
             return
         }
-        if self.conn.write(b"\r\n").is_none() {
+        if self.conn.write(b"\r\n").is_err() {
             self.mark_write_failed()
             return
         }
-        if self.conn.write(bytes).is_none() {
+        if self.conn.write(bytes).is_err() {
             self.mark_write_failed()
         }
     }
@@ -808,7 +810,7 @@ export fun parse_content_length(header: [u8]) -> i32 {
 
 fun write_content_length<W: Writer>(conn: W, len: u64) -> bool {
     let prefix = b"Content-Length: "
-    if conn.write(prefix).is_none() {
+    if conn.write(prefix).is_err() {
         return false
     }
 
@@ -835,21 +837,21 @@ fun write_content_length<W: Writer>(conn: W, len: u64) -> bool {
         j -= 1
         let mut one = [0; 1]
         one[0] = digits[j]
-        if conn.write(one).is_none() {
+        if conn.write(one).is_err() {
             return false
         }
     }
 
-    return conn.write(b"\r\n").is_some()
+    return conn.write(b"\r\n").is_ok()
 }
 
 export fun write_status_line<W: Writer>(conn: W, status: Status) -> bool {
     match status {
-        Status::Ok => return conn.write(b"HTTP/1.1 200 OK\r\n").is_some(),
-        Status::NotFound => return conn.write(b"HTTP/1.1 404 Not Found\r\n").is_some(),
-        Status::BadRequest => return conn.write(b"HTTP/1.1 400 Bad Request\r\n").is_some(),
-        Status::PayloadTooLarge => return conn.write(b"HTTP/1.1 413 Payload Too Large\r\n").is_some(),
-        Status::InternalServerError => return conn.write(b"HTTP/1.1 500 Internal Server Error\r\n").is_some(),
+        Status::Ok => return conn.write(b"HTTP/1.1 200 OK\r\n").is_ok(),
+        Status::NotFound => return conn.write(b"HTTP/1.1 404 Not Found\r\n").is_ok(),
+        Status::BadRequest => return conn.write(b"HTTP/1.1 400 Bad Request\r\n").is_ok(),
+        Status::PayloadTooLarge => return conn.write(b"HTTP/1.1 413 Payload Too Large\r\n").is_ok(),
+        Status::InternalServerError => return conn.write(b"HTTP/1.1 500 Internal Server Error\r\n").is_ok(),
     }
 
     return false
@@ -859,16 +861,16 @@ fun write_response_headers<W: Writer>(conn: W, headers: Vector<ResponseHeader>) 
     let mut i = 0
     while i < headers.len() {
         let header = headers.at(i).unwrap()
-        if conn.write(header.name.as_str().to_bytes().as_slice()).is_none() {
+        if conn.write(header.name.as_str().to_bytes().as_slice()).is_err() {
             return false
         }
-        if conn.write(b": ").is_none() {
+        if conn.write(b": ").is_err() {
             return false
         }
-        if conn.write(header.value.as_str().to_bytes().as_slice()).is_none() {
+        if conn.write(header.value.as_str().to_bytes().as_slice()).is_err() {
             return false
         }
-        if conn.write(b"\r\n").is_none() {
+        if conn.write(b"\r\n").is_err() {
             return false
         }
         i += 1
@@ -881,35 +883,35 @@ export fun write_text_response<W: Writer>(conn: W, close_conn: bool, status: Sta
     if !write_status_line(conn, status) {
         return false
     }
-    if close_conn && conn.write(b"Connection: close\r\n").is_none() {
+    if close_conn && conn.write(b"Connection: close\r\n").is_err() {
         return false
     }
     if !write_content_length(conn, body.len()) {
         return false
     }
-    if conn.write(b"\r\n").is_none() {
+    if conn.write(b"\r\n").is_err() {
         return false
     }
-    return conn.write(body).is_some()
+    return conn.write(body).is_ok()
 }
 
 fun write_websocket_upgrade_response<W: Writer>(conn: W, accept_value: [u8]) -> bool {
-    if conn.write(b"HTTP/1.1 101 Switching Protocols\r\n").is_none() {
+    if conn.write(b"HTTP/1.1 101 Switching Protocols\r\n").is_err() {
         return false
     }
-    if conn.write(b"Upgrade: websocket\r\n").is_none() {
+    if conn.write(b"Upgrade: websocket\r\n").is_err() {
         return false
     }
-    if conn.write(b"Connection: Upgrade\r\n").is_none() {
+    if conn.write(b"Connection: Upgrade\r\n").is_err() {
         return false
     }
-    if conn.write(b"Sec-WebSocket-Accept: ").is_none() {
+    if conn.write(b"Sec-WebSocket-Accept: ").is_err() {
         return false
     }
-    if conn.write(accept_value).is_none() {
+    if conn.write(accept_value).is_err() {
         return false
     }
-    return conn.write(b"\r\n\r\n").is_some()
+    return conn.write(b"\r\n\r\n").is_ok()
 }
 
 // Writes a WebSocket control frame and enforces its payload size limit.
@@ -947,7 +949,7 @@ fun write_ws_frame<W: Writer>(conn: W, opcode: u8, payload: [u8]) -> bool {
         10
     }
 
-    if conn.write(header[0:header_len]).is_none() {
+    if conn.write(header[0:header_len]).is_err() {
         return false
     }
 
@@ -955,14 +957,14 @@ fun write_ws_frame<W: Writer>(conn: W, opcode: u8, payload: [u8]) -> bool {
         return true
     }
 
-    return conn.write(payload).is_some()
+    return conn.write(payload).is_ok()
 }
 
 // Reads an exact number of bytes and reports whether it succeeded.
 fun read_exact_bytes<R: Reader>(r: R, buf: mut [u8], len: u64) -> bool {
     return match read_exact(r, buf, len) {
-        Option::Some(n) => n == len,
-        Option::None => false,
+        Result::Ok(n) => n == len,
+        Result::Err(_) => false,
     }
 }
 
@@ -1006,8 +1008,8 @@ fun read_ws_payload<R: Reader>(conn: R, payload_len: u64, mask_key: [u8]) -> Opt
     while remaining > 0 {
         let want = if remaining > chunk.len() { chunk.len() } else { remaining }
         let read = match read_exact(conn, chunk, want) {
-            Option::Some(value) => value,
-            Option::None => return Option::None,
+            Result::Ok(value) => value,
+            Result::Err(_) => return Option::None,
         }
         if read != want {
             return Option::None
@@ -1047,8 +1049,8 @@ fun discard_ws_frame_body<R: Reader>(conn: R, len: u64) -> bool {
 fun read_ws_frame<R: Reader>(conn: R) -> FrameReadResult {
     let mut first_bytes = [0; 2]
     let n = match read_exact(conn, first_bytes, 2) {
-        Option::Some(value) => value,
-        Option::None => return FrameReadResult::Closed,
+        Result::Ok(value) => value,
+        Result::Err(_) => return FrameReadResult::Closed,
     }
     if n == 0 {
         return FrameReadResult::Closed
@@ -1566,8 +1568,8 @@ fun serve_static_path(res: mut Response, fs_path: String) {
     }
 
     let file = match open_read(fs_path.as_str()) {
-        Option::Some(fd) => fd,
-        Option::None => {
+        Result::Ok(fd) => fd,
+        Result::Err(_) => {
             res.status(Status::NotFound).send(b"")
             return
         }
@@ -1580,8 +1582,8 @@ fun serve_static_path(res: mut Response, fs_path: String) {
     }
 
     let bytes = match read_all(file, 4 * 1024 * 1024) {
-        Option::Some(value) => value,
-        Option::None => {
+        Result::Ok(value) => value,
+        Result::Err(_) => {
             close_quiet(file)
             res.status(Status::InternalServerError).send(b"")
             return
@@ -1629,8 +1631,8 @@ fun handle_conn(conn: Fd, app: App) {
         let mut buf = [0; 8192]
 
         let n = match read_until(conn, buf, b"\r\n\r\n") {
-            Option::Some(value) => value,
-            Option::None => break,
+            Result::Ok(value) => value,
+            Result::Err(_) => break,
         }
         if n == 0 {
             break
@@ -1712,8 +1714,8 @@ fun handle_conn(conn: Fd, app: App) {
             // Request bodies can arrive across multiple socket reads, so consume
             // exactly Content-Length bytes before dispatching the handler.
             body_len = match read_exact(conn, body, content_length as u64) {
-                Option::Some(value) => value,
-                Option::None => break,
+                Result::Ok(value) => value,
+                Result::Err(_) => break,
             }
             if body_len != content_length as u64 {
                 break

--- a/library/src/std/sys.kd
+++ b/library/src/std/sys.kd
@@ -1,7 +1,10 @@
 import std.ffi.sys
-import std.option
+import std.io
+import std.result
 
-use std.option.Option
+use std.io.IoError
+use std.io.IoErrorKind
+use std.result.Result
 
 use std.ffi.sys.__sys_read
 use std.ffi.sys.__sys_write
@@ -22,15 +25,15 @@ impl Fd {
         return self.raw
     }
 
-    export fun read(self, buf: mut [u8]) -> Option<u64> {
+    export fun read(self, buf: mut [u8]) -> Result<u64, IoError> {
         let n = __sys_read(self.raw, buf.as_ptr(), buf.len())
         if n < 0 {
-            return Option::None
+            return Result::Err(IoError::from_errno(__sys_errno()))
         }
-        return Option::Some(n as u64)
+        return Result::Ok(n as u64)
     }
 
-    export fun write(self, buf: [u8]) -> Option<u64> {
+    export fun write(self, buf: [u8]) -> Result<u64, IoError> {
         let mut off = 0
         let total = buf.len()
 
@@ -43,17 +46,19 @@ impl Fd {
             let n = __sys_write(self.raw, ptr, rem)
 
             if n < 0 {
-                return Option::None
+                return Result::Err(IoError::from_errno(__sys_errno()))
             }
 
             if n == 0 {
-                return Option::None
+                // Zero-length write usually means the peer is gone. There's no
+                // dedicated errno here, so report it as a broken pipe.
+                return Result::Err(IoError::new(IoErrorKind::BrokenPipe, 0))
             }
 
             off += n as u64
         }
 
-        return Option::Some(total)
+        return Result::Ok(total)
     }
 }
 


### PR DESCRIPTION
## Summary

Switches the stdlib's I/O surface from `Option<T>` (collapsing every failure into `None`) to `Result<T, IoError>` so callers can distinguish EOF from transient syscall failure from real error, and propagate diagnostics.

## What changes

- New `std.io.IoError { kind, errno }` carrying the OS errno plus a coarse `IoErrorKind` (`WouldBlock`, `Interrupted`, `BrokenPipe`, `Other`). `IoError::from_errno` does a best-effort mapping. Linux-flavored numerics for now; macOS' `EAGAIN` (35) won't classify as `WouldBlock` until we expose errno constants from the runtime.
- `Reader::read` / `Writer::write` interfaces and their implementors (`Fd::read`, `Fd::write`) now return `Result<u64, IoError>`. EOF stays as `Ok(0)` — same convention as Rust's `io::Read` and the underlying `read(2)` syscall.
- `read_exact`, `read_all`, `read_until` (`std.io`) and `open_read` (`std.fs`) likewise return `Result<_, IoError>`.
- All call sites in `std.net.http` updated: response writers, status line, websocket frame I/O, static file serving, request parsing.

## What stays as `Option`

- `http`'s internal `read_ws_*` helpers (`read_ws_len16`, `read_ws_len64`, `read_ws_payload`) still return `Option<...>` — at that layer the semantic is "frame closed", not "I/O error". They just bridge `Result::Err` from the underlying read into `None`.

## Test plan

- [x] `cargo test --release --no-fail-fast` passes (255 codegen tests, runtime netpoll, etc.)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `example/http_server` and `example/comment_app` build end-to-end against the new API
- [x] Pre-existing failures in `example/calculator` and `example/http_kv_store` are confirmed to also fail on `main` (unrelated)

Closes #246.