### PR TITLE
feat(stdlib): make print/println generic over Stringer

### DIFF
--- a/compiler/driver/tests/run.rs
+++ b/compiler/driver/tests/run.rs
@@ -270,6 +270,34 @@ fun main() -> i32 {
 }
 
 #[test]
+fn println_accepts_any_stringer() -> anyhow::Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+
+    create_project(
+        &temp_dir,
+        r#"import std.string
+use std.string.String
+
+fun main() {
+    println("from str")
+    println(String::from("from String"))
+    println(42 as i64)
+}"#,
+    )?;
+
+    Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+        .current_dir(temp_dir.path())
+        .arg("run")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("from str\n"))
+        .stdout(predicate::str::contains("from String\n"))
+        .stdout(predicate::str::contains("42\n"));
+
+    Ok(())
+}
+
+#[test]
 fn build_rejects_rust_import_when_rust_section_is_missing() -> anyhow::Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
 

--- a/library/src/std/io.kd
+++ b/library/src/std/io.kd
@@ -1,10 +1,12 @@
 import std.ffi.io
 import std.collections
 import std.result
+import std.string
 
 use std.ffi.io.write
 use std.collections.Vector
 use std.result.Result
+use std.string.Stringer
 
 // Coarse classification of an I/O failure. `from_errno` maps a few well-known
 // errnos to a kind so callers can branch without parsing errno themselves;
@@ -67,20 +69,30 @@ export interface Writer {
     fun write(self, buf: [u8]) -> Result<u64, IoError>
 }
 
-export fun print(msg: str) -> i32 {
-    return write(1, msg)
+// Writes `msg` to stdout. Accepts any value implementing `Stringer` —
+// `str`, `String`, integers, and any user-defined type with a
+// `to_string(self) -> String` method.
+export fun print<S: Stringer>(msg: S) -> i32 {
+    let s = msg.to_string()
+    return write(1, s.as_str())
 }
 
-export fun println(msg: str) -> i32 {
+// Writes `msg` followed by a newline to stdout. See `print` for the
+// accepted argument types.
+export fun println<S: Stringer>(msg: S) -> i32 {
     print(msg)
     return write(1, "\n")
 }
 
-export fun eprint(msg: str) -> i32 {
-    return write(2, msg)
+// Writes `msg` to stderr. See `print` for the accepted argument types.
+export fun eprint<S: Stringer>(msg: S) -> i32 {
+    let s = msg.to_string()
+    return write(2, s.as_str())
 }
 
-export fun eprintln(msg: str) -> i32 {
+// Writes `msg` followed by a newline to stderr. See `print` for the
+// accepted argument types.
+export fun eprintln<S: Stringer>(msg: S) -> i32 {
     eprint(msg)
     return write(2, "\n")
 }

--- a/library/src/std/io.kd
+++ b/library/src/std/io.kd
@@ -73,8 +73,7 @@ export interface Writer {
 // `str`, `String`, integers, and any user-defined type with a
 // `to_string(self) -> String` method.
 export fun print<S: Stringer>(msg: S) -> i32 {
-    let s = msg.to_string()
-    return write(1, s.as_str())
+    return write(1, msg.to_string().as_str())
 }
 
 // Writes `msg` followed by a newline to stdout. See `print` for the
@@ -86,8 +85,7 @@ export fun println<S: Stringer>(msg: S) -> i32 {
 
 // Writes `msg` to stderr. See `print` for the accepted argument types.
 export fun eprint<S: Stringer>(msg: S) -> i32 {
-    let s = msg.to_string()
-    return write(2, s.as_str())
+    return write(2, msg.to_string().as_str())
 }
 
 // Writes `msg` followed by a newline to stderr. See `print` for the

--- a/library/src/std/string.kd
+++ b/library/src/std/string.kd
@@ -110,6 +110,10 @@ impl String {
         let byte_end = kaede_utf8_byte_index_of_char(self.as_ptr(), self.bytes.len(), safe_end)
         return String { bytes: Vector<u8>::from_slice(self.bytes.as_slice()[byte_start:byte_end]) }
     }
+
+    export fun to_string(self) -> String {
+        return self
+    }
 }
 
 fun parse_u64_from_str(s: str) -> Option<u64> {


### PR DESCRIPTION
## Summary

- `print`, `println`, `eprint`, `eprintln` are now generic over the `Stringer` interface, not fixed to `str`.
- Any value with `to_string(self) -> String` — `str`, `String`, integers, user-defined Stringer types — can be passed directly.
- Existing `println("...")` call sites keep working because `str` implements `Stringer`.

```kaede
println("hi")                      // str (existing)
println(String::from("hi"))        // String (newly accepted)
println(42 as i64)                 // any numeric Stringer
```

The implementation routes through `to_string()` + `String::as_str()`, so a `str` argument incurs one allocation. Trade-off favors a uniform surface.

Closes #293. Builds on #295 (String : Stringer), already merged into main.

## Test plan

- [x] New integration test `println_accepts_any_stringer` in `compiler/driver/tests/run.rs` covers str / String / i64 in one program.
- [x] `cargo test --release -p kaede_compiler_driver` (driver suite) — all pass except pre-existing valgrind-on-macOS failures unrelated to this change.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p kaede_compiler_driver --all-targets -- -D warnings` — clean. (Note: `cargo clippy --all-targets` flags a pre-existing `items-after-test-module` warning in `compiler/monomorphize/src/lib.rs` that exists on `main` and is unrelated.)