### PR TITLE
fix(semantic): defer struct-literal shape check when types contain a type variable

### DIFF
--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -512,6 +512,13 @@ impl SemanticAnalyzer {
                 .into());
             }
 
+            if ir::ty::contains_type_var(&value.ty) || ir::ty::contains_type_var(&field_info.ty) {
+                // Defer the strict shape check to the type-inference pass; either side
+                // may still carry unresolved type variables (e.g. an `Option::Some(node)`
+                // value whose payload generic argument is not yet bound).
+                continue;
+            }
+
             if !ir::ty::is_same_type(&field_info.ty, &value.ty) {
                 return Err(SemanticError::MismatchedTypes {
                     types: (field_info.ty.kind.to_string(), value.ty.kind.to_string()),

--- a/compiler/semantic/tests/top.rs
+++ b/compiler/semantic/tests/top.rs
@@ -517,6 +517,29 @@ fn option_none_allows_omitted_type_args_when_expected_type_is_known() -> anyhow:
 }
 
 #[test]
+fn struct_field_accepts_option_some_with_omitted_type_args() -> anyhow::Result<()> {
+    // Regression: a struct literal that puts `Option::Some(value)` into a recursive
+    // `Option<Self>` field used to be rejected by the pre-inference shape check
+    // because the value's payload type was still an unbound type variable.
+    semantic_analyze(
+        r#"
+        struct Node {
+            val: i32,
+            left: Option<Node>,
+        }
+
+        fun main() -> i32 {
+            let n1 = Node { val: 1, left: Option<Node>::None }
+            let n2 = Node { val: 2, left: Option::Some(n1) }
+            return n2.val
+        }
+        "#,
+    )?;
+
+    Ok(())
+}
+
+#[test]
 fn option_none_without_context_still_requires_type_args() -> anyhow::Result<()> {
     let err = semantic_analyze_expect_error(
         r#"


### PR DESCRIPTION
## Summary

- `verify_struct_literal_values` ran an exact `is_same_type` check on every field value before the type-inference pass had a chance to resolve generic arguments. `is_same_type` only short-circuits on a top-level `TyKind::Var`, so a type variable nested under a reference or generic argument tripped the check.
- For values like `Option::Some(node)` written in a struct field whose declared type is `Option<Node>`, the comparison saw `Option<&Node>` vs `Option<var?>` and rejected the literal — even though inference would have bound the variable a moment later.
- Skip the strict shape comparison when either side still contains an unresolved type variable. Inference unifies field values against their declared field types right after, so the deferred check is still enforced.

This unbreaks `example/calculator`, whose `parse.kd` builds AST nodes via `Node { ..., left: Option::Some(node), right: Option::Some(...) }`.

## Test plan

- [x] `cargo test --release -p kaede_semantic` (new regression test `struct_field_accepts_option_some_with_omitted_type_args` covers the calculator pattern)
- [x] `cargo test --release -p kaede_codegen`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --release -- -D warnings`
- [x] `kaede build` in `example/calculator`, then `./build/calculator "1+2*3"` returns `7` and `"(1+2)*3"` returns `9`