### PR TITLE
feat(lang): add `select` expression for channel multiplexing

### DIFF
--- a/compiler/ast/src/expr.rs
+++ b/compiler/ast/src/expr.rs
@@ -314,6 +314,42 @@ pub struct Match {
 }
 
 #[derive(Debug, Clone)]
+pub enum SelectBinding {
+    /// `case value = ch.recv()` — bind the received value to a name.
+    Named(Ident),
+    /// `case _ = ch.recv()` — discard the received value.
+    Wildcard,
+}
+
+#[derive(Debug, Clone)]
+pub enum SelectOp {
+    /// `case ch.send(value)`
+    Send {
+        channel: Box<Expr>,
+        value: Box<Expr>,
+    },
+    /// `case binding = ch.recv()`
+    Recv {
+        channel: Box<Expr>,
+        binding: SelectBinding,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct SelectArm {
+    pub op: SelectOp,
+    pub body: Rc<Expr>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub struct Select {
+    pub arms: Vec<SelectArm>,
+    pub default: Option<Rc<Expr>>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
 pub struct Expr {
     pub kind: ExprKind,
     pub span: Span,
@@ -403,6 +439,7 @@ pub enum ExprKind {
     While(While),
     Break(Break),
     Match(Match),
+    Select(Select),
     Block(Block),
     Ty(Ty),
 }

--- a/compiler/codegen/src/expr.rs
+++ b/compiler/codegen/src/expr.rs
@@ -18,8 +18,8 @@ use kaede_ir::{
         ArrayLiteral, ArrayRepeat, Binary, BinaryKind, BitNot, BuiltinFnCall, BuiltinFnCallKind,
         ByteLiteral, ByteStringLiteral, Cast, CharLiteral, Closure, Else, EnumUnpack, EnumVariant,
         Expr, ExprKind, FieldAccess, Float, FnCall, FnPointer, FormatPart, ITable, If, Indexing,
-        Int, InterfaceBox, InterfaceMethodCall, LogicalNot, Loop, Slicing, Spawn, StringLiteral,
-        StructLiteral, TupleIndexing, TupleLiteral, Variable,
+        Int, InterfaceBox, InterfaceMethodCall, LogicalNot, Loop, Select, SelectOp, Slicing, Spawn,
+        StringLiteral, StructLiteral, TupleIndexing, TupleLiteral, Variable,
     },
     stmt::Block,
     ty::{
@@ -193,6 +193,7 @@ impl<'ctx> CodeGenerator<'ctx> {
 
             ExprKind::InterfaceBox(node) => self.build_interface_box(node)?,
             ExprKind::InterfaceMethodCall(node) => self.build_interface_method_call(node)?,
+            ExprKind::Select(node) => self.build_select(node)?,
         })
     }
 
@@ -1549,6 +1550,389 @@ impl<'ctx> CodeGenerator<'ctx> {
         }
 
         Ok(wrapper_fn)
+    }
+
+    /// Reach through a `Reference` (one level) to find the inner UDT, if any.
+    fn extract_user_defined_ty(ty: &Ty) -> Option<kaede_ir::ty::UserDefinedType> {
+        let inner = match ty.kind.as_ref() {
+            TyKind::Reference(rty) => rty.refee_ty.clone(),
+            _ => {
+                return match ty.kind.as_ref() {
+                    TyKind::UserDefined(u) => Some(u.clone()),
+                    _ => None,
+                }
+            }
+        };
+        match inner.kind.as_ref() {
+            TyKind::UserDefined(u) => Some(u.clone()),
+            _ => None,
+        }
+    }
+
+    /// Layout of `struct KaedeSelectCase` in the runtime, matched in LLVM:
+    ///   { i8*, i32, i32_pad, i8*, i32 }
+    /// (8) channel, (12) op, (16) value_slot, (24) status, total 32 bytes.
+    fn select_case_struct_type(&self) -> StructType<'ctx> {
+        let ptr_ty = self.context().ptr_type(AddressSpace::default());
+        let i32_ty = self.context().i32_type();
+        self.context().struct_type(
+            &[
+                ptr_ty.into(),
+                i32_ty.into(),
+                i32_ty.into(), // explicit padding to match C alignment
+                ptr_ty.into(),
+                i32_ty.into(),
+            ],
+            false,
+        )
+    }
+
+    fn build_select(&mut self, node: &Select) -> anyhow::Result<Value<'ctx>> {
+        let parent = self.get_current_fn();
+        let case_struct_ty = self.select_case_struct_type();
+        let n = node.arms.len();
+        let array_ty = case_struct_ty.array_type(n as u32);
+        let cases_alloca = self.create_entry_block_alloca("select.cases", array_ty.into())?;
+
+        // Allocate value slots per arm and populate the case array in source
+        // order (Go semantics: evaluate every channel/send value once up front).
+        let mut value_slots: Vec<PointerValue<'ctx>> = Vec::with_capacity(n);
+
+        for (i, arm) in node.arms.iter().enumerate() {
+            let elem_llvm_ty = self.conv_to_llvm_type(&arm.elem_ty);
+            let slot =
+                self.create_entry_block_alloca(&format!("select.slot{}", i), elem_llvm_ty)?;
+            value_slots.push(slot);
+
+            // Evaluate the channel expression and extract `Channel<T>.ptr`
+            // (which is *u8). The channel value is a pointer to a single-
+            // field struct `Channel<T> { ptr: *u8 }`; look up that struct
+            // type by its mangled name to GEP into it.
+            let channel_struct_ptr = self.build_expr(&arm.channel)?.unwrap().into_pointer_value();
+            let channel_udt = Self::extract_user_defined_ty(&arm.channel.ty).ok_or_else(|| {
+                anyhow::anyhow!("select channel arm operand is not a user-defined type")
+            })?;
+            let channel_qsym = match &channel_udt.kind {
+                kaede_ir::ty::UserDefinedTypeKind::Struct(s) => s.name.clone(),
+                kaede_ir::ty::UserDefinedTypeKind::Placeholder(qsym) => qsym.clone(),
+                _ => anyhow::bail!("select channel arm operand is not Channel<T>"),
+            };
+            let channel_llvm_struct = self
+                .module
+                .get_struct_type(channel_qsym.mangle().as_str())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Channel<T> LLVM struct type not registered: {}",
+                        channel_qsym.mangle()
+                    )
+                })?;
+            let chan_ptr_gep = unsafe {
+                self.builder.build_in_bounds_gep(
+                    channel_llvm_struct,
+                    channel_struct_ptr,
+                    &[
+                        self.context().i32_type().const_zero(),
+                        self.context().i32_type().const_zero(),
+                    ],
+                    "",
+                )?
+            };
+            let chan_raw_ptr = self
+                .builder
+                .build_load(
+                    self.context().ptr_type(AddressSpace::default()),
+                    chan_ptr_gep,
+                    "",
+                )?
+                .into_pointer_value();
+
+            // For send arms: evaluate the value and store into the slot.
+            if let SelectOp::Send = arm.op {
+                let value = self.build_expr(arm.value.as_ref().unwrap())?.unwrap();
+                self.builder.build_store(slot, value)?;
+            }
+
+            // Build a pointer to cases[i].
+            let case_ptr = unsafe {
+                self.builder.build_in_bounds_gep(
+                    array_ty,
+                    cases_alloca,
+                    &[
+                        self.context().i32_type().const_zero(),
+                        self.context().i32_type().const_int(i as u64, false),
+                    ],
+                    "",
+                )?
+            };
+
+            let store_field = |ce: &CodeGenerator<'ctx>,
+                               field: u32,
+                               value: BasicValueEnum<'ctx>|
+             -> anyhow::Result<()> {
+                let gep = unsafe {
+                    ce.builder.build_in_bounds_gep(
+                        case_struct_ty,
+                        case_ptr,
+                        &[
+                            ce.context().i32_type().const_zero(),
+                            ce.context().i32_type().const_int(field as u64, false),
+                        ],
+                        "",
+                    )?
+                };
+                ce.builder.build_store(gep, value)?;
+                Ok(())
+            };
+
+            // channel
+            store_field(self, 0, chan_raw_ptr.as_basic_value_enum())?;
+            // op
+            let op_const = self.context().i32_type().const_int(
+                match arm.op {
+                    SelectOp::Send => 0,
+                    SelectOp::Recv => 1,
+                },
+                false,
+            );
+            store_field(self, 1, op_const.as_basic_value_enum())?;
+            // pad
+            store_field(
+                self,
+                2,
+                self.context().i32_type().const_zero().as_basic_value_enum(),
+            )?;
+            // value_slot
+            store_field(self, 3, slot.as_basic_value_enum())?;
+            // status
+            store_field(
+                self,
+                4,
+                self.context().i32_type().const_zero().as_basic_value_enum(),
+            )?;
+        }
+
+        // Call kaede_select(cases, n, has_default).
+        let has_default = node.default.is_some();
+        let ptr_ty = self.context().ptr_type(AddressSpace::default());
+        let i64_ty = self.context().i64_type();
+        let i32_ty = self.context().i32_type();
+        let bool_ty = self.context().bool_type();
+        let select_fn = self.declare_runtime_fn(
+            "kaede_select",
+            i32_ty.fn_type(&[ptr_ty.into(), i64_ty.into(), bool_ty.into()], false),
+        );
+
+        let chosen = self
+            .builder
+            .build_call(
+                select_fn,
+                &[
+                    cases_alloca.as_basic_value_enum().into(),
+                    i64_ty.const_int(n as u64, false).into(),
+                    bool_ty
+                        .const_int(if has_default { 1 } else { 0 }, false)
+                        .into(),
+                ],
+                "select.chosen",
+            )?
+            .try_as_basic_value()
+            .left()
+            .unwrap()
+            .into_int_value();
+
+        // Per-arm basic blocks, plus optional default block, plus a join block.
+        let mut arm_blocks: Vec<inkwell::basic_block::BasicBlock<'ctx>> = Vec::with_capacity(n);
+        for i in 0..n {
+            arm_blocks.push(
+                self.context()
+                    .append_basic_block(parent, &format!("select.arm{}", i)),
+            );
+        }
+        let default_block = if has_default {
+            Some(self.context().append_basic_block(parent, "select.default"))
+        } else {
+            None
+        };
+        let cont_block = self.context().append_basic_block(parent, "select.cont");
+
+        // Switch: -1 -> default (if any), else arm[i].
+        let unreachable_block = self
+            .context()
+            .append_basic_block(parent, "select.unreachable");
+        let switch_default = default_block.unwrap_or(unreachable_block);
+        let cases: Vec<(IntValue<'ctx>, inkwell::basic_block::BasicBlock<'ctx>)> = (0..n)
+            .map(|i| (i32_ty.const_int(i as u64, false), arm_blocks[i]))
+            .collect();
+        self.builder.build_switch(chosen, switch_default, &cases)?;
+
+        // Terminate the unreachable block (when no default).
+        self.builder.position_at_end(unreachable_block);
+        self.builder.build_unreachable()?;
+
+        // Per-arm bodies.
+        for (i, arm) in node.arms.iter().enumerate() {
+            self.builder.position_at_end(arm_blocks[i]);
+
+            self.tcx.push_symbol_table(SymbolTable::new());
+
+            match arm.op {
+                SelectOp::Send => {
+                    // Nothing to bind. Just build body.
+                    self.build_expr(&arm.body)?;
+                }
+                SelectOp::Recv => {
+                    if let Some(binding) = arm.binding {
+                        // Materialize Option<T>: read cases[i].status, branch
+                        // VALUE -> Some(load slot), CLOSED -> None.
+                        let option_ty = arm.option_ty.as_ref().unwrap();
+                        let enum_info = arm.option_enum_info.as_ref().ok_or_else(|| {
+                            anyhow::anyhow!("select recv arm missing resolved Option enum info")
+                        })?;
+                        let option_value = self.build_recv_option(
+                            enum_info,
+                            value_slots[i],
+                            cases_alloca,
+                            &case_struct_ty,
+                            array_ty,
+                            i,
+                        )?;
+                        let option_llvm_ty = self.conv_to_llvm_type(option_ty);
+                        self.build_let_internal(binding, option_llvm_ty, Some(option_value))?;
+                    }
+                    self.build_expr(&arm.body)?;
+                }
+            }
+
+            self.tcx.pop_symbol_table();
+
+            if self.no_terminator() {
+                self.builder.build_unconditional_branch(cont_block)?;
+            }
+        }
+
+        // Default body.
+        if let (Some(default_block), Some(default_body)) = (default_block, &node.default) {
+            self.builder.position_at_end(default_block);
+            self.tcx.push_symbol_table(SymbolTable::new());
+            self.build_expr(default_body)?;
+            self.tcx.pop_symbol_table();
+            if self.no_terminator() {
+                self.builder.build_unconditional_branch(cont_block)?;
+            }
+        }
+
+        self.builder.position_at_end(cont_block);
+        Ok(None)
+    }
+
+    fn build_recv_option(
+        &mut self,
+        enum_info: &Rc<kaede_ir::top::Enum>,
+        value_slot: PointerValue<'ctx>,
+        cases_alloca: PointerValue<'ctx>,
+        case_struct_ty: &StructType<'ctx>,
+        array_ty: inkwell::types::ArrayType<'ctx>,
+        case_index: usize,
+    ) -> anyhow::Result<BasicValueEnum<'ctx>> {
+        let some_offset = enum_info
+            .variants
+            .iter()
+            .find(|v| v.name.as_str() == "Some")
+            .map(|v| v.offset)
+            .ok_or_else(|| anyhow::anyhow!("Option enum is missing Some variant"))?;
+        let none_offset = enum_info
+            .variants
+            .iter()
+            .find(|v| v.name.as_str() == "None")
+            .map(|v| v.offset)
+            .ok_or_else(|| anyhow::anyhow!("Option enum is missing None variant"))?;
+
+        // status = cases[i].status
+        let status_gep = unsafe {
+            self.builder.build_in_bounds_gep(
+                array_ty,
+                cases_alloca,
+                &[
+                    self.context().i32_type().const_zero(),
+                    self.context()
+                        .i32_type()
+                        .const_int(case_index as u64, false),
+                    self.context().i32_type().const_int(4, false),
+                ],
+                "",
+            )?
+        };
+        let status = self
+            .builder
+            .build_load(self.context().i32_type(), status_gep, "select.status")?
+            .into_int_value();
+
+        let parent = self.get_current_fn();
+        let some_bb = self.context().append_basic_block(parent, "recv.some");
+        let none_bb = self.context().append_basic_block(parent, "recv.none");
+        let join_bb = self.context().append_basic_block(parent, "recv.join");
+
+        // KAEDE_SELECT_STATUS_VALUE = 0. status == 0 → Some, else None.
+        let zero = self.context().i32_type().const_zero();
+        let is_value =
+            self.builder
+                .build_int_compare(IntPredicate::EQ, status, zero, "is_value")?;
+        self.builder
+            .build_conditional_branch(is_value, some_bb, none_bb)?;
+
+        // Some branch: load value from slot, construct Option::Some.
+        self.builder.position_at_end(some_bb);
+        let enum_llvm_ty = self
+            .module
+            .get_struct_type(enum_info.name.mangle().as_str())
+            .ok_or_else(|| anyhow::anyhow!("Option enum LLVM type not registered"))?;
+        // Determine payload type from variant Some's ty (== T).
+        let some_variant = enum_info
+            .variants
+            .iter()
+            .find(|v| v.name.as_str() == "Some")
+            .unwrap();
+        let payload_ty = some_variant
+            .ty
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Option::Some variant has no payload type"))?;
+        let payload_llvm_ty = self.conv_to_llvm_type(payload_ty);
+        let loaded_value = self.builder.build_load(payload_llvm_ty, value_slot, "")?;
+        let some_struct = self.create_gc_struct(
+            enum_llvm_ty.as_basic_type_enum(),
+            &[
+                self.context()
+                    .i32_type()
+                    .const_int(some_offset as u64, false)
+                    .into(),
+                loaded_value,
+            ],
+        )?;
+        self.builder.build_unconditional_branch(join_bb)?;
+        let some_bb_end = self.builder.get_insert_block().unwrap();
+
+        // None branch.
+        self.builder.position_at_end(none_bb);
+        let none_struct = self.create_gc_struct(
+            enum_llvm_ty.as_basic_type_enum(),
+            &[self
+                .context()
+                .i32_type()
+                .const_int(none_offset as u64, false)
+                .into()],
+        )?;
+        self.builder.build_unconditional_branch(join_bb)?;
+        let none_bb_end = self.builder.get_insert_block().unwrap();
+
+        // Phi-join: both branches produce a pointer to the Option struct.
+        self.builder.position_at_end(join_bb);
+        let phi = self
+            .builder
+            .build_phi(self.context().ptr_type(AddressSpace::default()), "recv.phi")?;
+        phi.add_incoming(&[(&some_struct, some_bb_end), (&none_struct, none_bb_end)]);
+
+        let _ = case_struct_ty; // currently unused, kept for symmetry
+        Ok(phi.as_basic_value())
     }
 
     fn declare_runtime_fn(

--- a/compiler/codegen/src/expr.rs
+++ b/compiler/codegen/src/expr.rs
@@ -1552,26 +1552,10 @@ impl<'ctx> CodeGenerator<'ctx> {
         Ok(wrapper_fn)
     }
 
-    /// Reach through a `Reference` (one level) to find the inner UDT, if any.
-    fn extract_user_defined_ty(ty: &Ty) -> Option<kaede_ir::ty::UserDefinedType> {
-        let inner = match ty.kind.as_ref() {
-            TyKind::Reference(rty) => rty.refee_ty.clone(),
-            _ => {
-                return match ty.kind.as_ref() {
-                    TyKind::UserDefined(u) => Some(u.clone()),
-                    _ => None,
-                }
-            }
-        };
-        match inner.kind.as_ref() {
-            TyKind::UserDefined(u) => Some(u.clone()),
-            _ => None,
-        }
-    }
-
     /// Layout of `struct KaedeSelectCase` in the runtime, matched in LLVM:
     ///   { i8*, i32, i32_pad, i8*, i32 }
     /// (8) channel, (12) op, (16) value_slot, (24) status, total 32 bytes.
+    /// The named constants below index this struct.
     fn select_case_struct_type(&self) -> StructType<'ctx> {
         let ptr_ty = self.context().ptr_type(AddressSpace::default());
         let i32_ty = self.context().i32_type();
@@ -1588,11 +1572,21 @@ impl<'ctx> CodeGenerator<'ctx> {
     }
 
     fn build_select(&mut self, node: &Select) -> anyhow::Result<Value<'ctx>> {
+        // Field indices into the KaedeSelectCase struct above. Must stay in
+        // sync with library/runtime/include/kaede/channel.h.
+        const FIELD_CHANNEL: u32 = 0;
+        const FIELD_OP: u32 = 1;
+        // Field 2 is explicit padding; left zero-initialized.
+        const FIELD_VALUE_SLOT: u32 = 3;
+        const FIELD_STATUS: u32 = 4;
+
         let parent = self.get_current_fn();
         let case_struct_ty = self.select_case_struct_type();
         let n = node.arms.len();
         let array_ty = case_struct_ty.array_type(n as u32);
         let cases_alloca = self.create_entry_block_alloca("select.cases", array_ty.into())?;
+        let i32_ty = self.context().i32_type();
+        let ptr_ty = self.context().ptr_type(AddressSpace::default());
 
         // Allocate value slots per arm and populate the case array in source
         // order (Go semantics: evaluate every channel/send value once up front).
@@ -1604,19 +1598,9 @@ impl<'ctx> CodeGenerator<'ctx> {
                 self.create_entry_block_alloca(&format!("select.slot{}", i), elem_llvm_ty)?;
             value_slots.push(slot);
 
-            // Evaluate the channel expression and extract `Channel<T>.ptr`
-            // (which is *u8). The channel value is a pointer to a single-
-            // field struct `Channel<T> { ptr: *u8 }`; look up that struct
-            // type by its mangled name to GEP into it.
+            // Evaluate the channel expression and extract `Channel<T>.ptr`.
             let channel_struct_ptr = self.build_expr(&arm.channel)?.unwrap().into_pointer_value();
-            let channel_udt = Self::extract_user_defined_ty(&arm.channel.ty).ok_or_else(|| {
-                anyhow::anyhow!("select channel arm operand is not a user-defined type")
-            })?;
-            let channel_qsym = match &channel_udt.kind {
-                kaede_ir::ty::UserDefinedTypeKind::Struct(s) => s.name.clone(),
-                kaede_ir::ty::UserDefinedTypeKind::Placeholder(qsym) => qsym.clone(),
-                _ => anyhow::bail!("select channel arm operand is not Channel<T>"),
-            };
+            let channel_qsym = Self::channel_struct_qsym(&arm.channel.ty)?;
             let channel_llvm_struct = self
                 .module
                 .get_struct_type(channel_qsym.mangle().as_str())
@@ -1626,96 +1610,57 @@ impl<'ctx> CodeGenerator<'ctx> {
                         channel_qsym.mangle()
                     )
                 })?;
