### PR TITLE
feat(runtime): diagnose green thread stack overflow

### DIFF
--- a/compiler/driver/tests/runtime_stack_overflow.rs
+++ b/compiler/driver/tests/runtime_stack_overflow.rs
@@ -34,7 +34,7 @@ fn assert_stack_overflow(output: &Output, expected_task_label: &str) {
         stderr
     );
     assert!(
-        stderr.contains("kaede runtime: green thread stack overflow"),
+        stderr.contains("kaede runtime: task stack overflow"),
         "stderr did not contain stack overflow diagnostic\nstderr:\n{}",
         stderr
     );

--- a/compiler/driver/tests/runtime_stack_overflow.rs
+++ b/compiler/driver/tests/runtime_stack_overflow.rs
@@ -1,23 +1,9 @@
-use assert_cmd::prelude::*;
+mod driver_test_support;
+
 use assert_fs::prelude::*;
+use driver_test_support::compile_project;
 use std::path::Path;
 use std::process::{Command, Output};
-
-fn compile(file_paths: &[&Path], root_dir: &Path, output_path: &Path) -> anyhow::Result<Output> {
-    let mut args = file_paths
-        .iter()
-        .map(|p| p.to_string_lossy().to_string())
-        .collect::<Vec<String>>();
-
-    args.push("-o".to_string());
-    args.push(output_path.to_string_lossy().to_string());
-    args.push("--root-dir".to_string());
-    args.push(root_dir.to_string_lossy().to_string());
-
-    Ok(Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
-        .args(args)
-        .output()?)
-}
 
 fn compile_program(
     program: &str,
@@ -26,16 +12,7 @@ fn compile_program(
     let main = tempdir.child("main.kd");
     main.write_str(program)?;
 
-    let exe = assert_fs::NamedTempFile::new("overflow.out")?;
-    let output = compile(&[main.path()], tempdir.path(), exe.path())?;
-
-    assert!(
-        output.status.success(),
-        "kaede compile failed\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-
+    let (exe, _) = compile_project(&[main.path()], tempdir.path())?;
     Ok((tempdir, exe))
 }
 

--- a/compiler/driver/tests/runtime_stack_overflow.rs
+++ b/compiler/driver/tests/runtime_stack_overflow.rs
@@ -1,0 +1,134 @@
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn compile(file_paths: &[&Path], root_dir: &Path, output_path: &Path) -> anyhow::Result<Output> {
+    let mut args = file_paths
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect::<Vec<String>>();
+
+    args.push("-o".to_string());
+    args.push(output_path.to_string_lossy().to_string());
+    args.push("--root-dir".to_string());
+    args.push(root_dir.to_string_lossy().to_string());
+
+    Ok(Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+        .args(args)
+        .output()?)
+}
+
+fn compile_program(
+    program: &str,
+) -> anyhow::Result<(assert_fs::TempDir, assert_fs::NamedTempFile)> {
+    let tempdir = assert_fs::TempDir::new()?;
+    let main = tempdir.child("main.kd");
+    main.write_str(program)?;
+
+    let exe = assert_fs::NamedTempFile::new("overflow.out")?;
+    let output = compile(&[main.path()], tempdir.path(), exe.path())?;
+
+    assert!(
+        output.status.success(),
+        "kaede compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok((tempdir, exe))
+}
+
+fn run_and_capture_stderr(exe_path: &Path) -> anyhow::Result<Output> {
+    // Disable core dumps for the child so the test does not litter the
+    // working directory or stall on a slow `core_pattern` handler.
+    let mut cmd = Command::new(exe_path);
+    cmd.env("RUST_BACKTRACE", "0");
+    Ok(cmd.output()?)
+}
+
+fn assert_stack_overflow(output: &Output, expected_task_label: &str) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, got {:?}\nstderr:\n{}",
+        output.status,
+        stderr
+    );
+    assert!(
+        stderr.contains("kaede runtime: green thread stack overflow"),
+        "stderr did not contain stack overflow diagnostic\nstderr:\n{}",
+        stderr
+    );
+    assert!(
+        stderr.contains(&format!("task: {}", expected_task_label)),
+        "stderr did not identify task as `{}`\nstderr:\n{}",
+        expected_task_label,
+        stderr
+    );
+    assert!(
+        stderr.contains("configured stack size:"),
+        "stderr did not include configured stack size\nstderr:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn main_task_stack_overflow_emits_diagnostic() -> anyhow::Result<()> {
+    let (_tempdir, exe) = compile_program(
+        r#"fun recurse(n: i32) -> i32 {
+    let mut buf: [i32; 64] = [0; 64]
+    buf[0] = n
+    let r = recurse(n + 1)
+    return r + buf[0]
+}
+
+fun main() -> i32 {
+    return recurse(0)
+}"#,
+    )?;
+
+    let output = run_and_capture_stderr(exe.path())?;
+    assert_stack_overflow(&output, "main");
+    Ok(())
+}
+
+#[test]
+fn spawned_task_stack_overflow_emits_diagnostic() -> anyhow::Result<()> {
+    let (_tempdir, exe) = compile_program(
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun recurse(n: i32) -> i32 {
+    let mut buf: [i32; 64] = [0; 64]
+    buf[0] = n
+    let r = recurse(n + 1)
+    return r + buf[0]
+}
+
+fun overflow_task(ch: Channel<i32>) {
+    ch.send(recurse(0))
+}
+
+fun main() -> i32 {
+    let ch = Channel<i32>::new()
+    spawn overflow_task(ch)
+
+    // Block the main task until the spawned task sends — which will never
+    // happen, since it overflows its stack first and the runtime
+    // terminates the whole process via the SIGSEGV diagnostic.
+    match ch.recv() {
+        Option::Some(v) => return v,
+        Option::None => return 1,
+    }
+}"#,
+    )?;
+
+    let output = run_and_capture_stderr(exe.path())?;
+    assert_stack_overflow(&output, "spawned");
+    Ok(())
+}

--- a/library/runtime/CMakeLists.txt
+++ b/library/runtime/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     src/task.c
     src/worker.c
     src/runtime.c
+    src/signal.c
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/library/runtime/include/kaede/signal.h
+++ b/library/runtime/include/kaede/signal.h
@@ -1,14 +1,6 @@
 #ifndef KAEDE_SIGNAL_H
 #define KAEDE_SIGNAL_H
 
-struct Task;
-
-// Per-thread pointer to the green-thread task currently executing on this
-// worker, or NULL if the worker is in scheduler/system code. Mirrors
-// `worker.current_task` in worker.c, but lives at file scope so the SIGSEGV
-// handler can read it via async-signal-safe TLS load.
-extern _Thread_local struct Task *kaede_current_task;
-
 // Install a process-wide SIGSEGV/SIGBUS handler that turns green-thread
 // stack overflows into a clear diagnostic on stderr before chaining to the
 // default disposition. Call once during runtime startup, before any worker

--- a/library/runtime/include/kaede/signal.h
+++ b/library/runtime/include/kaede/signal.h
@@ -1,0 +1,23 @@
+#ifndef KAEDE_SIGNAL_H
+#define KAEDE_SIGNAL_H
+
+struct Task;
+
+// Per-thread pointer to the green-thread task currently executing on this
+// worker, or NULL if the worker is in scheduler/system code. Mirrors
+// `worker.current_task` in worker.c, but lives at file scope so the SIGSEGV
+// handler can read it via async-signal-safe TLS load.
+extern _Thread_local struct Task *kaede_current_task;
+
+// Install a process-wide SIGSEGV/SIGBUS handler that turns green-thread
+// stack overflows into a clear diagnostic on stderr before chaining to the
+// default disposition. Call once during runtime startup, before any worker
+// thread is created.
+void kaede_install_crash_handler(void);
+
+// Install a per-thread alternate signal stack so the crash handler can run
+// even after the green-thread stack has been exhausted. Call from each
+// worker thread before it starts executing tasks.
+void kaede_install_worker_altstack(void);
+
+#endif // KAEDE_SIGNAL_H

--- a/library/runtime/include/kaede/worker.h
+++ b/library/runtime/include/kaede/worker.h
@@ -6,6 +6,23 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+// The task currently executing on this OS thread, or NULL when the worker
+// is in scheduler/system code.
+//
+// Why _Thread_local:
+//   1. Each worker pthread runs at most one green-thread task at a time, so
+//      "current task" is intrinsically per-OS-thread state — no shared
+//      writes, no locking needed.
+//   2. The SIGSEGV handler reads this from inside a signal context to
+//      decide whether the fault is a guard-page hit, and a plain
+//      _Thread_local load is one of the few async-signal-safe ways to
+//      reach per-thread state (mutexes, malloc, and most pthread APIs are
+//      not signal-safe).
+//
+// This is the single source of truth for the runtime's "current task".
+// Do not introduce a parallel per-worker mirror.
+extern _Thread_local struct Task *kaede_current_task;
+
 bool worker_init(void);
 void worker_deinit(void);
 void worker_request_shutdown(void);

--- a/library/runtime/src/runtime.c
+++ b/library/runtime/src/runtime.c
@@ -1,6 +1,7 @@
 #include <errno.h>
 #include <gc/gc.h>
 #include <kaede/runtime.h>
+#include <kaede/signal.h>
 #include <kaede/task.h>
 #include <kaede/worker.h>
 #include <pthread.h>
@@ -21,6 +22,7 @@ void kaede_runtime_init(void) {
         fprintf(stderr, "Failed to ignore SIGPIPE: %s\n", strerror(errno));
         abort();
     }
+    kaede_install_crash_handler();
     if (!worker_init()) {
         fprintf(stderr, "Failed to initialize worker/runtime\n");
         abort();

--- a/library/runtime/src/signal.c
+++ b/library/runtime/src/signal.c
@@ -80,7 +80,7 @@ static void crash_handler(int sig, siginfo_t *info, void *uctx) {
         const uintptr_t guard_hi = stack_base;
 
         if (addr >= guard_lo && addr < guard_hi) {
-            write_str("\nkaede runtime: green thread stack overflow\n");
+            write_str("\nkaede runtime: task stack overflow\n");
             write_str("  task: ");
             write_str(task->scheduler.is_main ? "main\n" : "spawned\n");
             write_str("  configured stack size: ");

--- a/library/runtime/src/signal.c
+++ b/library/runtime/src/signal.c
@@ -1,5 +1,6 @@
 #include <kaede/signal.h>
 #include <kaede/task.h>
+#include <kaede/worker.h>
 
 #include <errno.h>
 #include <signal.h>
@@ -8,8 +9,6 @@
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
-
-_Thread_local struct Task *kaede_current_task = NULL;
 
 // Cached at handler-install time so the handler does not need to call
 // sysconf() (which is technically async-signal-safe but better avoided).

--- a/library/runtime/src/signal.c
+++ b/library/runtime/src/signal.c
@@ -1,0 +1,138 @@
+#include <kaede/signal.h>
+#include <kaede/task.h>
+
+#include <errno.h>
+#include <signal.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+_Thread_local struct Task *kaede_current_task = NULL;
+
+// Cached at handler-install time so the handler does not need to call
+// sysconf() (which is technically async-signal-safe but better avoided).
+// Set once on the main thread before any worker exists, then read-only.
+static volatile sig_atomic_t cached_page_size = 4096;
+
+static void safe_write(const void *buf, size_t len) {
+    const char *p = (const char *)buf;
+    while (len > 0) {
+        ssize_t n = write(STDERR_FILENO, p, len);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return;
+        }
+        p += n;
+        len -= (size_t)n;
+    }
+}
+
+static void write_str(const char *s) {
+    size_t len = 0;
+    while (s[len] != '\0') {
+        len++;
+    }
+    safe_write(s, len);
+}
+
+static void write_uint(uintmax_t v) {
+    char buf[32];
+    size_t i = sizeof(buf);
+    if (v == 0) {
+        buf[--i] = '0';
+    } else {
+        while (v > 0 && i > 0) {
+            buf[--i] = (char)('0' + (v % 10));
+            v /= 10;
+        }
+    }
+    safe_write(buf + i, sizeof(buf) - i);
+}
+
+static void write_hex_ptr(uintptr_t v) {
+    static const char digits[] = "0123456789abcdef";
+    const int n = (int)(sizeof(uintptr_t) * 2);
+    char buf[2 + sizeof(uintptr_t) * 2];
+    buf[0] = '0';
+    buf[1] = 'x';
+    for (int i = 0; i < n; ++i) {
+        buf[2 + n - 1 - i] = digits[v & 0xf];
+        v >>= 4;
+    }
+    safe_write(buf, 2 + (size_t)n);
+}
+
+static void crash_handler(int sig, siginfo_t *info, void *uctx) {
+    (void)uctx;
+
+    void *fault_addr = info ? info->si_addr : NULL;
+    struct Task *task = kaede_current_task;
+
+    if (task != NULL && task->stack != NULL && fault_addr != NULL) {
+        const uintptr_t addr = (uintptr_t)fault_addr;
+        const uintptr_t stack_base = (uintptr_t)task->stack;
+        const uintptr_t page_size = (uintptr_t)cached_page_size;
+        const uintptr_t guard_lo = stack_base - page_size;
+        const uintptr_t guard_hi = stack_base;
+
+        if (addr >= guard_lo && addr < guard_hi) {
+            write_str("\nkaede runtime: green thread stack overflow\n");
+            write_str("  task: ");
+            write_str(task->scheduler.is_main ? "main\n" : "spawned\n");
+            write_str("  configured stack size: ");
+            write_uint((uintmax_t)STACK_SIZE);
+            write_str(" bytes\n");
+            write_str("  faulting address: ");
+            write_hex_ptr(addr);
+            write_str("\n  stack base: ");
+            write_hex_ptr(stack_base);
+            write_str("\n");
+        }
+    }
+
+    // Reset disposition and re-raise so the kernel takes its default action
+    // (terminate, plus a core dump pointing at the original faulting frame
+    // when core dumps are enabled).
+    struct sigaction dfl;
+    memset(&dfl, 0, sizeof(dfl));
+    dfl.sa_handler = SIG_DFL;
+    sigemptyset(&dfl.sa_mask);
+    (void)sigaction(sig, &dfl, NULL);
+    (void)raise(sig);
+}
+
+void kaede_install_crash_handler(void) {
+    long ps = sysconf(_SC_PAGESIZE);
+    if (ps > 0) {
+        cached_page_size = (sig_atomic_t)ps;
+    }
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_sigaction = crash_handler;
+    sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    sigemptyset(&sa.sa_mask);
+
+    (void)sigaction(SIGSEGV, &sa, NULL);
+    (void)sigaction(SIGBUS, &sa, NULL);
+}
+
+// Per-thread alternate stack storage. Backed by TLS so the pthread runtime
+// reclaims it when the worker thread exits — no manual cleanup needed.
+// 32 KiB is comfortably above MINSIGSTKSZ on every supported platform and
+// plenty for our handler, which only writes a short diagnostic and
+// re-raises the original signal.
+#define KAEDE_ALTSTACK_SIZE (32u * 1024u)
+static _Thread_local char kaede_altstack_storage[KAEDE_ALTSTACK_SIZE];
+
+void kaede_install_worker_altstack(void) {
+    stack_t ss;
+    ss.ss_sp = kaede_altstack_storage;
+    ss.ss_size = sizeof(kaede_altstack_storage);
+    ss.ss_flags = 0;
+    (void)sigaltstack(&ss, NULL);
+}

--- a/library/runtime/src/signal.c
+++ b/library/runtime/src/signal.c
@@ -80,7 +80,7 @@ static void crash_handler(int sig, siginfo_t *info, void *uctx) {
         const uintptr_t guard_hi = stack_base;
 
         if (addr >= guard_lo && addr < guard_hi) {
-            write_str("\nkaede runtime: task stack overflow\n");
+            write_str("kaede runtime: task stack overflow\n");
             write_str("  task: ");
             write_str(task->scheduler.is_main ? "main\n" : "spawned\n");
             write_str("  configured stack size: ");

--- a/library/runtime/src/worker.c
+++ b/library/runtime/src/worker.c
@@ -27,8 +27,11 @@ static bool scheduler_main_finished = false;
 static bool main_spawned = false;
 static int main_exit_code = 0;
 
+// Per-OS-thread worker state. The currently-executing task is tracked by
+// the file-scope `kaede_current_task` below (declared in kaede/worker.h)
+// so the SIGSEGV handler can read it via async-signal-safe TLS load; do
+// not shadow it here.
 struct Worker {
-    struct Task *current_task;
     struct Context context;
     void *gc_thread_handle;
     struct GC_stack_base gc_stack_base;
@@ -53,6 +56,7 @@ struct IoWaitTable {
 static struct IoWaitTable io_waits;
 
 _Thread_local struct Worker worker;
+_Thread_local struct Task *kaede_current_task = NULL;
 
 static void fail_runtime(const char *message) {
     fprintf(stderr, "%s\n", message);
@@ -320,14 +324,14 @@ static void runtime_init_impl(void) {
 }
 
 static void task_finished(void) {
-    if (!worker.current_task) {
+    if (!kaede_current_task) {
         return;
     }
 
-    worker.current_task->scheduler.state = TASK_FINISHED;
+    kaede_current_task->scheduler.state = TASK_FINISHED;
     worker.yielded_state = TASK_FINISHED;
     worker.returned_with_scheduler_lock = false;
-    if (worker.current_task->scheduler.is_main) {
+    if (kaede_current_task->scheduler.is_main) {
         pthread_mutex_lock(&main_mutex);
         main_finished = true;
         pthread_cond_broadcast(&main_cond);
@@ -340,7 +344,7 @@ static void task_finished(void) {
         (void)kaede_poller_wake();
     }
 
-    context_switch(&worker.current_task->context, &worker.context);
+    context_switch(&kaede_current_task->context, &worker.context);
 }
 
 void task_entrypoint(void) {
@@ -464,7 +468,6 @@ static void worker_loop_impl(int worker_id) {
         }
         pthread_mutex_unlock(&scheduler_mutex);
 
-        worker.current_task = task;
         kaede_current_task = task;
 
         if (worker.gc_thread_handle) {
@@ -479,7 +482,6 @@ static void worker_loop_impl(int worker_id) {
             GC_set_stackbottom(worker.gc_thread_handle, &worker.gc_stack_base);
         }
 
-        worker.current_task = NULL;
         kaede_current_task = NULL;
         // Use the state captured at yield time instead of re-reading task state
         // after a cross-worker resume.
@@ -533,13 +535,13 @@ void *worker_loop(void *arg) {
 }
 
 KaedeIoWaitResult worker_park_current_on_io(int fd, uint32_t events) {
-    if (!worker.current_task || events == KAEDE_IO_EVENT_NONE) {
+    if (!kaede_current_task || events == KAEDE_IO_EVENT_NONE) {
         return KAEDE_IO_WAIT_FAILED;
     }
 
     // `context_switch()` may suspend here and resume this frame on a different
     // worker thread, so snapshot task/worker-owned state before touching TLS.
-    struct Task *task = worker.current_task;
+    struct Task *task = kaede_current_task;
     struct Context *worker_context = &worker.context;
     void *gc_thread_handle = worker.gc_thread_handle;
     struct GC_stack_base *gc_stack_base = &worker.gc_stack_base;
@@ -602,7 +604,7 @@ void worker_yield(void) {
     if (worker.gc_thread_handle) {
         GC_set_stackbottom(worker.gc_thread_handle, &worker.gc_stack_base);
     }
-    context_switch(&worker.current_task->context, &worker.context);
+    context_switch(&kaede_current_task->context, &worker.context);
 }
 
 void worker_scheduler_lock(void) {
@@ -618,18 +620,18 @@ bool worker_shutdown_requested_locked(void) {
 }
 
 struct Task *worker_current_task(void) {
-    return worker.current_task;
+    return kaede_current_task;
 }
 
 bool worker_park_current_on_channel_locked(void *obj, uint32_t wait_kind,
                                            void *value_slot) {
-    if (!worker.current_task || wait_kind == KAEDE_TASK_WAIT_NONE ||
+    if (!kaede_current_task || wait_kind == KAEDE_TASK_WAIT_NONE ||
         shutdown_requested) {
         pthread_mutex_unlock(&scheduler_mutex);
         return false;
     }
 
-    struct Task *task = worker.current_task;
+    struct Task *task = kaede_current_task;
     struct Context *worker_context = &worker.context;
     void *gc_thread_handle = worker.gc_thread_handle;
     struct GC_stack_base *gc_stack_base = &worker.gc_stack_base;

--- a/library/runtime/src/worker.c
+++ b/library/runtime/src/worker.c
@@ -1,5 +1,6 @@
 #include <gc/gc.h>
 #include <kaede/poller.h>
+#include <kaede/signal.h>
 #include <kaede/task.h>
 #include <kaede/worker.h>
 #include <pthread.h>
@@ -413,6 +414,8 @@ static void worker_loop_impl(int worker_id) {
     }
     worker.gc_thread_handle = GC_get_my_stackbottom(&worker.gc_stack_base);
 
+    kaede_install_worker_altstack();
+
     for (;;) {
         struct Task *task = NULL;
 
@@ -462,6 +465,7 @@ static void worker_loop_impl(int worker_id) {
         pthread_mutex_unlock(&scheduler_mutex);
 
         worker.current_task = task;
+        kaede_current_task = task;
 
         if (worker.gc_thread_handle) {
             struct GC_stack_base task_sb;
@@ -476,6 +480,7 @@ static void worker_loop_impl(int worker_id) {
         }
 
         worker.current_task = NULL;
+        kaede_current_task = NULL;
         // Use the state captured at yield time instead of re-reading task state
         // after a cross-worker resume.
         const enum TaskState yielded_state = worker.yielded_state;


### PR DESCRIPTION
## Summary

- Install a process-wide SIGSEGV/SIGBUS handler that detects faults landing on a green thread's guard page and writes a structured diagnostic to stderr before chaining to the default disposition (so the kernel still produces a core dump pointing at the original frame).
- Each worker thread sets up an alternate signal stack via TLS storage so the handler can run even after the green-thread stack has been exhausted.
- Add regression tests that overflow both the main task and a spawned task and assert the diagnostic appears.

Closes #111.

## Diagnostic output

```
kaede runtime: task stack overflow
  task: main          (or "spawned")
  configured stack size: 262144 bytes
  faulting address: 0x...
  stack base: 0x...
```

Process exits with the original SIGSEGV (exit 139) so existing tooling that relies on core dumps continues to work.

## Design notes

- The SIGSEGV handler is async-signal-safe: it only uses `write(2)` with stack-formatted integers — no `printf`, no `malloc`.
- Discrimination logic: read the per-worker `_Thread_local` task pointer (`kaede_current_task`); if non-null and `si_addr` falls inside `[task->stack - page_size, task->stack)`, it's a guard-page hit. Otherwise (NULL deref, fault outside any task) we silently chain to the default handler so we don't mask other crashes.
- Alternate signal stack is backed by a `_Thread_local` array, so it lives for the worker thread's lifetime and is reclaimed by the pthread runtime on exit (no manual free, no valgrind leak).
- Both `SIGSEGV` and `SIGBUS` are handled (macOS may deliver guard-page hits as SIGBUS).

## Test plan

- [x] `cargo test --release -p kaede_compiler_driver --test runtime_stack_overflow` — both new tests pass at the default `-O2`.
- [x] `cargo test --release --no-fail-fast` — full suite green, including the valgrind-based `leak_check_with_valgrind` (no `definitely lost`).
- [x] `cargo fmt --all -- --check` and `cargo clippy -- -D warnings` clean.
- [x] Manual: program that overflows in `main` prints `task: main`; program that overflows in a `spawn`'d task (with main blocked on a channel) prints `task: spawned`. Both terminate with exit 139 and produce a core dump.
- [x] CI runs on Linux + macOS.

## Out of scope

Per the issue, this is diagnostics only. Dynamic stack growth, recovery from overflow, and making `STACK_SIZE` configurable are explicitly out of scope and would be separate issues.