### PR TITLE
refactor(semantic): use rustdoc-json + rustdoc-types for Rust imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-manifest"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c6f1c3eb197d17dde4f1a1170fbe7ce3e5f23f1166ae480875a9f4a9c11c40"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+ "toml 0.8.23",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,7 +680,7 @@ dependencies = [
  "libc",
  "llvm-sys",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -694,7 +738,7 @@ dependencies = [
  "kaede_span",
  "kaede_symbol",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -722,7 +766,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -781,7 +825,7 @@ dependencies = [
  "kaede_span",
  "kaede_symbol",
  "kaede_type_infer",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -798,10 +842,12 @@ dependencies = [
  "kaede_symbol",
  "kaede_symbol_table",
  "kaede_type_infer",
+ "rustdoc-json",
+ "rustdoc-types",
  "serde_json",
  "tempfile",
- "thiserror",
- "toml",
+ "thiserror 1.0.63",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -830,7 +876,7 @@ dependencies = [
  "kaede_ir",
  "kaede_span",
  "kaede_symbol",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -843,7 +889,7 @@ dependencies = [
  "kaede_span",
  "kaede_symbol",
  "kaede_symbol_table",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1137,6 +1183,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustdoc-json"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb043802e453091b5cbf79b8e6a3ff4c3ae4487d2ccf6c38842bff19865eb7c9"
+dependencies = [
+ "cargo-manifest",
+ "cargo_metadata",
+ "serde",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "rustdoc-types"
+version = "0.57.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6919c49bdd9cca072b3b502d16c073d0a4d3b7283ff6e0c86a5f6e6b07bbfe"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,9 +1236,13 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -1231,6 +1305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1317,7 +1400,16 @@ version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.63",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1325,6 +1417,17 @@ name = "thiserror-impl"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1375,10 +1478,26 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
+ "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -1391,6 +1510,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,10 +1526,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -1409,6 +1546,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -1734,6 +1877,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "writeable"

--- a/compiler/semantic/Cargo.toml
+++ b/compiler/semantic/Cargo.toml
@@ -9,6 +9,8 @@ anyhow = "1.0.68"
 thiserror = "1.0.38"
 serde_json = "1.0"
 toml = "0.8"
+rustdoc-json = "0.9"
+rustdoc-types = "0.57"
 
 kaede_ast = { path = "../ast" }
 kaede_ast_type = { path = "../ast_type" }

--- a/compiler/semantic/src/rust_import.rs
+++ b/compiler/semantic/src/rust_import.rs
@@ -216,7 +216,12 @@ fn parse_supported_ty(
             ir_type::Mutability::Not,
         ))),
         Type::Primitive(name) => fundamental_kind_from_rustdoc_primitive(name)
-            .map(|kind| Rc::new(ir_type::make_fundamental_type(kind, ir_type::Mutability::Not)))
+            .map(|kind| {
+                Rc::new(ir_type::make_fundamental_type(
+                    kind,
+                    ir_type::Mutability::Not,
+                ))
+            })
             .ok_or_else(|| format!("unsupported primitive type `{name}`")),
         Type::Tuple(elems) if elems.is_empty() => Ok(Rc::new(ir_type::Ty::new_unit())),
         Type::BorrowedRef { .. } => parse_borrowed_ref_ty(ty, position),
@@ -362,9 +367,7 @@ fn parse_public_function_item(
         Some(ty) if ty_is_empty_tuple(ty) => Rc::new(ir_type::Ty::new_unit()),
         Some(ty) => match parse_supported_ty(ty, TyPosition::Return, paths) {
             Ok(t) => t,
-            Err(reason) => {
-                return Some(Err(format!("{name}: unsupported return type: {reason}")))
-            }
+            Err(reason) => return Some(Err(format!("{name}: unsupported return type: {reason}"))),
         },
     };
 

--- a/compiler/semantic/src/rust_import.rs
+++ b/compiler/semantic/src/rust_import.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     fs,
     path::{Path, PathBuf},
     process::Command,
@@ -9,7 +10,9 @@ use anyhow::{anyhow, Context as _};
 use kaede_common::lib_extension;
 use kaede_ir::{module_path::ModulePath, qualified_symbol::QualifiedSymbol, ty as ir_type};
 use kaede_symbol::Symbol;
-use serde_json::Value;
+use rustdoc_types::{
+    Crate, FunctionSignature, Id, Item, ItemEnum, ItemKind, ItemSummary, Type, Visibility,
+};
 use toml::Value as TomlValue;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,14 +61,6 @@ fn sanitize_symbol(name: &str) -> String {
     out
 }
 
-fn json_id_to_string(value: &Value) -> Option<String> {
-    match value {
-        Value::String(s) => Some(s.clone()),
-        Value::Number(n) => Some(n.to_string()),
-        _ => None,
-    }
-}
-
 fn fundamental_kind_from_rustdoc_primitive(name: &str) -> Option<ir_type::FundamentalTypeKind> {
     match name {
         "i8" => Some(ir_type::FundamentalTypeKind::I8),
@@ -83,79 +78,30 @@ fn fundamental_kind_from_rustdoc_primitive(name: &str) -> Option<ir_type::Fundam
     }
 }
 
-fn rustdoc_ty_description(value: &Value) -> String {
-    if value.is_null() {
-        return "()".to_string();
-    }
-
-    if value
-        .get("tuple")
-        .and_then(Value::as_array)
-        .is_some_and(|arr| arr.is_empty())
-    {
-        return "()".to_string();
-    }
-
-    if let Some(primitive) = value.get("primitive").and_then(Value::as_str) {
-        return primitive.to_string();
-    }
-
-    if let Some(borrowed_ref) = value.get("borrowed_ref") {
-        let is_mutable = borrowed_ref
-            .get("is_mutable")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        let prefix = if is_mutable { "&mut " } else { "&" };
-        let inner = borrowed_ref
-            .get("type")
-            .map(rustdoc_ty_description)
-            .unwrap_or_else(|| "?".to_string());
-        return format!("{prefix}{inner}");
-    }
-
-    if let Some(raw_pointer) = value.get("raw_pointer") {
-        let is_mutable = raw_pointer
-            .get("is_mutable")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        let prefix = if is_mutable { "*mut " } else { "*const " };
-        let inner = raw_pointer
-            .get("type")
-            .map(rustdoc_ty_description)
-            .unwrap_or_else(|| "?".to_string());
-        return format!("{prefix}{inner}");
-    }
-
-    if value.get("slice").is_some() {
-        return "[_]".to_string();
-    }
-
-    if let Some(array) = value.get("array") {
-        let inner = array
-            .get("type")
-            .map(rustdoc_ty_description)
-            .unwrap_or_else(|| "?".to_string());
-        let len = array
-            .get("len")
-            .map(|len| len.to_string())
-            .unwrap_or_else(|| "?".to_string());
-        return format!("[{inner}; {len}]");
-    }
-
-    if value.get("tuple").is_some() {
-        return "tuple".to_string();
-    }
-
-    if let Some(path) = value.get("resolved_path") {
-        if let Some(name) = path.get("name").and_then(Value::as_str) {
-            return name.to_string();
+fn rustdoc_ty_description(ty: &Type) -> String {
+    match ty {
+        Type::Primitive(name) => name.clone(),
+        Type::Tuple(elems) if elems.is_empty() => "()".to_string(),
+        Type::Tuple(_) => "tuple".to_string(),
+        Type::BorrowedRef {
+            is_mutable, type_, ..
+        } => {
+            let prefix = if *is_mutable { "&mut " } else { "&" };
+            format!("{prefix}{}", rustdoc_ty_description(type_))
         }
-        if let Some(name) = path.get("path").and_then(Value::as_str) {
-            return name.to_string();
+        Type::RawPointer { is_mutable, type_ } => {
+            let prefix = if *is_mutable { "*mut " } else { "*const " };
+            format!("{prefix}{}", rustdoc_ty_description(type_))
         }
+        Type::Slice(_) => "[_]".to_string(),
+        Type::Array { type_, len } => format!("[{}; {len}]", rustdoc_ty_description(type_)),
+        Type::ResolvedPath(path) => path.path.clone(),
+        _ => "unknown".to_string(),
     }
+}
 
-    "unknown".to_string()
+fn ty_is_empty_tuple(ty: &Type) -> bool {
+    matches!(ty, Type::Tuple(elems) if elems.is_empty())
 }
 
 fn kaede_string_qualified_symbol() -> QualifiedSymbol {
@@ -214,57 +160,39 @@ fn is_kaede_char_ty(ty: &ir_type::Ty) -> bool {
     )
 }
 
-fn resolved_path_segments(
-    value: &Value,
-    paths: Option<&serde_json::Map<String, Value>>,
-) -> Option<Vec<String>> {
-    let resolved_path = value.get("resolved_path")?;
-    let path_id = json_id_to_string(resolved_path.get("id")?)?;
-    let path_entry = paths?.get(&path_id)?;
-    let path = path_entry.get("path")?.as_array()?;
-
-    path.iter()
-        .map(|segment| segment.as_str().map(ToOwned::to_owned))
-        .collect()
+fn resolved_path_segments<'a>(
+    ty: &Type,
+    paths: Option<&'a HashMap<Id, ItemSummary>>,
+) -> Option<&'a [String]> {
+    let Type::ResolvedPath(path) = ty else {
+        return None;
+    };
+    let summary = paths?.get(&path.id)?;
+    Some(summary.path.as_slice())
 }
 
-fn is_rust_string_resolved_path(
-    value: &Value,
-    paths: Option<&serde_json::Map<String, Value>>,
-) -> bool {
-    let Some(segments) = resolved_path_segments(value, paths) else {
+fn is_rust_string_resolved_path(ty: &Type, paths: Option<&HashMap<Id, ItemSummary>>) -> bool {
+    let Some(segments) = resolved_path_segments(ty, paths) else {
         return false;
     };
-
-    let matches = |expected: &[&str]| -> bool {
-        segments.len() == expected.len()
-            && segments
-                .iter()
-                .zip(expected.iter())
-                .all(|(actual, expected)| actual == expected)
-    };
-
-    matches(&["alloc", "string", "String"]) || matches(&["std", "string", "String"])
+    segments == ["alloc", "string", "String"] || segments == ["std", "string", "String"]
 }
 
-fn parse_borrowed_ref_ty(value: &Value, position: TyPosition) -> Result<Rc<ir_type::Ty>, String> {
-    let borrowed_ref = value.get("borrowed_ref").ok_or_else(|| {
-        format!(
+fn parse_borrowed_ref_ty(ty: &Type, position: TyPosition) -> Result<Rc<ir_type::Ty>, String> {
+    let Type::BorrowedRef {
+        is_mutable, type_, ..
+    } = ty
+    else {
+        return Err(format!(
             "unsupported borrowed reference type `{}`",
-            rustdoc_ty_description(value)
-        )
-    })?;
-    let is_mutable = borrowed_ref
-        .get("is_mutable")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let inner = borrowed_ref.get("type").unwrap_or(&Value::Null);
+            rustdoc_ty_description(ty)
+        ));
+    };
 
-    if inner.get("primitive").and_then(Value::as_str) == Some("str") {
-        if is_mutable {
+    if matches!(type_.as_ref(), Type::Primitive(p) if p == "str") {
+        if *is_mutable {
             return Err("unsupported mutable borrowed string type `&mut str`".to_string());
         }
-
         return match position {
             TyPosition::Param => Ok(kaede_str_ir_ty()),
             TyPosition::Return => Ok(kaede_string_ir_ty()),
@@ -273,90 +201,37 @@ fn parse_borrowed_ref_ty(value: &Value, position: TyPosition) -> Result<Rc<ir_ty
 
     Err(format!(
         "unsupported borrowed reference type `{}`",
-        rustdoc_ty_description(value)
+        rustdoc_ty_description(ty)
     ))
 }
 
 fn parse_supported_ty(
-    value: &Value,
+    ty: &Type,
     position: TyPosition,
-    paths: Option<&serde_json::Map<String, Value>>,
+    paths: Option<&HashMap<Id, ItemSummary>>,
 ) -> Result<Rc<ir_type::Ty>, String> {
-    if value.is_null() {
-        return Ok(Rc::new(ir_type::Ty::new_unit()));
-    }
-
-    if let Some(primitive) = value.get("primitive").and_then(Value::as_str) {
-        if primitive == "char" {
-            return Ok(Rc::new(ir_type::make_fundamental_type(
-                ir_type::FundamentalTypeKind::Char,
-                ir_type::Mutability::Not,
-            )));
+    match ty {
+        Type::Primitive(name) if name == "char" => Ok(Rc::new(ir_type::make_fundamental_type(
+            ir_type::FundamentalTypeKind::Char,
+            ir_type::Mutability::Not,
+        ))),
+        Type::Primitive(name) => fundamental_kind_from_rustdoc_primitive(name)
+            .map(|kind| Rc::new(ir_type::make_fundamental_type(kind, ir_type::Mutability::Not)))
+            .ok_or_else(|| format!("unsupported primitive type `{name}`")),
+        Type::Tuple(elems) if elems.is_empty() => Ok(Rc::new(ir_type::Ty::new_unit())),
+        Type::BorrowedRef { .. } => parse_borrowed_ref_ty(ty, position),
+        Type::ResolvedPath(_) if is_rust_string_resolved_path(ty, paths) => {
+            Ok(kaede_string_ir_ty())
         }
-
-        if let Some(kind) = fundamental_kind_from_rustdoc_primitive(primitive) {
-            return Ok(Rc::new(ir_type::make_fundamental_type(
-                kind,
-                ir_type::Mutability::Not,
-            )));
-        }
-
-        return Err(format!("unsupported primitive type `{primitive}`"));
-    }
-
-    if value
-        .get("tuple")
-        .and_then(Value::as_array)
-        .is_some_and(|arr| arr.is_empty())
-    {
-        return Ok(Rc::new(ir_type::Ty::new_unit()));
-    }
-
-    if value.get("borrowed_ref").is_some() {
-        return parse_borrowed_ref_ty(value, position);
-    }
-
-    if value.get("resolved_path").is_some() && is_rust_string_resolved_path(value, paths) {
-        return Ok(kaede_string_ir_ty());
-    }
-
-    if value.get("raw_pointer").is_some() {
-        return Err(format!(
+        Type::RawPointer { .. } => Err(format!(
             "unsupported raw pointer type `{}`",
-            rustdoc_ty_description(value)
-        ));
+            rustdoc_ty_description(ty)
+        )),
+        _ => Err(format!(
+            "unsupported non-primitive type `{}`",
+            rustdoc_ty_description(ty)
+        )),
     }
-
-    Err(format!(
-        "unsupported non-primitive type `{}`",
-        rustdoc_ty_description(value)
-    ))
-}
-
-fn is_public_visibility(item: &Value) -> bool {
-    match item.get("visibility") {
-        Some(Value::String(s)) => s == "public",
-        Some(Value::Object(map)) => map.get("public").and_then(Value::as_bool).unwrap_or(false),
-        _ => false,
-    }
-}
-
-fn extract_fn_io(sig_container: &Value) -> Option<(&Value, &Value)> {
-    if let Some(sig) = sig_container.get("sig") {
-        let inputs = sig.get("inputs")?;
-        let output = sig.get("output")?;
-        return Some((inputs, output));
-    }
-
-    if let Some(decl) = sig_container.get("decl") {
-        let inputs = decl.get("inputs")?;
-        let output = decl.get("output")?;
-        return Some((inputs, output));
-    }
-
-    let inputs = sig_container.get("inputs")?;
-    let output = sig_container.get("output")?;
-    Some((inputs, output))
 }
 
 fn project_root_from_root_dir(root_dir: &Path, rust_subdir: &Path) -> anyhow::Result<PathBuf> {
@@ -409,152 +284,52 @@ fn read_package_name(manifest_path: &Path) -> anyhow::Result<String> {
         .ok_or_else(|| anyhow!("package.name not found in {}", manifest_path.display()))
 }
 
-fn run_rustdoc_json(rust_manifest: &Path) -> anyhow::Result<()> {
-    let mut cmd = Command::new("cargo");
-    cmd.args([
-        "+nightly",
-        "rustdoc",
-        "--manifest-path",
-        &rust_manifest.to_string_lossy(),
-        "--lib",
-        "--",
-        "-Z",
-        "unstable-options",
-        "--output-format",
-        "json",
-    ]);
-    run_command(cmd, "cargo +nightly rustdoc")
-}
-
-fn rustdoc_json_path(rust_dir: &Path, crate_name: &str) -> anyhow::Result<PathBuf> {
-    let doc_dir = rust_dir.join("target").join("doc");
-    let candidates = [
-        doc_dir.join(format!("{crate_name}.json")),
-        doc_dir.join(format!("{}.json", crate_name.replace('-', "_"))),
-    ];
-
-    candidates
-        .into_iter()
-        .find(|p| p.exists())
-        .ok_or_else(|| anyhow!("rustdoc JSON not found in {}", doc_dir.display()))
-}
-
-fn infer_root_id(
-    index: &serde_json::Map<String, Value>,
-    crate_name: &str,
-) -> anyhow::Result<String> {
-    index
+fn collect_candidate_ids(krate: &Crate, crate_name: &str) -> Vec<Id> {
+    let mut ids: Vec<Id> = krate
+        .paths
         .iter()
-        .find_map(|(id, item)| {
-            let is_module = item
-                .get("kind")
-                .and_then(Value::as_str)
-                .is_some_and(|k| k == "module");
-            let is_local_crate = item
-                .get("crate_id")
-                .and_then(Value::as_u64)
-                .is_some_and(|cid| cid == 0);
-            let is_named_like_crate = item
-                .get("name")
-                .and_then(Value::as_str)
-                .is_some_and(|name| name == crate_name || name == crate_name.replace('-', "_"));
-
-            if is_module && is_local_crate && is_named_like_crate {
-                Some(id.clone())
+        .filter_map(|(id, summary)| {
+            let is_root_exposed = summary.path.len() == 2
+                && summary
+                    .path
+                    .first()
+                    .is_some_and(|p| p == crate_name || p == &crate_name.replace('-', "_"));
+            if matches!(summary.kind, ItemKind::Function) && is_root_exposed {
+                Some(*id)
             } else {
                 None
             }
         })
-        .or_else(|| {
-            index.iter().find_map(|(id, item)| {
-                let is_module = item
-                    .get("kind")
-                    .and_then(Value::as_str)
-                    .is_some_and(|k| k == "module");
-                let is_local_crate = item
-                    .get("crate_id")
-                    .and_then(Value::as_u64)
-                    .is_some_and(|cid| cid == 0);
-                if is_module && is_local_crate {
-                    Some(id.clone())
-                } else {
-                    None
-                }
-            })
-        })
-        .ok_or_else(|| anyhow!("missing root id in rustdoc json and failed to infer it"))
-}
+        .collect();
 
-fn collect_candidate_ids(root_item: &Value, rustdoc: &Value, crate_name: &str) -> Vec<String> {
-    let root_item_ids = root_item
-        .get("inner")
-        .and_then(|v| v.get("module"))
-        .and_then(|v| v.get("items"))
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|v| json_id_to_string(&v))
-        .collect::<Vec<_>>();
-
-    if let Some(paths) = rustdoc.get("paths").and_then(Value::as_object) {
-        let mut ids = paths
-            .iter()
-            .filter_map(|(id, entry)| {
-                let kind_is_fn = entry
-                    .get("kind")
-                    .and_then(Value::as_str)
-                    .is_some_and(|k| k == "function");
-                let path = entry.get("path").and_then(Value::as_array)?;
-                let is_root_exposed = path.len() == 2
-                    && path
-                        .first()
-                        .and_then(Value::as_str)
-                        .is_some_and(|p| p == crate_name || p == crate_name.replace('-', "_"));
-
-                if kind_is_fn && is_root_exposed {
-                    Some(id.clone())
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-        if !ids.is_empty() {
-            ids.sort();
-            ids.dedup();
-            return ids;
-        }
+    if !ids.is_empty() {
+        ids.sort_by_key(|id| id.0);
+        ids.dedup();
+        return ids;
     }
 
-    root_item_ids
+    if let Some(root_item) = krate.index.get(&krate.root) {
+        if let ItemEnum::Module(module) = &root_item.inner {
+            return module.items.clone();
+        }
+    }
+    Vec::new()
 }
 
 fn parse_supported_params(
-    inputs: &[Value],
-    paths: Option<&serde_json::Map<String, Value>>,
+    inputs: &[(String, Type)],
+    paths: Option<&HashMap<Id, ItemSummary>>,
 ) -> Result<Vec<(Symbol, Rc<ir_type::Ty>)>, String> {
     let mut params = Vec::with_capacity(inputs.len());
 
-    for (idx, input) in inputs.iter().enumerate() {
-        let Some(input_pair) = input.as_array() else {
-            return Err(format!("parameter #{idx} format is unsupported"));
+    for (idx, (raw_name, ty)) in inputs.iter().enumerate() {
+        let sanitized = sanitize_symbol(raw_name);
+        let param_name = if sanitized.is_empty() {
+            format!("arg{idx}")
+        } else {
+            sanitized
         };
-        if input_pair.len() != 2 {
-            return Err(format!("parameter #{idx} format is unsupported"));
-        }
-        let param_name = input_pair[0]
-            .as_str()
-            .map(ToOwned::to_owned)
-            .unwrap_or_else(|| format!("arg{idx}"));
-        let param_name = {
-            let sanitized = sanitize_symbol(&param_name);
-            if sanitized.is_empty() {
-                format!("arg{idx}")
-            } else {
-                sanitized
-            }
-        };
-        let param_ty = parse_supported_ty(&input_pair[1], TyPosition::Param, paths)
+        let param_ty = parse_supported_ty(ty, TyPosition::Param, paths)
             .map_err(|reason| format!("unsupported parameter type at #{idx}: {reason}"))?;
         params.push((Symbol::from(param_name), param_ty));
     }
@@ -563,44 +338,34 @@ fn parse_supported_params(
 }
 
 fn parse_public_function_item(
-    item: &Value,
+    item: &Item,
     crate_sanitized: &str,
-    paths: Option<&serde_json::Map<String, Value>>,
+    paths: Option<&HashMap<Id, ItemSummary>>,
 ) -> Option<Result<RustImportedFn, String>> {
-    if !is_public_visibility(item) {
+    if !matches!(item.visibility, Visibility::Public) {
         return None;
     }
 
-    let is_function = item
-        .get("kind")
-        .and_then(Value::as_str)
-        .is_some_and(|v| v == "function")
-        || item.get("inner").and_then(|v| v.get("function")).is_some();
-    if !is_function {
+    let ItemEnum::Function(function) = &item.inner else {
         return None;
-    }
+    };
+    let name = item.name.as_deref()?;
 
-    let name = item.get("name").and_then(Value::as_str)?;
-    let function_node = match item.get("inner").and_then(|v| v.get("function")) {
-        Some(node) => node,
-        None => return Some(Err(format!("{name}: failed to read function signature"))),
-    };
-    let (inputs, output) = match extract_fn_io(function_node) {
-        Some(io) => io,
-        None => return Some(Err(format!("{name}: failed to read function signature"))),
-    };
+    let FunctionSignature { inputs, output, .. } = &function.sig;
 
-    let inputs = match inputs.as_array() {
-        Some(inputs) => inputs,
-        None => return Some(Err(format!("{name}: failed to read input types"))),
-    };
     let params = match parse_supported_params(inputs, paths) {
         Ok(params) => params,
         Err(reason) => return Some(Err(format!("{name}: {reason}"))),
     };
-    let return_ty = match parse_supported_ty(output, TyPosition::Return, paths) {
-        Ok(ty) => ty,
-        Err(reason) => return Some(Err(format!("{name}: unsupported return type: {reason}"))),
+    let return_ty = match output.as_ref() {
+        None => Rc::new(ir_type::Ty::new_unit()),
+        Some(ty) if ty_is_empty_tuple(ty) => Rc::new(ir_type::Ty::new_unit()),
+        Some(ty) => match parse_supported_ty(ty, TyPosition::Return, paths) {
+            Ok(t) => t,
+            Err(reason) => {
+                return Some(Err(format!("{name}: unsupported return type: {reason}")))
+            }
+        },
     };
 
     Some(Ok(RustImportedFn {
@@ -621,35 +386,21 @@ fn parse_root_public_functions(
 ) -> anyhow::Result<(Vec<RustImportedFn>, Vec<String>)> {
     let content = fs::read_to_string(rustdoc_json)
         .with_context(|| format!("failed to read rustdoc json: {}", rustdoc_json.display()))?;
-    let v: Value = serde_json::from_str(&content)
+    let krate: Crate = serde_json::from_str(&content)
         .with_context(|| format!("failed to parse rustdoc json: {}", rustdoc_json.display()))?;
 
-    let index = v
-        .get("index")
-        .and_then(Value::as_object)
-        .ok_or_else(|| anyhow!("missing index in rustdoc json"))?;
-    let paths = v.get("paths").and_then(Value::as_object);
-
-    let root_id = match v.get("root").and_then(json_id_to_string) {
-        Some(root) => root,
-        None => infer_root_id(index, crate_name)?,
-    };
-
-    let root_item = index
-        .get(&root_id)
-        .ok_or_else(|| anyhow!("root item not found in rustdoc index"))?;
-    let candidate_ids = collect_candidate_ids(root_item, &v, crate_name);
+    let candidate_ids = collect_candidate_ids(&krate, crate_name);
 
     let mut functions = Vec::new();
     let mut skipped = Vec::new();
     let crate_sanitized = sanitize_symbol(crate_name);
 
     for item_id in candidate_ids {
-        let Some(item) = index.get(&item_id) else {
+        let Some(item) = krate.index.get(&item_id) else {
             continue;
         };
 
-        match parse_public_function_item(item, &crate_sanitized, paths) {
+        match parse_public_function_item(item, &crate_sanitized, Some(&krate.paths)) {
             Some(Ok(parsed)) => functions.push(parsed),
             Some(Err(reason)) => skipped.push(reason),
             None => {}
@@ -1031,8 +782,17 @@ pub fn resolve_rust_import(
         ));
     }
 
-    run_rustdoc_json(&rust_manifest)?;
-    let rustdoc_json = rustdoc_json_path(project_root.join(rust_subdir).as_path(), crate_name)?;
+    let rustdoc_json = rustdoc_json::Builder::default()
+        .toolchain("nightly-2026-03-17")
+        .manifest_path(&rust_manifest)
+        .silent(true)
+        .build()
+        .with_context(|| {
+            format!(
+                "cargo +nightly rustdoc failed for {}",
+                rust_manifest.display()
+            )
+        })?;
     let (functions, skipped) = parse_root_public_functions(&rustdoc_json, crate_name)?;
     let dylib_path = generate_shim_crate(
         &project_root,
@@ -1056,7 +816,7 @@ pub fn resolve_rust_import(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
+    use serde_json::{json, Value};
 
     fn fundamental(kind: ir_type::FundamentalTypeKind) -> Rc<ir_type::Ty> {
         Rc::new(ir_type::make_fundamental_type(
@@ -1065,25 +825,35 @@ mod tests {
         ))
     }
 
-    fn rust_string_resolved_path_ty() -> Value {
-        json!({
+    fn ty(value: Value) -> Type {
+        serde_json::from_value(value).expect("failed to deserialize rustdoc_types::Type")
+    }
+
+    fn rust_string_resolved_path_ty() -> Type {
+        ty(json!({
             "resolved_path": {
                 "path": "String",
                 "id": 1,
                 "args": null
             }
-        })
+        }))
     }
 
-    fn rust_string_paths() -> serde_json::Map<String, Value> {
-        json!({
-            "1": {
-                "path": ["alloc", "string", "String"]
-            }
-        })
-        .as_object()
-        .unwrap()
-        .clone()
+    fn rust_string_paths() -> HashMap<Id, ItemSummary> {
+        let mut paths = HashMap::new();
+        paths.insert(
+            Id(1),
+            ItemSummary {
+                crate_id: 0,
+                path: vec![
+                    "alloc".to_string(),
+                    "string".to_string(),
+                    "String".to_string(),
+                ],
+                kind: ItemKind::Struct,
+            },
+        );
+        paths
     }
 
     fn rust_imported_fn(
@@ -1113,9 +883,12 @@ mod tests {
         ];
 
         for (primitive, expected) in cases {
-            let parsed =
-                parse_supported_ty(&json!({ "primitive": primitive }), TyPosition::Param, None)
-                    .unwrap();
+            let parsed = parse_supported_ty(
+                &ty(json!({ "primitive": primitive })),
+                TyPosition::Param,
+                None,
+            )
+            .unwrap();
             assert_eq!(parsed, fundamental(expected), "primitive `{primitive}`");
         }
     }
@@ -1123,11 +896,7 @@ mod tests {
     #[test]
     fn parse_supported_ty_accepts_unit_shapes() {
         assert_eq!(
-            parse_supported_ty(&Value::Null, TyPosition::Param, None).unwrap(),
-            Rc::new(ir_type::Ty::new_unit())
-        );
-        assert_eq!(
-            parse_supported_ty(&json!({ "tuple": [] }), TyPosition::Param, None).unwrap(),
+            parse_supported_ty(&ty(json!({ "tuple": [] })), TyPosition::Param, None).unwrap(),
             Rc::new(ir_type::Ty::new_unit())
         );
     }
@@ -1135,13 +904,13 @@ mod tests {
     #[test]
     fn parse_supported_ty_accepts_shared_borrowed_str_parameter() {
         let parsed = parse_supported_ty(
-            &json!({
+            &ty(json!({
                 "borrowed_ref": {
                     "lifetime": null,
                     "is_mutable": false,
                     "type": { "primitive": "str" }
                 }
-            }),
+            })),
             TyPosition::Param,
             None,
         )
@@ -1154,7 +923,8 @@ mod tests {
     #[test]
     fn parse_supported_ty_accepts_char_and_owned_string_shapes() {
         let char_ty =
-            parse_supported_ty(&json!({ "primitive": "char" }), TyPosition::Param, None).unwrap();
+            parse_supported_ty(&ty(json!({ "primitive": "char" })), TyPosition::Param, None)
+                .unwrap();
         assert_eq!(char_ty, fundamental(ir_type::FundamentalTypeKind::Char));
 
         let paths = rust_string_paths();
@@ -1167,13 +937,13 @@ mod tests {
         assert!(is_kaede_string_ty(&string_param));
 
         let str_return = parse_supported_ty(
-            &json!({
+            &ty(json!({
                 "borrowed_ref": {
                     "lifetime": null,
                     "is_mutable": false,
                     "type": { "primitive": "str" }
                 }
-            }),
+            })),
             TyPosition::Return,
             None,
         )
@@ -1198,13 +968,13 @@ mod tests {
     #[test]
     fn parse_supported_ty_rejects_unsupported_shapes_with_reason() {
         let mut_str_err = parse_supported_ty(
-            &json!({
+            &ty(json!({
                 "borrowed_ref": {
                     "lifetime": null,
                     "is_mutable": true,
                     "type": { "primitive": "str" }
                 }
-            }),
+            })),
             TyPosition::Param,
             None,
         )
@@ -1212,13 +982,13 @@ mod tests {
         assert!(mut_str_err.contains("mutable borrowed string type `&mut str`"));
 
         let borrowed_ref_err = parse_supported_ty(
-            &json!({
+            &ty(json!({
                 "borrowed_ref": {
                     "lifetime": null,
                     "is_mutable": false,
                     "type": { "primitive": "i32" }
                 }
-            }),
+            })),
             TyPosition::Param,
             None,
         )
@@ -1226,12 +996,12 @@ mod tests {
         assert!(borrowed_ref_err.contains("borrowed reference type `&i32`"));
 
         let raw_ptr_err = parse_supported_ty(
-            &json!({
+            &ty(json!({
                 "raw_pointer": {
                     "is_mutable": false,
                     "type": { "primitive": "i8" }
                 }
-            }),
+            })),
             TyPosition::Param,
             None,
         )

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,9 @@
             # Mirror CI's toolchain layout (stable + minimal nightly for rustdoc).
             if command -v rustup >/dev/null; then
               rustup toolchain list | grep -q '^stable'  || rustup toolchain install stable --component rustfmt --component clippy
-              rustup toolchain list | grep -q '^nightly' || rustup toolchain install nightly --profile minimal
+              # Pinned nightly: rustdoc JSON format_version must match the rustdoc-types
+              # crate version used by compiler/semantic. Bump together when upgrading.
+              rustup toolchain list | grep -q '^nightly-2026-03-17' || rustup toolchain install nightly-2026-03-17 --profile minimal
             fi
           '';
         };


### PR DESCRIPTION
Closes #291.

## Summary

- Replace the hand-rolled `cargo +nightly rustdoc` invocation and `target/doc/*.json` discovery in `compiler/semantic/src/rust_import.rs` with `rustdoc-json::Builder`.
- Replace ~250 lines of `serde_json::Value` traversal (string-keyed `.get("kind")` / `.get("inner")` chains) with typed `match` on `rustdoc_types::{Crate, Item, ItemEnum, Type, FunctionSignature, Visibility, ItemKind, ItemSummary, Id}`. Schema mismatches now surface as compile errors.
- Pin nightly to `nightly-2026-03-17` in `flake.nix` so rustdoc JSON `format_version` (57) stays aligned with the chosen `rustdoc-types = "0.57"`. Bump together when upgrading.
- Pin `cargo-platform` to `0.3.2` in `Cargo.lock` (transitive dep of `rustdoc-json`); the latest 0.3.3 requires rustc 1.91+ which conflicts with the project's stable rustc 1.90.

The public API of `rust_import` (`resolve_rust_import`, `RustImportedFn`, `RustImportOutput`) is unchanged; the only consumer (`compiler/semantic/src/top.rs`) needed no edits.

Net change: `compiler/semantic/src/rust_import.rs` shrinks by ~80 lines and loses an entire layer of stringly-typed parsing.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy -p kaede_semantic --all-targets` — no warnings
- [x] `cargo test -p kaede_semantic --lib rust_import` — 10/10 pass
- [x] `cargo test -p kaede_semantic` — 42/42 pass
- [x] `cargo test -p kaede_compiler_driver --test run -- rust` — 2/2 pass (E2E Rust import path)
- [x] `cargo test --workspace` — 254 pass, 2 pre-existing failures on main (`user_defined_reader_flows_through_stdlib_read_exact`, `user_defined_writer_flows_through_stdlib_http_helper`) confirmed unrelated to this change