-            let chan_ptr_gep = unsafe {
-                self.builder.build_in_bounds_gep(
-                    channel_llvm_struct,
-                    channel_struct_ptr,
-                    &[
-                        self.context().i32_type().const_zero(),
-                        self.context().i32_type().const_zero(),
-                    ],
-                    "",
-                )?
-            };
+            let chan_ptr_gep =
+                self.builder
+                    .build_struct_gep(channel_llvm_struct, channel_struct_ptr, 0, "")?;
             let chan_raw_ptr = self
                 .builder
-                .build_load(
-                    self.context().ptr_type(AddressSpace::default()),
-                    chan_ptr_gep,
-                    "",
-                )?
+                .build_load(ptr_ty, chan_ptr_gep, "")?
                 .into_pointer_value();
 
-            // For send arms: evaluate the value and store into the slot.
             if let SelectOp::Send = arm.op {
                 let value = self.build_expr(arm.value.as_ref().unwrap())?.unwrap();
                 self.builder.build_store(slot, value)?;
             }
 
-            // Build a pointer to cases[i].
             let case_ptr = unsafe {
                 self.builder.build_in_bounds_gep(
                     array_ty,
                     cases_alloca,
-                    &[
-                        self.context().i32_type().const_zero(),
-                        self.context().i32_type().const_int(i as u64, false),
-                    ],
+                    &[i32_ty.const_zero(), i32_ty.const_int(i as u64, false)],
                     "",
                 )?
             };
-
             let store_field = |ce: &CodeGenerator<'ctx>,
                                field: u32,
                                value: BasicValueEnum<'ctx>|
              -> anyhow::Result<()> {
-                let gep = unsafe {
-                    ce.builder.build_in_bounds_gep(
-                        case_struct_ty,
-                        case_ptr,
-                        &[
-                            ce.context().i32_type().const_zero(),
-                            ce.context().i32_type().const_int(field as u64, false),
-                        ],
-                        "",
-                    )?
-                };
+                let gep = ce
+                    .builder
+                    .build_struct_gep(case_struct_ty, case_ptr, field, "")?;
                 ce.builder.build_store(gep, value)?;
                 Ok(())
             };
 
-            // channel
-            store_field(self, 0, chan_raw_ptr.as_basic_value_enum())?;
-            // op
-            let op_const = self.context().i32_type().const_int(
+            let op_const = i32_ty.const_int(
                 match arm.op {
                     SelectOp::Send => 0,
                     SelectOp::Recv => 1,
                 },
                 false,
             );
-            store_field(self, 1, op_const.as_basic_value_enum())?;
-            // pad
+            store_field(self, FIELD_CHANNEL, chan_raw_ptr.as_basic_value_enum())?;
+            store_field(self, FIELD_OP, op_const.as_basic_value_enum())?;
+            store_field(self, FIELD_VALUE_SLOT, slot.as_basic_value_enum())?;
             store_field(
                 self,
-                2,
-                self.context().i32_type().const_zero().as_basic_value_enum(),
-            )?;
-            // value_slot
-            store_field(self, 3, slot.as_basic_value_enum())?;
-            // status
-            store_field(
-                self,
-                4,
-                self.context().i32_type().const_zero().as_basic_value_enum(),
+                FIELD_STATUS,
+                i32_ty.const_zero().as_basic_value_enum(),
             )?;
         }
 
-        // Call kaede_select(cases, n, has_default).
         let has_default = node.default.is_some();
-        let ptr_ty = self.context().ptr_type(AddressSpace::default());
         let i64_ty = self.context().i64_type();
