### PR TITLE
feat(stdlib): implement Stringer for String

### DIFF
--- a/library/src/std/string.kd
+++ b/library/src/std/string.kd
@@ -110,6 +110,10 @@ impl String {
         let byte_end = kaede_utf8_byte_index_of_char(self.as_ptr(), self.bytes.len(), safe_end)
         return String { bytes: Vector<u8>::from_slice(self.bytes.as_slice()[byte_start:byte_end]) }
     }
+
+    export fun to_string(self) -> String {
+        return self
+    }
 }
 
 fun parse_u64_from_str(s: str) -> Option<u64> {


### PR DESCRIPTION
## Summary

  - Add `to_string(self) -> String` to `impl String`, returning `self`.
  - `String` now satisfies the `Stringer` interface (`std/string.kd:322`), unblocking generic-over-`Stringer` APIs (see #293).

  The return type is the immutable `String` (not `mut String`), so callers cannot observe any aliasing of the underlying `Vector<u8>` buffer — no `clone()` is needed.

  Closes #294.