### PR TITLE
fix(semantic): canonicalize source path before taking parent

### DIFF
--- a/compiler/driver/tests/cli.rs
+++ b/compiler/driver/tests/cli.rs
@@ -215,3 +215,31 @@ fun main() -> i32 {
 
     Ok(())
 }
+
+// Regression: passing a bare filename (no leading "./" or directory) used to
+// panic in semantic analysis because Path::parent() returns an empty path,
+// which fails to canonicalize. See issue #285.
+#[test]
+fn direct_compile_accepts_bare_filename_in_cwd() -> anyhow::Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let app = temp_dir.child("app.kd");
+    let exe = temp_dir.child("a.out");
+
+    app.write_str("fun main() -> i32 { return 7 }")?;
+
+    Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+        .current_dir(temp_dir.path())
+        .args([
+            "app.kd",
+            "-o",
+            exe.path().to_str().unwrap(),
+            "--root-dir",
+            temp_dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    Command::new(exe.path()).assert().code(predicate::eq(7));
+
+    Ok(())
+}

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -5,6 +5,7 @@ use std::{
     rc::Rc,
 };
 
+use anyhow::Context as _;
 use context::AnalysisContext;
 use kaede_common::{kaede_autoload_dir, kaede_lib_src_dir};
 use kaede_ir::{
@@ -424,7 +425,17 @@ impl SemanticAnalyzer {
         let mut diff_from_root = {
             // Get the canonical paths
             let kaede_lib_src_dir = kaede_lib_src_dir().canonicalize()?;
-            let file_parent = file_path.path().parent().unwrap().canonicalize()?;
+            // Canonicalize the file itself first so that `parent()` always
+            // returns a non-empty absolute path. Calling `parent()` directly
+            // on a bare filename like "foo.kd" would yield an empty path,
+            // which then fails to canonicalize.
+            let canonical_file = file_path.path().canonicalize().with_context(|| {
+                format!(
+                    "Failed to resolve source file '{}'",
+                    file_path.path().display()
+                )
+            })?;
+            let file_parent = canonical_file.parent().unwrap().to_path_buf();
 
             // Try to strip the project root first, if that fails try the standard library root
             if let Ok(relative_path) = file_parent.strip_prefix(&root_dir.canonicalize()?) {


### PR DESCRIPTION
## Summary

Closes #285.

`kaede foo.kd` (bare filename, no leading `./` or directory component) used to panic with an opaque `"No such file or directory (os error 2)"` because `Path::parent()` on a bare filename returns an empty path, which then fails to canonicalize.

The fix canonicalizes the source file itself first; the resulting absolute path is guaranteed to have a non-empty parent. Also adds an `anyhow::Context` so any future canonicalize failure mentions the offending file.

## Repro (before fix)

```sh
kaede --root-dir . overflow_main_task.kd
# thread 'main' panicked at compiler/semantic/src/lib.rs:314:82:
# called `Result::unwrap()` on an `Err` value: No such file or directory (os error 2)
```

After the fix the same command compiles successfully. `./overflow_main_task.kd` continues to work as before.

## Changes

- `compiler/semantic/src/lib.rs` — canonicalize file path before `parent()`, add `with_context`
- `compiler/driver/tests/cli.rs` — add `direct_compile_accepts_bare_filename_in_cwd` regression test that runs the compiler with a bare filename and a `current_dir` set, and verifies success

## Test plan

- [x] `cargo test --release -p kaede_compiler_driver --test cli direct_compile_accepts_bare_filename_in_cwd` — new test passes
- [x] `cargo test --release --no-fail-fast` — full suite green
- [x] `cargo fmt --all -- --check` and `cargo clippy -- -D warnings` clean
- [x] Manual: `kaede --root-dir . hello.kd` from a tempdir compiles & runs
- [ ] CI green on Linux + macOS