-        let i32_ty = self.context().i32_type();
         let bool_ty = self.context().bool_type();
         let select_fn = self.declare_runtime_fn(
             "kaede_select",
@@ -1788,14 +1733,22 @@ impl<'ctx> CodeGenerator<'ctx> {
                         let enum_info = arm.option_enum_info.as_ref().ok_or_else(|| {
                             anyhow::anyhow!("select recv arm missing resolved Option enum info")
                         })?;
-                        let option_value = self.build_recv_option(
-                            enum_info,
-                            value_slots[i],
-                            cases_alloca,
-                            &case_struct_ty,
-                            array_ty,
-                            i,
+                        let case_ptr = unsafe {
+                            self.builder.build_in_bounds_gep(
+                                array_ty,
+                                cases_alloca,
+                                &[i32_ty.const_zero(), i32_ty.const_int(i as u64, false)],
+                                "",
+                            )?
+                        };
+                        let status_gep = self.builder.build_struct_gep(
+                            case_struct_ty,
+                            case_ptr,
+                            FIELD_STATUS,
+                            "",
                         )?;
+                        let option_value =
+                            self.build_recv_option(enum_info, value_slots[i], status_gep)?;
                         let option_llvm_ty = self.conv_to_llvm_type(option_ty);
                         self.build_let_internal(binding, option_llvm_ty, Some(option_value))?;
                     }
@@ -1829,42 +1782,31 @@ impl<'ctx> CodeGenerator<'ctx> {
         &mut self,
         enum_info: &Rc<kaede_ir::top::Enum>,
         value_slot: PointerValue<'ctx>,
-        cases_alloca: PointerValue<'ctx>,
-        case_struct_ty: &StructType<'ctx>,
-        array_ty: inkwell::types::ArrayType<'ctx>,
-        case_index: usize,
+        status_gep: PointerValue<'ctx>,
     ) -> anyhow::Result<BasicValueEnum<'ctx>> {
-        let some_offset = enum_info
+        let some_variant = enum_info
             .variants
             .iter()
             .find(|v| v.name.as_str() == "Some")
-            .map(|v| v.offset)
             .ok_or_else(|| anyhow::anyhow!("Option enum is missing Some variant"))?;
-        let none_offset = enum_info
+        let none_variant = enum_info
             .variants
             .iter()
             .find(|v| v.name.as_str() == "None")
-            .map(|v| v.offset)
             .ok_or_else(|| anyhow::anyhow!("Option enum is missing None variant"))?;
+        let enum_llvm_ty = self
+            .module
+            .get_struct_type(enum_info.name.mangle().as_str())
+            .ok_or_else(|| anyhow::anyhow!("Option enum LLVM type not registered"))?;
+        let payload_ty = some_variant
+            .ty
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Option::Some variant has no payload type"))?;
 
-        // status = cases[i].status
-        let status_gep = unsafe {
-            self.builder.build_in_bounds_gep(
-                array_ty,
-                cases_alloca,
-                &[
-                    self.context().i32_type().const_zero(),
-                    self.context()
-                        .i32_type()
-                        .const_int(case_index as u64, false),
-                    self.context().i32_type().const_int(4, false),
-                ],
-                "",
-            )?
-        };
+        let i32_ty = self.context().i32_type();
         let status = self
             .builder
-            .build_load(self.context().i32_type(), status_gep, "select.status")?
+            .build_load(i32_ty, status_gep, "select.status")?
             .into_int_value();
 
         let parent = self.get_current_fn();
@@ -1873,66 +1815,65 @@ impl<'ctx> CodeGenerator<'ctx> {
         let join_bb = self.context().append_basic_block(parent, "recv.join");
 
         // KAEDE_SELECT_STATUS_VALUE = 0. status == 0 → Some, else None.
-        let zero = self.context().i32_type().const_zero();
-        let is_value =
-            self.builder
-                .build_int_compare(IntPredicate::EQ, status, zero, "is_value")?;
+        let is_value = self.builder.build_int_compare(
+            IntPredicate::EQ,
+            status,
+            i32_ty.const_zero(),
+            "is_value",
+        )?;
         self.builder
             .build_conditional_branch(is_value, some_bb, none_bb)?;
 
-        // Some branch: load value from slot, construct Option::Some.
         self.builder.position_at_end(some_bb);
-        let enum_llvm_ty = self
-            .module
-            .get_struct_type(enum_info.name.mangle().as_str())
-            .ok_or_else(|| anyhow::anyhow!("Option enum LLVM type not registered"))?;
-        // Determine payload type from variant Some's ty (== T).
-        let some_variant = enum_info
-            .variants
-            .iter()
-            .find(|v| v.name.as_str() == "Some")
-            .unwrap();
-        let payload_ty = some_variant
-            .ty
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Option::Some variant has no payload type"))?;
         let payload_llvm_ty = self.conv_to_llvm_type(payload_ty);
         let loaded_value = self.builder.build_load(payload_llvm_ty, value_slot, "")?;
         let some_struct = self.create_gc_struct(
             enum_llvm_ty.as_basic_type_enum(),
             &[
-                self.context()
-                    .i32_type()
-                    .const_int(some_offset as u64, false)
-                    .into(),
+                i32_ty.const_int(some_variant.offset as u64, false).into(),
                 loaded_value,
             ],
         )?;
         self.builder.build_unconditional_branch(join_bb)?;
         let some_bb_end = self.builder.get_insert_block().unwrap();
 
-        // None branch.
         self.builder.position_at_end(none_bb);
         let none_struct = self.create_gc_struct(
             enum_llvm_ty.as_basic_type_enum(),
-            &[self
-                .context()
-                .i32_type()
-                .const_int(none_offset as u64, false)
-                .into()],
+            &[i32_ty.const_int(none_variant.offset as u64, false).into()],
         )?;
         self.builder.build_unconditional_branch(join_bb)?;
         let none_bb_end = self.builder.get_insert_block().unwrap();
 
-        // Phi-join: both branches produce a pointer to the Option struct.
         self.builder.position_at_end(join_bb);
         let phi = self
             .builder
             .build_phi(self.context().ptr_type(AddressSpace::default()), "recv.phi")?;
         phi.add_incoming(&[(&some_struct, some_bb_end), (&none_struct, none_bb_end)]);
-
-        let _ = case_struct_ty; // currently unused, kept for symmetry
         Ok(phi.as_basic_value())
+    }
+
+    /// For a `Reference<Channel<T>>` (or bare `Channel<T>`) operand type, return
+    /// the qualified symbol naming the LLVM struct type for `Channel<T>`.
+    fn channel_struct_qsym(ty: &Ty) -> anyhow::Result<kaede_ir::qualified_symbol::QualifiedSymbol> {
+        let base = match ty.kind.as_ref() {
+            TyKind::Reference(rty) => rty.get_base_type(),
+            _ => return Self::channel_struct_qsym_from_udt_ty(ty),
+        };
+        Self::channel_struct_qsym_from_udt_ty(&base)
+    }
+
+    fn channel_struct_qsym_from_udt_ty(
+        ty: &Ty,
+    ) -> anyhow::Result<kaede_ir::qualified_symbol::QualifiedSymbol> {
+        let TyKind::UserDefined(udt) = ty.kind.as_ref() else {
+            anyhow::bail!("select channel arm operand is not a user-defined type");
+        };
+        match &udt.kind {
+            kaede_ir::ty::UserDefinedTypeKind::Struct(s) => Ok(s.name.clone()),
+            kaede_ir::ty::UserDefinedTypeKind::Placeholder(qsym) => Ok(qsym.clone()),
+            _ => anyhow::bail!("select channel arm operand is not Channel<T>"),
+        }
     }
 
     fn declare_runtime_fn(

--- a/compiler/driver/tests/runtime_select.rs
+++ b/compiler/driver/tests/runtime_select.rs
@@ -1,0 +1,207 @@
+mod driver_test_support;
+
+use driver_test_support::run_program as test;
+
+#[test]
+fn select_single_recv_arm_behaves_like_plain_recv() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun producer(ch: Channel<i32>) {
+    ch.send(42)
+}
+
+fun main() -> i32 {
+    let ch = Channel<i32>::new()
+    spawn producer(ch)
+
+    select {
+        case value = ch.recv() => {
+            match value {
+                Option::Some(v) => {
+                    if v != 42 { return 2 }
+                    return 0
+                },
+                Option::None => return 1,
+            }
+        }
+    }
+    return 3
+}"#,
+    )
+}
+
+#[test]
+fn select_fan_in_from_two_producers() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun producer1(ch: Channel<i32>) {
+    ch.send(10)
+}
+
+fun producer2(ch: Channel<i32>) {
+    ch.send(32)
+}
+
+fun main() -> i32 {
+    let a = Channel<i32>::new()
+    let b = Channel<i32>::new()
+    spawn producer1(a)
+    spawn producer2(b)
+
+    let mut sum = 0
+    let mut received = 0
+    loop {
+        if received == 2 { break }
+        select {
+            case va = a.recv() => {
+                match va {
+                    Option::Some(v) => { sum = sum + v },
+                    Option::None => {},
+                }
+                received = received + 1
+            },
+            case vb = b.recv() => {
+                match vb {
+                    Option::Some(v) => { sum = sum + v },
+                    Option::None => {},
+                }
+                received = received + 1
+            },
+        }
+    }
+
+    if sum == 42 { return 0 }
+    return 4
+}"#,
+    )
+}
+
+#[test]
+fn select_default_falls_through_when_no_case_ready() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun main() -> i32 {
+    let ch = Channel<i32>::with_capacity(1)
+
+    select {
+        case _ = ch.recv() => return 1,
+        default => return 0,
+    }
+    return 2
+}"#,
+    )
+}
+
+#[test]
+fn select_observes_closed_channel_as_none() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun closer(ch: Channel<i32>) {
+    ch.close()
+}
+
+fun main() -> i32 {
+    let ch = Channel<i32>::new()
+    spawn closer(ch)
+
+    select {
+        case value = ch.recv() => {
+            match value {
+                Option::None => return 0,
+                Option::Some(_) => return 1,
+            }
+        }
+    }
+    return 2
+}"#,
+    )
+}
+
+#[test]
+fn select_send_case_into_buffered_channel() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun main() -> i32 {
+    let ch = Channel<i32>::with_capacity(1)
+
+    select {
+        case ch.send(11) => {},
+    }
+
+    match ch.recv() {
+        Option::Some(v) => {
+            if v == 11 { return 0 }
+            return 2
+        },
+        Option::None => return 1,
+    }
+}"#,
+    )
+}
+
+#[test]
+fn select_send_case_handshakes_with_blocked_receiver() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun receiver(ch: Channel<i32>, out: Channel<i32>) {
+    match ch.recv() {
+        Option::Some(v) => out.send(v),
+        Option::None => out.send(-1),
+    }
+}
+
+fun main() -> i32 {
+    let ch = Channel<i32>::new()
+    let out = Channel<i32>::new()
+    spawn receiver(ch, out)
+
+    select {
+        case ch.send(99) => {},
+    }
+
+    match out.recv() {
+        Option::Some(v) => {
+            if v == 99 { return 0 }
+            return 2
+        },
+        Option::None => return 1,
+    }
+}"#,
+    )
+}

--- a/compiler/ir/src/expr.rs
+++ b/compiler/ir/src/expr.rs
@@ -370,6 +370,43 @@ pub struct InterfaceMethodCall {
 }
 
 #[derive(Debug, Clone)]
