### PR TITLE
fix(codegen): terminate ifcont block when every arm returns

### DIFF
--- a/compiler/codegen/src/expr.rs
+++ b/compiler/codegen/src/expr.rs
@@ -883,7 +883,8 @@ impl<'ctx> CodeGenerator<'ctx> {
         }
 
         // Since there can be no more than one terminator per block
-        if self.no_terminator() {
+        let then_falls_through = self.no_terminator();
+        if then_falls_through {
             self.builder.build_unconditional_branch(cont_bb)?;
         }
 
@@ -912,11 +913,21 @@ impl<'ctx> CodeGenerator<'ctx> {
         let else_bb = self.builder.get_insert_block().unwrap();
 
         // Since there can be no more than one terminator per block
-        if self.no_terminator() {
+        let else_falls_through = self.no_terminator();
+        if else_falls_through {
             self.builder.build_unconditional_branch(cont_bb)?;
         }
 
         self.builder.position_at_end(cont_bb);
+
+        if !then_falls_through && !else_falls_through {
+            // Neither arm branches to cont_bb (e.g. both `return`), so it has
+            // no predecessors. Terminate it with `unreachable` instead of
+            // leaving it dangling — LLVM verification would otherwise reject
+            // the function for the unterminated block.
+            self.builder.build_unreachable()?;
+            return Ok(None);
+        }
 
         // Either then_val or else_val could be never
         let phi_ty = if then_val.is_none() {

--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -2251,6 +2251,34 @@ fn if_in_loop() -> anyhow::Result<()> {
 }
 
 #[test]
+fn if_with_both_arms_returning_does_not_leave_dangling_cont_block() -> anyhow::Result<()> {
+    // When every arm of an if/else (or match, which lowers to nested ifs)
+    // terminates with `return`, the synthetic `ifcont` continuation block has
+    // no predecessors. Make sure codegen terminates that block instead of
+    // leaving it dangling, which would fail LLVM verification.
+    let program = r#"
+        fun main() -> i32 {
+            if 1 == 1 { return 7 } else { return 9 }
+        }
+    "#;
+    assert_eq!(exec(program)?, 7);
+
+    let match_program = r#"
+        enum Color { Red, Blue }
+        fun pick() -> Color { return Color::Red }
+        fun main() -> i32 {
+            match pick() {
+                Color::Red => return 3,
+                Color::Blue => return 4,
+            }
+        }
+    "#;
+    assert_eq!(exec(match_program)?, 3);
+
+    Ok(())
+}
+
+#[test]
 fn simple_method() -> anyhow::Result<()> {
     let program = r#"struct Person {
         age: i32,


### PR DESCRIPTION
## Summary

`build_if` always appends a continuation block (\`ifcont\`) and uses fall-through branches from then/else as its only predecessors. When every arm self-terminates (e.g. each ends in \`return\`), nothing branches to \`ifcont\`; the builder positions at it and the function returns, leaving an orphan block with no terminator. LLVM's verifier then aborts:

\`\`\`
Error: Basic Block in function 'kdmain' does not have terminator!
label %ifcont
\`\`\`

## Reproducer (smallest)

\`\`\`kaede
fun main() -> i32 {
    if 1 == 1 { return 0 } else { return 1 }
}
\`\`\`

Same shape via \`match\`:

\`\`\`kaede
enum Color { Red, Blue }
fun pick() -> Color { return Color::Red }
fun main() -> i32 {
    match pick() {
        Color::Red => return 0,
        Color::Blue => return 1,
    }
}
\`\`\`

The bug is generic to any if/match whose every arm returns. The very common \`match foo() { Result::Ok(v) => return v, Result::Err(_) => return 1 }\` shape at the top of \`main\` hits it.

## Fix

Track whether each arm fell through (i.e. needed an unconditional branch to \`ifcont\`) and, when neither did, emit \`unreachable\` at \`ifcont\` so the function still satisfies the verifier. The orphan block is dead code but keeping it keeps the rest of \`build_if\` simple — DCE drops it later.

The previous attempt of using \`then_val.is_none() && else_val.is_none()\` as the predicate was wrong: \`is_none()\` also fires for void-typed expressions that *do* fall through, which broke a wide swath of the existing test suite.

## Test plan

- [x] New regression test \`if_with_both_arms_returning_does_not_leave_dangling_cont_block\` covers both the \`if/else\` and \`match\` repros.
- [x] \`cargo test --release --no-fail-fast\` passes (255 codegen tests).
- [x] All three repros from above now build and run correctly.