+pub enum SelectOp {
+    Send,
+    Recv,
+}
+
+#[derive(Debug, Clone)]
+pub struct SelectArm {
+    pub op: SelectOp,
+    /// Resolved Channel<T> expression.
+    pub channel: Box<Expr>,
+    /// Channel element type T.
+    pub elem_ty: Rc<Ty>,
+    /// For send arms: the value expression (already type-checked against T).
+    /// For recv arms: None.
+    pub value: Option<Box<Expr>>,
+    /// For recv arms with a name binding: the bound symbol whose type is
+    /// `Option<T>`. `None` for `_ = ...` (discarded) or for send arms.
+    pub binding: Option<Symbol>,
+    /// `Option<T>` type for recv arms (used by codegen to materialize the
+    /// Some/None value). `None` for send arms.
+    pub option_ty: Option<Rc<Ty>>,
+    /// Pre-resolved `Option` enum metadata for recv arms (variants + name).
+    /// Set during semantic analysis so codegen does not need to chase
+    /// Placeholder lookups.
+    pub option_enum_info: Option<Rc<crate::top::Enum>>,
+    pub body: Box<Expr>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub struct Select {
+    pub arms: Vec<SelectArm>,
+    pub default: Option<Box<Expr>>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
 pub enum ExprKind {
     Int(Int),
     Float(Float),
@@ -406,6 +443,7 @@ pub enum ExprKind {
     BuiltinFnCall(BuiltinFnCall),
     InterfaceBox(InterfaceBox),
     InterfaceMethodCall(InterfaceMethodCall),
+    Select(Select),
 }
 
 #[derive(Debug, Clone)]

--- a/compiler/lex/src/lib.rs
+++ b/compiler/lex/src/lib.rs
@@ -188,6 +188,9 @@ impl Cursor<'_> {
                     "self" => self.create_token(TokenKind::Self_),
                     "use" => self.create_token(TokenKind::Use),
                     "spawn" => self.create_token(TokenKind::Spawn),
+                    "select" => self.create_token(TokenKind::Select),
+                    "default" => self.create_token(TokenKind::Default),
+                    "case" => self.create_token(TokenKind::Case),
                     "type" => self.create_token(TokenKind::Type),
 
                     // Identifier

--- a/compiler/lex/src/token.rs
+++ b/compiler/lex/src/token.rs
@@ -151,6 +151,12 @@ pub enum TokenKind {
     Use,
     /// "spawn"
     Spawn,
+    /// "select"
+    Select,
+    /// "default"
+    Default,
+    /// "case"
+    Case,
 
     /// "type"
     Type,
@@ -249,6 +255,9 @@ impl std::fmt::Display for TokenKind {
                 Self_ => "'self'",
                 Use => "'use'",
                 Spawn => "'spawn'",
+                Select => "'select'",
+                Default => "'default'",
+                Case => "'case'",
                 Type => "'type'",
 
                 True => "'true'",

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -299,6 +299,7 @@ fn semantic_error_span(err: &SemanticError) -> Option<Span> {
         | SemanticError::SpawnReturnTypeNotUnit { span, .. }
         | SemanticError::ChannelSendRequiresChannel { span, .. }
         | SemanticError::ChannelRecvRequiresChannel { span, .. }
+        | SemanticError::SelectCaseRequiresChannel { span, .. }
         | SemanticError::UnsupportedLanguageLinkage { span, .. }
         | SemanticError::TopLevelStatementsWithExplicitMain { span }
         | SemanticError::TopLevelStatementsOnlyAllowedInEntryUnit { span }

--- a/compiler/monomorphize/src/lib.rs
+++ b/compiler/monomorphize/src/lib.rs
@@ -157,6 +157,16 @@ mod tests {
                 contains_generic_call(&call.receiver)
                     || call.args.0.iter().any(contains_generic_call)
             }
+            ExprKind::Select(select) => {
+                select.arms.iter().any(|arm| {
+                    contains_generic_call(&arm.channel)
+                        || arm.value.as_ref().is_some_and(|v| contains_generic_call(v))
+                        || contains_generic_call(&arm.body)
+                }) || select
+                    .default
+                    .as_ref()
+                    .is_some_and(|d| contains_generic_call(d))
+            }
             ExprKind::Int(_)
             | ExprKind::Float(_)
             | ExprKind::StringLiteral(_)
@@ -524,6 +534,18 @@ impl Monomorphizer {
                 self.rewrite_expr(&mut call.receiver)?;
                 for arg in &mut call.args.0 {
                     self.rewrite_expr(arg)?;
+                }
+            }
+            ExprKind::Select(select) => {
+                for arm in &mut select.arms {
+                    self.rewrite_expr(&mut arm.channel)?;
+                    if let Some(value) = &mut arm.value {
+                        self.rewrite_expr(value)?;
+                    }
+                    self.rewrite_expr(&mut arm.body)?;
+                }
+                if let Some(default) = &mut select.default {
+                    self.rewrite_expr(default)?;
                 }
             }
             ExprKind::Int(_)

--- a/compiler/parse/src/expr.rs
+++ b/compiler/parse/src/expr.rs
@@ -4,7 +4,8 @@ use kaede_ast::expr::{
     Arg, Args, ArrayLiteral, ArrayRepeat, Binary, BinaryKind, BitNot, Break, ByteLiteral,
     ByteStringLiteral, ChannelRecv, ChannelSend, CharLiteral, Closure, Else, Expr, ExprKind, Float,
     FloatKind, FnCall, If, Indexing, Int, IntKind, LogicalNot, Loop, Match, MatchArm, Return,
-    Slicing, Spawn, StringLiteral, StructLiteral, Try, TupleLiteral, While,
+    Select, SelectArm, SelectBinding, SelectOp, Slicing, Spawn, StringLiteral, StructLiteral, Try,
+    TupleLiteral, While,
 };
 use kaede_ast_type::{GenericArgs, Ty, TyKind};
 use kaede_lex::token::TokenKind;
@@ -548,6 +549,10 @@ impl Parser {
             return self.match_();
         }
 
+        if self.check(&TokenKind::Select) {
+            return self.select_();
+        }
+
         if self.check(&TokenKind::Return) {
             return self.return_();
         }
@@ -793,6 +798,235 @@ impl Parser {
                 span,
             }),
         })
+    }
+
+    /// `select { (case CASE_OP "=>" BODY (",")?)* (default "=>" BODY)? }`
+    /// Case op is restricted to one of:
+    ///   - `IDENT "=" EXPR "." "recv" "(" ")"`
+    ///   - `"_" "=" EXPR "." "recv" "(" ")"`
+    ///   - `EXPR "." "send" "(" EXPR ")"`
+    fn select_(&mut self) -> ParseResult<Expr> {
+        let start = self.consume(&TokenKind::Select)?.start;
+
+        self.consume(&TokenKind::OpenBrace)?;
+
+        let mut arms: Vec<SelectArm> = Vec::new();
+        let mut default: Option<Rc<Expr>> = None;
+
+        loop {
+            if self.check(&TokenKind::CloseBrace) {
+                break;
+            }
+
+            if self.consume_b(&TokenKind::Default) {
+                self.consume(&TokenKind::Eq)?;
+                self.consume(&TokenKind::Gt)?;
+                let body = self.expr()?;
+                if default.is_some() {
+                    return Err(ParseError::ExpectedError {
+                        expected: "at most one 'default' arm in select".to_string(),
+                        but: "second 'default' arm".to_string(),
+                        span: body.span,
+                    }
+                    .into());
+                }
+                default = Some(Rc::new(body));
+            } else {
+                self.consume(&TokenKind::Case)?;
+                let arm = self.select_arm()?;
+                arms.push(arm);
+            }
+
+            if self.consume_b(&TokenKind::Comma) {
+                continue;
+            }
+            if self.check(&TokenKind::CloseBrace) {
+                break;
+            }
+            if self.check_semi() {
+                self.consume_semi()?;
+                continue;
+            }
+
+            return Err(ParseError::ExpectedError {
+                expected: "',' or '}'".to_string(),
+                but: self.first().kind.to_string(),
+                span: self.first().span,
+            }
+            .into());
+        }
+
+        let finish = self.consume(&TokenKind::CloseBrace)?.finish;
+        let span = self.new_span(start, finish);
+
+        if arms.is_empty() && default.is_none() {
+            return Err(ParseError::ExpectedError {
+                expected: "at least one 'case' or 'default' arm in select".to_string(),
+                but: "empty select".to_string(),
+                span,
+            }
+            .into());
+        }
+
+        Ok(Expr {
+            span,
+            kind: ExprKind::Select(Select {
+                arms,
+                default,
+                span,
+            }),
+        })
+    }
+
+    fn select_arm(&mut self) -> ParseResult<SelectArm> {
+        let arm_start = self.first().span.start;
+
+        // Peek at the first two tokens to decide between recv-binding form
+        // (`IDENT = ...` or `_ = ...`) and send form (`EXPR.send(...)`).
+        let is_recv_binding = {
+            let first = self.first().kind.clone();
+            let second_kind = self
+                .tokens
+                .get(1)
+                .map(|t| t.kind.clone())
+                .unwrap_or(TokenKind::Eoi);
+            matches!(first, TokenKind::Ident(_)) && matches!(second_kind, TokenKind::Eq)
+        };
+
+        if is_recv_binding {
+            let name_tok = self.first().clone();
+            let TokenKind::Ident(name_str) = name_tok.kind.clone() else {
+                unreachable!("checked above");
+            };
+            self.bump();
+            let binding = if name_str.as_str() == "_" {
+                SelectBinding::Wildcard
+            } else {
+                SelectBinding::Named(Ident::new(Symbol::from(name_str), name_tok.span))
+            };
+            self.consume(&TokenKind::Eq)?;
+            // RHS must be a method call: EXPR.recv().
+            let call = self.expr()?;
+            let (channel, _value) = Self::decompose_channel_method_call(call, "recv")?;
+            self.consume(&TokenKind::Eq)?;
+            self.consume(&TokenKind::Gt)?;
+            let body = self.expr()?;
+            let span = self.new_span(arm_start, body.span.finish);
+            return Ok(SelectArm {
+                op: SelectOp::Recv {
+                    channel: Box::new(channel),
+                    binding,
+                },
+                body: Rc::new(body),
+                span,
+            });
+        }
+
+        // Send: EXPR.send(EXPR)
+        let call = self.expr()?;
+        let (channel, value) = Self::decompose_channel_method_call(call, "send")?;
+        let value = value.ok_or_else(|| ParseError::ExpectedError {
+            expected: "send value expression".to_string(),
+            but: "missing argument".to_string(),
+            span: channel.span,
+        })?;
+        self.consume(&TokenKind::Eq)?;
+        self.consume(&TokenKind::Gt)?;
+        let body = self.expr()?;
+        let span = self.new_span(arm_start, body.span.finish);
+        Ok(SelectArm {
+            op: SelectOp::Send {
+                channel: Box::new(channel),
+                value: Box::new(value),
+            },
+            body: Rc::new(body),
+            span,
+        })
+    }
+
+    /// Given a parsed `EXPR.method(...)` call, return (channel, arg) where
+    /// channel is the receiver and arg is the first argument (for send) or
+    /// None (for recv). Errors if the expression is not a method call to
+    /// `expected_method`.
+    /// Channel method calls (`ch.method(args)`) can produce two AST shapes in
+    /// Kaede's parser, depending on whether `method` resolves as a type name in
+    /// `primary()`:
+    ///
+    /// 1. `FnCall { callee: Binary(ch, Access, method), args }` — classic.
+    /// 2. `Binary(ch, Access, FnCall { callee: method, args })` — happens when
+    ///    `primary()` consumed `method(...)` as a fn-call before postfix saw the
+    ///    surrounding `ch.`.
+    ///
+    /// Accept both and return `(channel, first_arg)`.
+    fn decompose_channel_method_call(
+        call: Expr,
+        expected_method: &str,
+    ) -> ParseResult<(Expr, Option<Expr>)> {
+        let span = call.span;
+        let err = || ParseError::ExpectedError {
+            expected: format!("'channel.{}(...)' method call", expected_method),
+            but: "non-method-call expression".to_string(),
+            span,
+        };
+
+        let (channel, method_name, method_name_span, args_iter): (
+            Expr,
+            Symbol,
+            Span,
+            Box<dyn Iterator<Item = Arg>>,
+        ) = match call.kind {
+            ExprKind::FnCall(fn_call) => {
+                let ExprKind::Binary(callee_bin) = fn_call.callee.kind else {
+                    return Err(err().into());
+                };
+                if !matches!(callee_bin.kind, BinaryKind::Access) {
+                    return Err(err().into());
+                }
+                let ExprKind::Ident(method_ident) = callee_bin.rhs.kind else {
+                    return Err(err().into());
+                };
+                (
+                    *callee_bin.lhs,
+                    method_ident.symbol(),
+                    method_ident.span(),
+                    Box::new(fn_call.args.args.into_iter()),
+                )
+            }
+            ExprKind::Binary(bin) => {
+                if !matches!(bin.kind, BinaryKind::Access) {
+                    return Err(err().into());
+                }
+                let lhs = *bin.lhs;
+                let rhs = *bin.rhs;
+                let ExprKind::FnCall(inner) = rhs.kind else {
+                    return Err(err().into());
+                };
+                let method_name_expr = *inner.callee;
+                let (method_name, method_name_span) = match method_name_expr.kind {
+                    ExprKind::Ident(ident) => (ident.symbol(), ident.span()),
+                    _ => return Err(err().into()),
+                };
+                (
+                    lhs,
+                    method_name,
+                    method_name_span,
+                    Box::new(inner.args.args.into_iter()),
+                )
+            }
+            _ => return Err(err().into()),
+        };
+
+        if method_name.as_str() != expected_method {
+            return Err(ParseError::ExpectedError {
+                expected: format!("'{}'", expected_method),
+                but: format!("'{}'", method_name),
+                span: method_name_span,
+            }
+            .into());
+        }
+
+        let first_arg = args_iter.into_iter().next().map(|a| a.value);
+        Ok((channel, first_arg))
     }
 
     fn comma_separated_elements(&mut self, end: &TokenKind) -> ParseResult<Vec<Expr>> {

--- a/compiler/parse/tests/select_syntax.rs
+++ b/compiler/parse/tests/select_syntax.rs
@@ -1,0 +1,104 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use kaede_ast::expr::{ExprKind, SelectBinding, SelectOp};
+use kaede_parse::Parser;
+use kaede_span::file::FilePath;
+
+fn parse(source: &str) -> Result<kaede_ast::expr::Expr> {
+    let mut parser = Parser::new(source, FilePath::from(PathBuf::from("test.kd")));
+    parser.expr()
+}
+
+#[test]
+fn parses_single_recv_binding() -> Result<()> {
+    let expr = parse("select { case value = ch.recv() => 1 }")?;
+    let select = match expr.kind {
+        ExprKind::Select(s) => s,
+        other => panic!("expected select, got {other:?}"),
+    };
+    assert_eq!(select.arms.len(), 1);
+    assert!(select.default.is_none());
+    match &select.arms[0].op {
+        SelectOp::Recv { binding, channel } => {
+            match binding {
+                SelectBinding::Named(ident) => assert_eq!(ident.symbol().as_str(), "value"),
+                other => panic!("expected named binding, got {other:?}"),
+            }
+            assert!(matches!(channel.kind, ExprKind::Ident(_)));
+        }
+        other => panic!("expected recv op, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[test]
+fn parses_wildcard_recv() -> Result<()> {
+    let expr = parse("select { case _ = ch.recv() => 1 }")?;
+    let select = match expr.kind {
+        ExprKind::Select(s) => s,
+        other => panic!("expected select, got {other:?}"),
+    };
+    match &select.arms[0].op {
+        SelectOp::Recv { binding, .. } => {
+            assert!(matches!(binding, SelectBinding::Wildcard));
+        }
+        other => panic!("expected recv op, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[test]
+fn parses_send_arm() -> Result<()> {
+    let expr = parse("select { case ch.send(42) => 1 }")?;
+    let select = match expr.kind {
+        ExprKind::Select(s) => s,
+        other => panic!("expected select, got {other:?}"),
+    };
+    match &select.arms[0].op {
+        SelectOp::Send { channel, value } => {
+            assert!(matches!(channel.kind, ExprKind::Ident(_)));
+            assert!(matches!(value.kind, ExprKind::Int(_)));
+        }
+        other => panic!("expected send op, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[test]
+fn parses_default_arm() -> Result<()> {
+    let expr = parse("select { default => 7 }")?;
+    let select = match expr.kind {
+        ExprKind::Select(s) => s,
+        other => panic!("expected select, got {other:?}"),
+    };
+    assert_eq!(select.arms.len(), 0);
+    assert!(select.default.is_some());
+    Ok(())
+}
+
+#[test]
+fn parses_mixed_arms_with_default() -> Result<()> {
+    let expr = parse("select { case v = ch.recv() => 1, case ch.send(2) => 3, default => 4 }")?;
+    let select = match expr.kind {
+        ExprKind::Select(s) => s,
+        other => panic!("expected select, got {other:?}"),
+    };
+    assert_eq!(select.arms.len(), 2);
+    assert!(select.default.is_some());
+    assert!(matches!(select.arms[0].op, SelectOp::Recv { .. }));
+    assert!(matches!(select.arms[1].op, SelectOp::Send { .. }));
+    Ok(())
+}
+
+#[test]
+fn rejects_empty_select() {
+    let result = parse("select {}");
+    assert!(result.is_err(), "expected empty select to fail to parse");
+}
+
+#[test]
+fn rejects_non_method_case() {
+    let result = parse("select { case 1 + 2 => 0 }");
+    assert!(result.is_err(), "expected non-method case to fail to parse");
+}

--- a/compiler/semantic/src/error.rs
+++ b/compiler/semantic/src/error.rs
@@ -208,6 +208,9 @@ pub enum SemanticError {
     #[error("{}:{}:{} channel receive requires `std.sync.Channel<T>`, got `{}`", span.file, span.start.line, span.start.column, actual)]
     ChannelRecvRequiresChannel { actual: String, span: Span },
 
+    #[error("{}:{}:{} select case requires `std.sync.Channel<T>`, got `{}`", span.file, span.start.line, span.start.column, actual)]
+    SelectCaseRequiresChannel { actual: String, span: Span },
+
     #[error("{}:{}:{} `format` template must be a string literal", span.file, span.start.line, span.start.column)]
     FormatTemplateMustBeStringLiteral { span: Span },
 

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -209,6 +209,7 @@ impl SemanticAnalyzer {
             ExprKind::Loop(node) => self.analyze_loop(node),
             ExprKind::While(node) => self.analyze_while(node),
             ExprKind::Match(node) => self.analyze_match(node),
+            ExprKind::Select(node) => self.analyze_select(node),
             ExprKind::StructLiteral(node) => self.analyze_struct_literal(node),
             ExprKind::TupleLiteral(node) => self.analyze_tuple_literal(node),
             ExprKind::Closure(node) => self.analyze_closure(node, None),
@@ -354,6 +355,160 @@ impl SemanticAnalyzer {
             &[],
             node.span,
         )
+    }
+
+    /// Channel<T> element type T, extracted from a Channel UDT's generic args.
+    fn channel_elem_ty(udt: &ir_type::UserDefinedType) -> Option<Rc<ir_type::Ty>> {
+        udt.generic_instance
+            .as_ref()
+            .and_then(|gi| gi.args.first().cloned())
+    }
+
+    fn analyze_select(&mut self, node: &ast::expr::Select) -> anyhow::Result<ir::expr::Expr> {
+        let mut ir_arms: Vec<ir::expr::SelectArm> = Vec::with_capacity(node.arms.len());
+
+        for arm in &node.arms {
+            let arm_ir = match &arm.op {
+                ast::expr::SelectOp::Send { channel, value } => {
+                    let chan_ir = self.analyze_expr(channel)?;
+                    let Some(udt) = self.channel_udt_from_ty(&chan_ir.ty) else {
+                        return Err(SemanticError::SelectCaseRequiresChannel {
+                            actual: chan_ir.ty.kind.to_string(),
+                            span: channel.span,
+                        }
+                        .into());
+                    };
+                    let elem_ty = Self::channel_elem_ty(&udt).ok_or_else(|| {
+                        SemanticError::SelectCaseRequiresChannel {
+                            actual: chan_ir.ty.kind.to_string(),
+                            span: channel.span,
+                        }
+                    })?;
+                    let value_ir = self.analyze_expr_with_expected_type(value, elem_ty.clone())?;
+
+                    self.push_scope(SymbolTable::new());
+                    let body = self.analyze_expr(arm.body.as_ref())?;
+                    self.pop_scope();
+
+                    ir::expr::SelectArm {
+                        op: ir::expr::SelectOp::Send,
+                        channel: Box::new(chan_ir),
+                        elem_ty,
+                        value: Some(Box::new(value_ir)),
+                        binding: None,
+                        option_ty: None,
+                        option_enum_info: None,
+                        body: Box::new(body),
+                        span: arm.span,
+                    }
+                }
+                ast::expr::SelectOp::Recv { channel, binding } => {
+                    let chan_ir = self.analyze_expr(channel)?;
+                    let Some(udt) = self.channel_udt_from_ty(&chan_ir.ty) else {
+                        return Err(SemanticError::SelectCaseRequiresChannel {
+                            actual: chan_ir.ty.kind.to_string(),
+                            span: channel.span,
+                        }
+                        .into());
+                    };
+                    let elem_ty = Self::channel_elem_ty(&udt).ok_or_else(|| {
+                        SemanticError::SelectCaseRequiresChannel {
+                            actual: chan_ir.ty.kind.to_string(),
+                            span: channel.span,
+                        }
+                    })?;
+
+                    // Resolve `Option<T>` by asking the channel UDT for its
+                    // `recv` method: its return type is `Option<T>` already.
+                    let dummy_call = self.build_channel_method_call_expr(
+                        chan_ir.clone(),
+                        &udt,
+                        Symbol::from("recv".to_owned()),
+                        &[],
+                        arm.span,
+                    )?;
+                    let option_ty = dummy_call.ty.clone();
+
+                    // Resolve the Option enum (may be a Placeholder UDT at
+                    // this point) so codegen does not have to chase symbol
+                    // tables to find the variants.
+                    let option_enum_info = {
+                        let inner = match option_ty.kind.as_ref() {
+                            ir_type::TyKind::Reference(rty) => rty.refee_ty.clone(),
+                            _ => option_ty.clone(),
+                        };
+                        let opt_udt = match inner.kind.as_ref() {
+                            ir_type::TyKind::UserDefined(u) => Some(u.clone()),
+                            _ => None,
+                        };
+                        opt_udt.and_then(|u| match &u.kind {
+                            ir_type::UserDefinedTypeKind::Enum(e) => Some(e.clone()),
+                            ir_type::UserDefinedTypeKind::Placeholder(qsym) => self
+                                .lookup_qualified_symbol(qsym.clone())
+                                .and_then(|v| match &v.borrow().kind {
+                                    SymbolTableValueKind::Enum(e) => Some(e.clone()),
+                                    _ => None,
+                                }),
+                            _ => None,
+                        })
+                    };
+
+                    self.push_scope(SymbolTable::new());
+                    let bound_symbol = match binding {
+                        ast::expr::SelectBinding::Named(ident) => {
+                            let sym = ident.symbol();
+                            self.insert_symbol_to_current_scope(
+                                sym,
+                                SymbolTableValue::new(
+                                    SymbolTableValueKind::Variable(VariableInfo {
+                                        ty: option_ty.clone(),
+                                    }),
+                                    self.current_module_path().clone(),
+                                ),
+                                ident.span(),
+                            )?;
+                            Some(sym)
+                        }
+                        ast::expr::SelectBinding::Wildcard => None,
+                    };
+                    let body = self.analyze_expr(arm.body.as_ref())?;
+                    self.pop_scope();
+
+                    ir::expr::SelectArm {
+                        op: ir::expr::SelectOp::Recv,
+                        channel: Box::new(chan_ir),
+                        elem_ty,
+                        value: None,
+                        binding: bound_symbol,
+                        option_ty: Some(option_ty),
+                        option_enum_info,
+                        body: Box::new(body),
+                        span: arm.span,
+                    }
+                }
+            };
+            ir_arms.push(arm_ir);
+        }
+
+        let default_ir = match &node.default {
+            Some(body) => {
+                self.push_scope(SymbolTable::new());
+                let ir = self.analyze_expr(body.as_ref())?;
+                self.pop_scope();
+                Some(Box::new(ir))
+            }
+            None => None,
+        };
+
+        Ok(ir::expr::Expr {
+            kind: ir::expr::ExprKind::Select(ir::expr::Select {
+                arms: ir_arms,
+                default: default_ir,
+                span: node.span,
+            }),
+            ty: Rc::new(ir_type::Ty::new_unit()),
+            span: node.span,
+        })
     }
 
     fn analyze_spawn(&mut self, node: &ast::expr::Spawn) -> anyhow::Result<ir::expr::Expr> {

--- a/compiler/semantic/src/subst.rs
+++ b/compiler/semantic/src/subst.rs
@@ -264,6 +264,22 @@ impl<'a> GenericSubstituter<'a> {
                 }
                 call.method.return_ty = self.apply_ty(&call.method.return_ty);
             }
+            ir::expr::ExprKind::Select(select) => {
+                for arm in &mut select.arms {
+                    self.apply_expr(&mut arm.channel);
+                    arm.elem_ty = self.apply_ty(&arm.elem_ty);
+                    if let Some(opt_ty) = &mut arm.option_ty {
+                        *opt_ty = self.apply_ty(opt_ty);
+                    }
+                    if let Some(value) = &mut arm.value {
+                        self.apply_expr(value);
+                    }
+                    self.apply_expr(&mut arm.body);
+                }
+                if let Some(default) = &mut select.default {
+                    self.apply_expr(default);
+                }
+            }
             ir::expr::ExprKind::Int(_)
             | ir::expr::ExprKind::Float(_)
             | ir::expr::ExprKind::StringLiteral(_)

--- a/compiler/type_infer/src/lib.rs
+++ b/compiler/type_infer/src/lib.rs
@@ -510,6 +510,28 @@ impl TypeInferrer {
                 }
                 Ok(expr_ty.clone())
             }
+            Select(select) => {
+                for arm in &select.arms {
+                    self.infer_expr(&arm.channel)?;
+                    if let Some(v) = &arm.value {
+                        self.infer_expr(v)?;
+                    }
+                    self.with_new_scope(|this| {
+                        if let (Some(name), Some(opt_ty)) = (arm.binding, arm.option_ty.as_ref()) {
+                            this.register_variable(name, opt_ty.clone());
+                        }
+                        this.infer_expr(&arm.body)?;
+                        Ok(())
+                    })?;
+                }
+                if let Some(d) = &select.default {
+                    self.with_new_scope(|this| {
+                        this.infer_expr(d)?;
+                        Ok(())
+                    })?;
+                }
+                Ok(expr_ty.clone())
+            }
             Closure(closure) => {
                 for cap in &closure.captures {
                     self.infer_expr(cap)?;
@@ -2070,6 +2092,22 @@ impl TypeInferrer {
                 self.apply_expr(&mut call.receiver)?;
                 for arg in &mut call.args.0 {
                     self.apply_expr(arg)?;
+                }
+            }
+            Select(select) => {
+                for arm in &mut select.arms {
+                    self.apply_expr(&mut arm.channel)?;
+                    arm.elem_ty = self.context.apply(&arm.elem_ty);
+                    if let Some(opt_ty) = &mut arm.option_ty {
+                        *opt_ty = self.context.apply(opt_ty);
+                    }
+                    if let Some(value) = &mut arm.value {
+                        self.apply_expr(value)?;
+                    }
+                    self.apply_expr(&mut arm.body)?;
+                }
+                if let Some(default) = &mut select.default {
+                    self.apply_expr(default)?;
                 }
             }
         }

--- a/library/runtime/include/kaede/channel.h
+++ b/library/runtime/include/kaede/channel.h
@@ -16,7 +16,30 @@ enum KaedeChannelRecvResult {
     KAEDE_CHANNEL_RECV_CLOSED = 2,
 };
 
+enum KaedeSelectOp {
+    KAEDE_SELECT_OP_SEND = 0,
+    KAEDE_SELECT_OP_RECV = 1,
+};
+
+enum KaedeSelectStatus {
+    KAEDE_SELECT_STATUS_VALUE = 0,   // recv: value received
+    KAEDE_SELECT_STATUS_CLOSED = 1,  // recv: channel was closed
+    KAEDE_SELECT_STATUS_SENT = 2,    // send: value sent
+};
+
+// Returned by kaede_select when has_default is true and no case is ready.
+#define KAEDE_SELECT_DEFAULT_INDEX (-1)
+
 struct KaedeChannel;
+
+// Layout must match the LLVM struct emitted by codegen for select cases.
+struct KaedeSelectCase {
+    struct KaedeChannel *channel;
+    uint32_t op;        // KaedeSelectOp
+    uint32_t _pad;      // explicit padding to keep ABI deterministic
+    void *value_slot;   // send: pointer to value; recv: pointer to out slot
+    int32_t status;     // out: meaningful for the chosen case only
+};
 
 struct KaedeChannel *kaede_channel_new(size_t elem_size, size_t capacity);
 int32_t kaede_channel_send(struct KaedeChannel *channel, void *value);
@@ -25,5 +48,7 @@ int32_t kaede_channel_recv(struct KaedeChannel *channel, void *out);
 int32_t kaede_channel_try_recv(struct KaedeChannel *channel, void *out);
 void kaede_channel_close(struct KaedeChannel *channel);
 bool kaede_channel_is_closed(struct KaedeChannel *channel);
+
+int32_t kaede_select(struct KaedeSelectCase *cases, size_t n, bool has_default);
 
 #endif // KAEDE_CHANNEL_H

--- a/library/runtime/include/kaede/task.h
+++ b/library/runtime/include/kaede/task.h
@@ -51,20 +51,13 @@ struct TaskIoWaitState {
     uint32_t events;
     bool wake_success;
 };
-enum KaedeTaskWaitKind {
-    KAEDE_TASK_WAIT_NONE = 0,
-    KAEDE_TASK_WAIT_CHANNEL_SEND = 1u << 0,
-    KAEDE_TASK_WAIT_CHANNEL_RECV = 1u << 1,
-};
-
 struct Task;
 
+// Set by the waker (channel runtime) before a parked task is re-enqueued.
+// `true` means the wait completed normally and the waiter (channel-side) has
+// populated its result fields; `false` signals shutdown or a closed channel.
 struct TaskChannelWaitState {
-    void *obj;
-    uint32_t kind;
-    void *value_slot;
     bool wake_success;
-    struct Task *next;
 };
 struct Task {
     struct Context context;

--- a/library/runtime/include/kaede/worker.h
+++ b/library/runtime/include/kaede/worker.h
@@ -34,8 +34,7 @@ void worker_scheduler_lock(void);
 void worker_scheduler_unlock(void);
 bool worker_shutdown_requested_locked(void);
 struct Task *worker_current_task(void);
-bool worker_park_current_on_channel_locked(void *obj, uint32_t wait_kind,
-                                           void *value_slot);
+bool worker_park_current_on_channel_locked(void);
 bool worker_wake_task_locked(struct Task *task, bool success);
 void worker_yield(void);
 void worker_reset_main_state(void);

--- a/library/runtime/src/channel.c
+++ b/library/runtime/src/channel.c
@@ -7,9 +7,34 @@
 #include <stdlib.h>
 #include <string.h>
 
+// -----------------------------------------------------------------------------
+// Generic channel waiter (regular send/recv and select cases share one queue).
+// -----------------------------------------------------------------------------
+
+enum ChannelWaiterKind {
+    CW_REGULAR = 0,
+    CW_SELECT = 1,
+};
+
+struct KaedeSelectState;
+struct KaedeChannel;
+
+struct ChannelWaiter {
+    int kind;                      // ChannelWaiterKind
+    int op;                        // KaedeSelectOp (SEND/RECV)
+    struct ChannelWaiter *prev;
+    struct ChannelWaiter *next;
+    struct KaedeChannel *channel;  // queue this waiter is parked on (or NULL once removed)
+    struct Task *task;             // task to wake; for select, == state->task
+    void *value_slot;              // send: source; recv: destination
+    int32_t recv_status;           // for regular recv: VALUE/CLOSED
+    struct KaedeSelectState *state;  // NULL for regular waiters
+    uint32_t case_index;             // for select waiters
+};
+
 struct TaskWaitQueue {
-    struct Task *head;
-    struct Task *tail;
+    struct ChannelWaiter *head;
+    struct ChannelWaiter *tail;
 };
 
 struct KaedeChannel {
@@ -24,29 +49,64 @@ struct KaedeChannel {
     struct TaskWaitQueue recv_waiters;
 };
 
-static void wait_queue_push(struct TaskWaitQueue *queue, struct Task *task) {
-    task->channel_wait.next = NULL;
-    if (queue->tail) {
-        queue->tail->channel_wait.next = task;
+struct KaedeSelectState {
+    bool done;
+    int32_t chosen_index;
+    int32_t chosen_status;
+    struct Task *task;
+};
+
+static void wait_queue_push_tail(struct TaskWaitQueue *q,
+                                 struct ChannelWaiter *w,
+                                 struct KaedeChannel *channel) {
+    w->prev = q->tail;
+    w->next = NULL;
+    w->channel = channel;
+    if (q->tail) {
+        q->tail->next = w;
     } else {
-        queue->head = task;
+        q->head = w;
     }
-    queue->tail = task;
+    q->tail = w;
 }
 
-static struct Task *wait_queue_pop(struct TaskWaitQueue *queue) {
-    struct Task *task = queue->head;
-    if (!task) {
+static struct ChannelWaiter *wait_queue_pop_head(struct TaskWaitQueue *q) {
+    struct ChannelWaiter *w = q->head;
+    if (!w) {
         return NULL;
     }
-
-    queue->head = task->channel_wait.next;
-    if (!queue->head) {
-        queue->tail = NULL;
+    q->head = w->next;
+    if (q->head) {
+        q->head->prev = NULL;
+    } else {
+        q->tail = NULL;
     }
-    task->channel_wait.next = NULL;
-    return task;
+    w->prev = NULL;
+    w->next = NULL;
+    w->channel = NULL;
+    return w;
 }
+
+static void wait_queue_unlink(struct TaskWaitQueue *q,
+                              struct ChannelWaiter *w) {
+    if (w->prev) {
+        w->prev->next = w->next;
+    } else if (q->head == w) {
+        q->head = w->next;
+    }
+    if (w->next) {
+        w->next->prev = w->prev;
+    } else if (q->tail == w) {
+        q->tail = w->prev;
+    }
+    w->prev = NULL;
+    w->next = NULL;
+    w->channel = NULL;
+}
+
+// -----------------------------------------------------------------------------
+// Buffer helpers
+// -----------------------------------------------------------------------------
 
 static uint8_t *buffer_slot(struct KaedeChannel *channel, size_t index) {
     if (!channel->buffer || channel->elem_size == 0) {
@@ -74,31 +134,90 @@ static void buffer_pop(struct KaedeChannel *channel, void *out) {
     channel->len--;
 }
 
+// -----------------------------------------------------------------------------
+// Wake helpers: pop one waiter and complete it. For select waiters that have
+// already been claimed by another case, skip and continue popping.
+// -----------------------------------------------------------------------------
+
+// Pop the next waiter still eligible for waking (regular, or select whose
+// shared state isn't `done`). Returns NULL if the queue is exhausted.
+static struct ChannelWaiter *pop_live_waiter(struct TaskWaitQueue *queue) {
+    for (;;) {
+        struct ChannelWaiter *w = wait_queue_pop_head(queue);
+        if (!w) {
+            return NULL;
+        }
+        if (w->kind == CW_SELECT && w->state && w->state->done) {
+            // Already fired via another case; drop and continue.
+            continue;
+        }
+        return w;
+    }
+}
+
+// Wake `waiter` after copying `value` (of `elem_size` bytes) into its slot.
+// For select waiters, also marks the shared state as done with VALUE status.
+static void complete_recv_waiter_with_value(struct ChannelWaiter *waiter,
+                                            const void *value,
+                                            size_t elem_size) {
+    copy_value(waiter->value_slot, value, elem_size);
+    if (waiter->kind == CW_SELECT) {
+        waiter->state->done = true;
+        waiter->state->chosen_index = (int32_t)waiter->case_index;
+        waiter->state->chosen_status = KAEDE_SELECT_STATUS_VALUE;
+    } else {
+        waiter->recv_status = KAEDE_SELECT_STATUS_VALUE;
+    }
+    if (!worker_wake_task_locked(waiter->task, true)) {
+        abort();
+    }
+}
+
+// Wake a parked sender by copying its value into `out` and marking it sent.
+static void complete_send_waiter_into(struct ChannelWaiter *waiter, void *out,
+                                      size_t elem_size) {
+    copy_value(out, waiter->value_slot, elem_size);
+    if (waiter->kind == CW_SELECT) {
+        waiter->state->done = true;
+        waiter->state->chosen_index = (int32_t)waiter->case_index;
+        waiter->state->chosen_status = KAEDE_SELECT_STATUS_SENT;
+    }
+    if (!worker_wake_task_locked(waiter->task, true)) {
+        abort();
+    }
+}
+
+// Wake a parked sender by transferring its value into the channel buffer.
+static void complete_send_waiter_into_buffer(struct ChannelWaiter *waiter,
+                                             struct KaedeChannel *channel) {
+    buffer_push(channel, waiter->value_slot);
+    if (waiter->kind == CW_SELECT) {
+        waiter->state->done = true;
+        waiter->state->chosen_index = (int32_t)waiter->case_index;
+        waiter->state->chosen_status = KAEDE_SELECT_STATUS_SENT;
+    }
+    if (!worker_wake_task_locked(waiter->task, true)) {
+        abort();
+    }
+}
+
 static bool wake_waiting_receiver_locked(struct KaedeChannel *channel,
                                          const void *value) {
-    struct Task *receiver = wait_queue_pop(&channel->recv_waiters);
+    struct ChannelWaiter *receiver = pop_live_waiter(&channel->recv_waiters);
     if (!receiver) {
         return false;
     }
-
-    copy_value(receiver->channel_wait.value_slot, value, channel->elem_size);
-    if (!worker_wake_task_locked(receiver, true)) {
-        abort();
-    }
+    complete_recv_waiter_with_value(receiver, value, channel->elem_size);
     return true;
 }
 
 static bool wake_waiting_sender_direct_locked(struct KaedeChannel *channel,
                                               void *out) {
-    struct Task *sender = wait_queue_pop(&channel->send_waiters);
+    struct ChannelWaiter *sender = pop_live_waiter(&channel->send_waiters);
     if (!sender) {
         return false;
     }
-
-    copy_value(out, sender->channel_wait.value_slot, channel->elem_size);
-    if (!worker_wake_task_locked(sender, true)) {
-        abort();
-    }
+    complete_send_waiter_into(sender, out, channel->elem_size);
     return true;
 }
 
@@ -106,18 +225,17 @@ static bool buffer_one_waiting_sender_locked(struct KaedeChannel *channel) {
     if (channel->capacity == 0 || channel->len >= channel->capacity) {
         return false;
     }
-
-    struct Task *sender = wait_queue_pop(&channel->send_waiters);
+    struct ChannelWaiter *sender = pop_live_waiter(&channel->send_waiters);
     if (!sender) {
         return false;
     }
-
-    buffer_push(channel, sender->channel_wait.value_slot);
-    if (!worker_wake_task_locked(sender, true)) {
-        abort();
-    }
+    complete_send_waiter_into_buffer(sender, channel);
     return true;
 }
+
+// -----------------------------------------------------------------------------
+// Non-blocking attempt primitives (used by both regular ops and select Phase A)
+// -----------------------------------------------------------------------------
 
 static int32_t try_send_locked(struct KaedeChannel *channel, void *value) {
     if (channel->closed || worker_shutdown_requested_locked()) {
@@ -133,7 +251,7 @@ static int32_t try_send_locked(struct KaedeChannel *channel, void *value) {
         return KAEDE_CHANNEL_SEND_OK;
     }
 
-    return KAEDE_CHANNEL_SEND_CLOSED + 1;
+    return KAEDE_CHANNEL_SEND_CLOSED + 1; // sentinel: would block
 }
 
 static int32_t try_recv_locked(struct KaedeChannel *channel, void *out) {
@@ -155,6 +273,10 @@ static int32_t try_recv_locked(struct KaedeChannel *channel, void *out) {
 
     return KAEDE_CHANNEL_RECV_EMPTY;
 }
+
+// -----------------------------------------------------------------------------
+// Channel allocation and core API
+// -----------------------------------------------------------------------------
 
 struct KaedeChannel *kaede_channel_new(size_t elem_size, size_t capacity) {
     struct KaedeChannel *channel = GC_malloc(sizeof(struct KaedeChannel));
@@ -214,9 +336,20 @@ int32_t kaede_channel_send(struct KaedeChannel *channel, void *value) {
         return KAEDE_CHANNEL_SEND_CLOSED;
     }
 
-    wait_queue_push(&channel->send_waiters, task);
-    if (!worker_park_current_on_channel_locked(
-            channel, KAEDE_TASK_WAIT_CHANNEL_SEND, value)) {
+    struct ChannelWaiter waiter = {0};
+    waiter.kind = CW_REGULAR;
+    waiter.op = KAEDE_SELECT_OP_SEND;
+    waiter.task = task;
+    waiter.value_slot = value;
+    wait_queue_push_tail(&channel->send_waiters, &waiter, channel);
+
+    if (!worker_park_current_on_channel_locked()) {
+        // park failed (shutdown): waiter may still be linked
+        worker_scheduler_lock();
+        if (waiter.channel) {
+            wait_queue_unlink(&channel->send_waiters, &waiter);
+        }
+        worker_scheduler_unlock();
         return KAEDE_CHANNEL_SEND_CLOSED;
     }
 
@@ -253,9 +386,20 @@ int32_t kaede_channel_recv(struct KaedeChannel *channel, void *out) {
         return KAEDE_CHANNEL_RECV_EMPTY;
     }
 
-    wait_queue_push(&channel->recv_waiters, task);
-    if (!worker_park_current_on_channel_locked(
-            channel, KAEDE_TASK_WAIT_CHANNEL_RECV, out)) {
+    struct ChannelWaiter waiter = {0};
+    waiter.kind = CW_REGULAR;
+    waiter.op = KAEDE_SELECT_OP_RECV;
+    waiter.task = task;
+    waiter.value_slot = out;
+    waiter.recv_status = KAEDE_CHANNEL_RECV_CLOSED;
+    wait_queue_push_tail(&channel->recv_waiters, &waiter, channel);
+
+    if (!worker_park_current_on_channel_locked()) {
+        worker_scheduler_lock();
+        if (waiter.channel) {
+            wait_queue_unlink(&channel->recv_waiters, &waiter);
+        }
+        worker_scheduler_unlock();
         return KAEDE_CHANNEL_RECV_CLOSED;
     }
 
@@ -287,15 +431,41 @@ void kaede_channel_close(struct KaedeChannel *channel) {
 
     channel->closed = true;
 
-    struct Task *task = NULL;
-    while ((task = wait_queue_pop(&channel->send_waiters)) != NULL) {
-        if (!worker_wake_task_locked(task, false)) {
-            abort();
+    // Wake all parked senders as failed (closed).
+    struct ChannelWaiter *w = NULL;
+    while ((w = wait_queue_pop_head(&channel->send_waiters)) != NULL) {
+        if (w->kind == CW_SELECT) {
+            if (w->state && !w->state->done) {
+                w->state->done = true;
+                w->state->chosen_index = (int32_t)w->case_index;
+                w->state->chosen_status = KAEDE_SELECT_STATUS_CLOSED;
+                if (!worker_wake_task_locked(w->task, true)) {
+                    abort();
+                }
+            }
+            // already-done select waiters: nothing to do.
+        } else {
+            if (!worker_wake_task_locked(w->task, false)) {
+                abort();
+            }
         }
     }
-    while ((task = wait_queue_pop(&channel->recv_waiters)) != NULL) {
-        if (!worker_wake_task_locked(task, false)) {
-            abort();
+    // Wake all parked receivers; for select recv cases this fires the case
+    // with CLOSED status. For regular recv it triggers RECV_CLOSED return.
+    while ((w = wait_queue_pop_head(&channel->recv_waiters)) != NULL) {
+        if (w->kind == CW_SELECT) {
+            if (w->state && !w->state->done) {
+                w->state->done = true;
+                w->state->chosen_index = (int32_t)w->case_index;
+                w->state->chosen_status = KAEDE_SELECT_STATUS_CLOSED;
+                if (!worker_wake_task_locked(w->task, true)) {
+                    abort();
+                }
+            }
+        } else {
+            if (!worker_wake_task_locked(w->task, false)) {
+                abort();
+            }
         }
     }
 
@@ -312,6 +482,203 @@ bool kaede_channel_is_closed(struct KaedeChannel *channel) {
     worker_scheduler_unlock();
     return closed;
 }
+
+// -----------------------------------------------------------------------------
+// select implementation
+// -----------------------------------------------------------------------------
+
+// Try to satisfy a single case immediately (must hold scheduler lock).
+// Returns true if the case fired; updates the case's `status` field on success.
+static bool try_select_case_locked(struct KaedeSelectCase *cs) {
+    struct KaedeChannel *channel = cs->channel;
+    if (!channel) {
+        return false;
+    }
+
+    if (cs->op == KAEDE_SELECT_OP_SEND) {
+        int32_t r = try_send_locked(channel, cs->value_slot);
+        if (r == KAEDE_CHANNEL_SEND_OK) {
+            cs->status = KAEDE_SELECT_STATUS_SENT;
+            return true;
+        }
+        // Closed sends in select fire with CLOSED status (so the caller can
+        // observe and panic if appropriate, mirroring Go where send on closed
+        // panics even in select).
+        if (r == KAEDE_CHANNEL_SEND_CLOSED) {
+            cs->status = KAEDE_SELECT_STATUS_CLOSED;
+            return true;
+        }
+        return false;
+    }
+
+    if (cs->op == KAEDE_SELECT_OP_RECV) {
+        int32_t r = try_recv_locked(channel, cs->value_slot);
+        if (r == KAEDE_CHANNEL_RECV_VALUE) {
+            cs->status = KAEDE_SELECT_STATUS_VALUE;
+            return true;
+        }
+        if (r == KAEDE_CHANNEL_RECV_CLOSED) {
+            cs->status = KAEDE_SELECT_STATUS_CLOSED;
+            return true;
+        }
+        return false;
+    }
+
+    return false;
+}
+
+// Fisher-Yates shuffle on an index array using rand(). The runtime does not
+// seed rand() explicitly; tests that depend on randomness call srand().
+static void shuffle_indices(uint32_t *idx, size_t n) {
+    for (size_t i = n; i > 1; --i) {
+        size_t j = (size_t)((unsigned)rand() % (unsigned)i);
+        uint32_t tmp = idx[i - 1];
+        idx[i - 1] = idx[j];
+        idx[j] = tmp;
+    }
+}
+
+int32_t kaede_select(struct KaedeSelectCase *cases, size_t n, bool has_default) {
+    if (n == 0) {
+        // Empty select: no cases. With default, return default; without it,
+        // there is nothing to wait on — this is treated like Go's `select {}`
+        // (blocks forever). Approximate by parking, which the parser should
+        // make unreachable.
+        if (has_default) {
+            return KAEDE_SELECT_DEFAULT_INDEX;
+        }
+        worker_scheduler_lock();
+        (void)worker_park_current_on_channel_locked();
+        return KAEDE_SELECT_DEFAULT_INDEX;
+    }
+
+    // Stack-allocated shuffled index order for fairness.
+    uint32_t order_buf[32];
+    uint32_t *order = order_buf;
+    uint32_t *order_heap = NULL;
+    if (n > sizeof(order_buf) / sizeof(order_buf[0])) {
+        order_heap = malloc(n * sizeof(uint32_t));
+        if (!order_heap) {
+            return KAEDE_SELECT_DEFAULT_INDEX;
+        }
+        order = order_heap;
+    }
+    for (size_t i = 0; i < n; ++i) {
+        order[i] = (uint32_t)i;
+    }
+    shuffle_indices(order, n);
+
+    worker_scheduler_lock();
+
+    // Phase A: try every case once in randomized order.
+    for (size_t i = 0; i < n; ++i) {
+        struct KaedeSelectCase *cs = &cases[order[i]];
+        if (try_select_case_locked(cs)) {
+            int32_t chosen = (int32_t)order[i];
+            worker_scheduler_unlock();
+            free(order_heap);
+            return chosen;
+        }
+    }
+
+    if (has_default) {
+        worker_scheduler_unlock();
+        free(order_heap);
+        return KAEDE_SELECT_DEFAULT_INDEX;
+    }
+
+    // Phase B: nothing was ready and no default — register waiters and park.
+    struct Task *task = worker_current_task();
+    if (!task) {
+        worker_scheduler_unlock();
+        free(order_heap);
+        return KAEDE_SELECT_DEFAULT_INDEX;
+    }
+
+    struct KaedeSelectState state = {0};
+    state.done = false;
+    state.chosen_index = -1;
+    state.chosen_status = 0;
+    state.task = task;
+
+    struct ChannelWaiter waiters_buf[32];
+    struct ChannelWaiter *waiters = waiters_buf;
+    struct ChannelWaiter *waiters_heap = NULL;
+    if (n > sizeof(waiters_buf) / sizeof(waiters_buf[0])) {
+        waiters_heap = calloc(n, sizeof(struct ChannelWaiter));
+        if (!waiters_heap) {
+            worker_scheduler_unlock();
+            free(order_heap);
+            return KAEDE_SELECT_DEFAULT_INDEX;
+        }
+        waiters = waiters_heap;
+    } else {
+        memset(waiters_buf, 0, sizeof(waiters_buf));
+    }
+
+    for (size_t i = 0; i < n; ++i) {
+        struct ChannelWaiter *w = &waiters[i];
+        w->kind = CW_SELECT;
+        w->op = (int)cases[i].op;
+        w->task = task;
+        w->value_slot = cases[i].value_slot;
+        w->state = &state;
+        w->case_index = (uint32_t)i;
+        struct KaedeChannel *ch = cases[i].channel;
+        if (!ch) {
+            continue;
+        }
+        struct TaskWaitQueue *q = (cases[i].op == KAEDE_SELECT_OP_SEND)
+                                      ? &ch->send_waiters
+                                      : &ch->recv_waiters;
+        wait_queue_push_tail(q, w, ch);
+    }
+
+    if (!worker_park_current_on_channel_locked()) {
+        // Park failed (shutdown). Re-acquire lock to scrub residual waiters.
+        worker_scheduler_lock();
+        for (size_t i = 0; i < n; ++i) {
+            struct ChannelWaiter *w = &waiters[i];
+            if (w->channel) {
+                struct TaskWaitQueue *q = (w->op == KAEDE_SELECT_OP_SEND)
+                                              ? &w->channel->send_waiters
+                                              : &w->channel->recv_waiters;
+                wait_queue_unlink(q, w);
+            }
+        }
+        worker_scheduler_unlock();
+        free(waiters_heap);
+        free(order_heap);
+        return KAEDE_SELECT_DEFAULT_INDEX;
+    }
+
+    // We woke; re-acquire scheduler lock to remove any leftover waiters that
+    // were not the firing case.
+    worker_scheduler_lock();
+    for (size_t i = 0; i < n; ++i) {
+        struct ChannelWaiter *w = &waiters[i];
+        if (w->channel) {
+            struct TaskWaitQueue *q = (w->op == KAEDE_SELECT_OP_SEND)
+                                          ? &w->channel->send_waiters
+                                          : &w->channel->recv_waiters;
+            wait_queue_unlink(q, w);
+        }
+    }
+    worker_scheduler_unlock();
+
+    int32_t chosen = state.chosen_index;
+    if (chosen >= 0 && (size_t)chosen < n) {
+        cases[chosen].status = state.chosen_status;
+    }
+
+    free(waiters_heap);
+    free(order_heap);
+    return chosen;
+}
+
+// -----------------------------------------------------------------------------
+// void* shims for Kaede FFI
+// -----------------------------------------------------------------------------
 
 void *kaede_chan_new(size_t elem_size, size_t capacity) {
     return kaede_channel_new(elem_size, capacity);

--- a/library/runtime/src/channel.c
+++ b/library/runtime/src/channel.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 // -----------------------------------------------------------------------------
 // Generic channel waiter (regular send/recv and select cases share one queue).
@@ -155,46 +156,18 @@ static struct ChannelWaiter *pop_live_waiter(struct TaskWaitQueue *queue) {
     }
 }
 
-// Wake `waiter` after copying `value` (of `elem_size` bytes) into its slot.
-// For select waiters, also marks the shared state as done with VALUE status.
-static void complete_recv_waiter_with_value(struct ChannelWaiter *waiter,
-                                            const void *value,
-                                            size_t elem_size) {
-    copy_value(waiter->value_slot, value, elem_size);
+// Mark `waiter` as completed with the given status and wake its task. For
+// select waiters this also records the chosen-case bookkeeping; for regular
+// recv waiters it stores the status onto the waiter for the parked recv() to
+// observe after wakeup. Callers are responsible for any value transfer that
+// must happen before the task can read its slot.
+static void complete_waiter(struct ChannelWaiter *waiter, int32_t status) {
     if (waiter->kind == CW_SELECT) {
         waiter->state->done = true;
         waiter->state->chosen_index = (int32_t)waiter->case_index;
-        waiter->state->chosen_status = KAEDE_SELECT_STATUS_VALUE;
+        waiter->state->chosen_status = status;
     } else {
-        waiter->recv_status = KAEDE_SELECT_STATUS_VALUE;
-    }
-    if (!worker_wake_task_locked(waiter->task, true)) {
-        abort();
-    }
-}
-
-// Wake a parked sender by copying its value into `out` and marking it sent.
-static void complete_send_waiter_into(struct ChannelWaiter *waiter, void *out,
-                                      size_t elem_size) {
-    copy_value(out, waiter->value_slot, elem_size);
-    if (waiter->kind == CW_SELECT) {
-        waiter->state->done = true;
-        waiter->state->chosen_index = (int32_t)waiter->case_index;
-        waiter->state->chosen_status = KAEDE_SELECT_STATUS_SENT;
-    }
-    if (!worker_wake_task_locked(waiter->task, true)) {
-        abort();
-    }
-}
-
-// Wake a parked sender by transferring its value into the channel buffer.
-static void complete_send_waiter_into_buffer(struct ChannelWaiter *waiter,
-                                             struct KaedeChannel *channel) {
-    buffer_push(channel, waiter->value_slot);
-    if (waiter->kind == CW_SELECT) {
-        waiter->state->done = true;
-        waiter->state->chosen_index = (int32_t)waiter->case_index;
-        waiter->state->chosen_status = KAEDE_SELECT_STATUS_SENT;
+        waiter->recv_status = status;
     }
     if (!worker_wake_task_locked(waiter->task, true)) {
         abort();
@@ -207,7 +180,8 @@ static bool wake_waiting_receiver_locked(struct KaedeChannel *channel,
     if (!receiver) {
         return false;
     }
-    complete_recv_waiter_with_value(receiver, value, channel->elem_size);
+    copy_value(receiver->value_slot, value, channel->elem_size);
+    complete_waiter(receiver, KAEDE_SELECT_STATUS_VALUE);
     return true;
 }
 
@@ -217,7 +191,8 @@ static bool wake_waiting_sender_direct_locked(struct KaedeChannel *channel,
     if (!sender) {
         return false;
     }
-    complete_send_waiter_into(sender, out, channel->elem_size);
+    copy_value(out, sender->value_slot, channel->elem_size);
+    complete_waiter(sender, KAEDE_SELECT_STATUS_SENT);
     return true;
 }
 
@@ -229,13 +204,34 @@ static bool buffer_one_waiting_sender_locked(struct KaedeChannel *channel) {
     if (!sender) {
         return false;
     }
-    complete_send_waiter_into_buffer(sender, channel);
+    buffer_push(channel, sender->value_slot);
+    complete_waiter(sender, KAEDE_SELECT_STATUS_SENT);
     return true;
+}
+
+// Drain `queue`, completing select waiters with CLOSED and waking regular
+// waiters with `wake_success=false`. Used by kaede_channel_close on both the
+// send and recv queues.
+static void wake_all_as_closed_locked(struct TaskWaitQueue *queue) {
+    struct ChannelWaiter *w;
+    while ((w = wait_queue_pop_head(queue)) != NULL) {
+        if (w->kind == CW_SELECT) {
+            if (w->state && !w->state->done) {
+                complete_waiter(w, KAEDE_SELECT_STATUS_CLOSED);
+            }
+        } else if (!worker_wake_task_locked(w->task, false)) {
+            abort();
+        }
+    }
 }
 
 // -----------------------------------------------------------------------------
 // Non-blocking attempt primitives (used by both regular ops and select Phase A)
 // -----------------------------------------------------------------------------
+
+// Internal sentinel used only by try_send_locked, distinct from the public
+// KaedeChannelSendResult values. Callers translate it to a parking decision.
+#define TRY_SEND_WOULD_BLOCK 2
 
 static int32_t try_send_locked(struct KaedeChannel *channel, void *value) {
     if (channel->closed || worker_shutdown_requested_locked()) {
@@ -251,7 +247,7 @@ static int32_t try_send_locked(struct KaedeChannel *channel, void *value) {
         return KAEDE_CHANNEL_SEND_OK;
     }
 
-    return KAEDE_CHANNEL_SEND_CLOSED + 1; // sentinel: would block
+    return TRY_SEND_WOULD_BLOCK;
 }
 
 static int32_t try_recv_locked(struct KaedeChannel *channel, void *out) {
@@ -325,7 +321,7 @@ int32_t kaede_channel_send(struct KaedeChannel *channel, void *value) {
         return result;
     }
 
-    if (result != KAEDE_CHANNEL_SEND_CLOSED + 1) {
+    if (result != TRY_SEND_WOULD_BLOCK) {
         worker_scheduler_unlock();
         return KAEDE_CHANNEL_SEND_CLOSED;
     }
@@ -430,45 +426,8 @@ void kaede_channel_close(struct KaedeChannel *channel) {
     }
 
     channel->closed = true;
-
-    // Wake all parked senders as failed (closed).
-    struct ChannelWaiter *w = NULL;
-    while ((w = wait_queue_pop_head(&channel->send_waiters)) != NULL) {
-        if (w->kind == CW_SELECT) {
-            if (w->state && !w->state->done) {
-                w->state->done = true;
-                w->state->chosen_index = (int32_t)w->case_index;
-                w->state->chosen_status = KAEDE_SELECT_STATUS_CLOSED;
-                if (!worker_wake_task_locked(w->task, true)) {
-                    abort();
-                }
-            }
-            // already-done select waiters: nothing to do.
-        } else {
-            if (!worker_wake_task_locked(w->task, false)) {
-                abort();
-            }
-        }
-    }
-    // Wake all parked receivers; for select recv cases this fires the case
-    // with CLOSED status. For regular recv it triggers RECV_CLOSED return.
-    while ((w = wait_queue_pop_head(&channel->recv_waiters)) != NULL) {
-        if (w->kind == CW_SELECT) {
-            if (w->state && !w->state->done) {
-                w->state->done = true;
-                w->state->chosen_index = (int32_t)w->case_index;
-                w->state->chosen_status = KAEDE_SELECT_STATUS_CLOSED;
-                if (!worker_wake_task_locked(w->task, true)) {
-                    abort();
-                }
-            }
-        } else {
-            if (!worker_wake_task_locked(w->task, false)) {
-                abort();
-            }
-        }
-    }
-
+    wake_all_as_closed_locked(&channel->send_waiters);
+    wake_all_as_closed_locked(&channel->recv_waiters);
     worker_scheduler_unlock();
 }
 
@@ -527,11 +486,47 @@ static bool try_select_case_locked(struct KaedeSelectCase *cs) {
     return false;
 }
 
-// Fisher-Yates shuffle on an index array using rand(). The runtime does not
-// seed rand() explicitly; tests that depend on randomness call srand().
+// Fisher-Yates shuffle on an index array using a per-thread xorshift PRNG.
+// kaede_select runs concurrently on every worker; using libc rand() would
+// race on its internal state. The seed is lazily initialized from the task
+// pointer and the wall clock so distinct workers diverge quickly.
+static _Thread_local uint64_t select_rng_state = 0;
+
+static uint64_t select_rng_next(void) {
+    if (select_rng_state == 0) {
+        select_rng_state = (uint64_t)(uintptr_t)worker_current_task()
+                           ^ ((uint64_t)time(NULL) * 0x9E3779B97F4A7C15ULL);
+        if (select_rng_state == 0) {
+            select_rng_state = 0x9E3779B97F4A7C15ULL;
+        }
+    }
+    uint64_t x = select_rng_state;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    select_rng_state = x;
+    return x;
+}
+
+// Remove every select waiter still linked into a channel's queue. Used both
+// on park failure (none have fired) and after wakeup (one fired and was
+// already unlinked by the waker; we drop the rest).
+static void scrub_select_waiters(struct ChannelWaiter *waiters, size_t n) {
+    for (size_t i = 0; i < n; ++i) {
+        struct ChannelWaiter *w = &waiters[i];
+        if (!w->channel) {
+            continue;
+        }
+        struct TaskWaitQueue *q = (w->op == KAEDE_SELECT_OP_SEND)
+                                      ? &w->channel->send_waiters
+                                      : &w->channel->recv_waiters;
+        wait_queue_unlink(q, w);
+    }
+}
+
 static void shuffle_indices(uint32_t *idx, size_t n) {
     for (size_t i = n; i > 1; --i) {
-        size_t j = (size_t)((unsigned)rand() % (unsigned)i);
+        size_t j = (size_t)(select_rng_next() % (uint64_t)i);
         uint32_t tmp = idx[i - 1];
         idx[i - 1] = idx[j];
         idx[j] = tmp;
@@ -637,33 +632,16 @@ int32_t kaede_select(struct KaedeSelectCase *cases, size_t n, bool has_default) 
     if (!worker_park_current_on_channel_locked()) {
         // Park failed (shutdown). Re-acquire lock to scrub residual waiters.
         worker_scheduler_lock();
-        for (size_t i = 0; i < n; ++i) {
-            struct ChannelWaiter *w = &waiters[i];
-            if (w->channel) {
-                struct TaskWaitQueue *q = (w->op == KAEDE_SELECT_OP_SEND)
-                                              ? &w->channel->send_waiters
-                                              : &w->channel->recv_waiters;
-                wait_queue_unlink(q, w);
-            }
-        }
+        scrub_select_waiters(waiters, n);
         worker_scheduler_unlock();
         free(waiters_heap);
         free(order_heap);
         return KAEDE_SELECT_DEFAULT_INDEX;
     }
 
-    // We woke; re-acquire scheduler lock to remove any leftover waiters that
-    // were not the firing case.
+    // We woke; remove any leftover waiters that were not the firing case.
     worker_scheduler_lock();
-    for (size_t i = 0; i < n; ++i) {
-        struct ChannelWaiter *w = &waiters[i];
-        if (w->channel) {
-            struct TaskWaitQueue *q = (w->op == KAEDE_SELECT_OP_SEND)
-                                          ? &w->channel->send_waiters
-                                          : &w->channel->recv_waiters;
-            wait_queue_unlink(q, w);
-        }
-    }
+    scrub_select_waiters(waiters, n);
     worker_scheduler_unlock();
 
     int32_t chosen = state.chosen_index;

--- a/library/runtime/src/task.c
+++ b/library/runtime/src/task.c
@@ -224,9 +224,5 @@ void task_cleanup(struct Task *task) {
     task->io_wait.fd = -1;
     task->io_wait.events = KAEDE_IO_EVENT_NONE;
     task->io_wait.wake_success = false;
-    task->channel_wait.obj = NULL;
-    task->channel_wait.kind = KAEDE_TASK_WAIT_NONE;
-    task->channel_wait.value_slot = NULL;
     task->channel_wait.wake_success = false;
-    task->channel_wait.next = NULL;
 }

--- a/library/runtime/src/worker.c
+++ b/library/runtime/src/worker.c
@@ -221,10 +221,6 @@ static bool enqueue_runnable_task_locked(struct Task *task) {
     task->scheduler.state = TASK_RUNNABLE;
     task->io_wait.fd = -1;
     task->io_wait.events = KAEDE_IO_EVENT_NONE;
-    task->channel_wait.obj = NULL;
-    task->channel_wait.kind = KAEDE_TASK_WAIT_NONE;
-    task->channel_wait.value_slot = NULL;
-    task->channel_wait.next = NULL;
     return task_queue_push(&runnable_tasks, task);
 }
 
@@ -623,10 +619,8 @@ struct Task *worker_current_task(void) {
     return kaede_current_task;
 }
 
-bool worker_park_current_on_channel_locked(void *obj, uint32_t wait_kind,
-                                           void *value_slot) {
-    if (!kaede_current_task || wait_kind == KAEDE_TASK_WAIT_NONE ||
-        shutdown_requested) {
+bool worker_park_current_on_channel_locked(void) {
+    if (!kaede_current_task || shutdown_requested) {
         pthread_mutex_unlock(&scheduler_mutex);
         return false;
     }
@@ -637,9 +631,6 @@ bool worker_park_current_on_channel_locked(void *obj, uint32_t wait_kind,
     struct GC_stack_base *gc_stack_base = &worker.gc_stack_base;
 
     task->scheduler.state = TASK_WAITING_CHANNEL;
-    task->channel_wait.obj = obj;
-    task->channel_wait.kind = wait_kind;
-    task->channel_wait.value_slot = value_slot;
     task->channel_wait.wake_success = false;
     worker.yielded_state = TASK_WAITING_CHANNEL;
     worker.returned_with_scheduler_lock = true;
@@ -704,11 +695,7 @@ bool worker_spawn(TaskFn fn, void *arg, size_t arg_size, bool is_main) {
     task->io_wait.fd = -1;
     task->io_wait.events = KAEDE_IO_EVENT_NONE;
     task->io_wait.wake_success = false;
-    task->channel_wait.obj = NULL;
-    task->channel_wait.kind = KAEDE_TASK_WAIT_NONE;
-    task->channel_wait.value_slot = NULL;
     task->channel_wait.wake_success = false;
-    task->channel_wait.next = NULL;
     create_context(&task->context, fn, arg_on_stack, stack_top);
     task_register_stack_roots(task);
 

--- a/website/docs/language/concurrency.md
+++ b/website/docs/language/concurrency.md
@@ -54,6 +54,41 @@ value := match <-ch {
 }
 ```
 
+## Selecting across multiple channels
+
+`select` blocks the current task until one of its channel operations can
+proceed, then runs the matching arm. It mirrors Go's `select`:
+
+```rust
+select {
+    case value = ch1.recv() => {
+        // value: Option<T>; None means ch1 was closed.
+    }
+    case _ = ch3.recv() => {
+        // received value is discarded
+    }
+    case ch2.send(x) => {
+        // successfully sent x on ch2
+    }
+    default => {
+        // taken only if no other case is immediately ready
+    }
+}
+```
+
+Notes:
+
+- Each `case` must be a `ch.recv()` or `ch.send(value)` method call —
+  arbitrary expressions are rejected at parse time.
+- The bound name on a `recv` arm has type `Option<T>`. A closed channel
+  fires the arm immediately with `None`, mirroring `ch.recv()`'s contract.
+- With `default`, `select` is non-blocking. Without it, the task blocks
+  until at least one case can proceed.
+- When multiple cases are simultaneously ready, one is chosen at random to
+  avoid starvation (Go semantics).
+- Channel expressions and `send` value expressions are evaluated in source
+  order on entry, exactly once per `select` evaluation.
+
 ## Synchronization helpers
 
 Use `WaitGroup` when one task needs to wait for other spawned tasks to finish:


### PR DESCRIPTION
## Summary

- Adds a Go-style `select` expression that blocks until one of its listed
  channel operations can proceed (closes #172).
- Refactors the runtime's channel wait queues to a generic
  `ChannelWaiter` so regular send/recv and per-case select waiters share
  a single, doubly-linked structure.
- New `kaede_select` runtime ABI implements the two-phase wake-driven
  scheme: shuffled try-all under the scheduler lock, then register a
  `CW_SELECT` waiter on each case's queue and park; the first waker
  wins and the woken task unlinks the others.

### Syntax

```kaede
select {
    case value = ch1.recv() => { /* value: Option<T> */ }
    case _     = ch3.recv() => { /* discard */ }
    case         ch2.send(x) => { /* sent */ }
    default => { /* only when no case is immediately ready */ }
}
```

### Compiler pipeline

- **Lex**: `select`, `default`, `case` keywords.
- **AST / IR**: `Select` / `SelectArm` / `SelectOp` plumbed through
  type_infer, semantic `subst`, monomorphize, and codegen.
- **Parser**: cases are restricted to `IDENT|_ = ch.recv()` or
  `ch.send(value)`; empty `select {}` and arbitrary case expressions
  are rejected with a parse error.
- **Semantic**: validates `Channel<T>`, type-checks send values against
  `T`, binds the recv name to `Option<T>`, and pre-resolves the Option
  enum metadata so codegen does not need to chase Placeholder lookups.
  New error `SelectCaseRequiresChannel`.
- **Codegen**: allocates a stack array of `KaedeSelectCase` ABI structs,
  calls `kaede_select`, then `switch`es on the chosen index. For recv
  arms with a binding, materializes `Option::{Some(load slot), None}`
  based on the per-case `status` field and inserts it via `let`.

### Runtime

- `library/runtime/include/kaede/channel.h` defines `KaedeSelectCase`,
  `kaede_select`, and the status enums (`VALUE`, `CLOSED`, `SENT`).
- `library/runtime/src/channel.c` reworks the waiter queue to
  `ChannelWaiter` and adds `kaede_select` with Phase A (shuffled
  try-all) and Phase B (register + park + unlink-on-wake).
- `close()` fires any pending select recv waiters with `CLOSED` so the
  language side observes closure as `Option::None`, matching Go's
  semantics.

### Semantics chosen (per acceptance criteria and the issue thread)

- recv binding is `Option<T>` — `Some(v)` on value, `None` on close.
- Runtime is wake-driven (Go-compatible), not polling.
- Send-case value expressions are evaluated in source order on entry,
  exactly once per `select` evaluation, matching Go.
- When multiple cases are simultaneously ready, one is chosen via
  Fisher-Yates shuffle + first-success-wins to avoid starvation.

## Test plan

- [x] `cargo test --release -p kaede_parse --test select_syntax` —
  7 parser tests (binding, wildcard, send, default, mixed, rejection of
  empty and non-method cases).
- [x] `cargo test --release -p kaede_compiler_driver --test runtime_select` —
  6 end-to-end tests: single-case recv, fan-in from two producers,
  `default` immediate fallthrough, closed-channel recv → `None`,
  buffered send, and send handshake with a blocked receiver.
- [x] `cargo test --release -p kaede_compiler_driver --test runtime_channel` —
  pre-existing channel tests still pass after the waiter-queue refactor.
- [x] `cargo fmt --all -- --check` and `cargo clippy -- -D warnings`
  are clean.
- [ ] `leak` integration tests require valgrind (Linux-only per
  `AGENTS.md`) — not run in this environment.

## Docs

`website/docs/language/concurrency.md` gains a "Selecting across
multiple channels" section covering the syntax, the `Option<T>`
recv-binding semantics, default/blocking modes, fairness, and the
source-order evaluation guarantee.