### PR TITLE
feat(packaging): add Homebrew formula and release docs (#278)

### DIFF
--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,79 @@
+# Homebrew packaging
+
+This directory holds a draft Homebrew formula for kaede. The canonical copy
+once published lives in a separate tap repo:
+
+- Tap repo: `itto-hiramoto/homebrew-kaede`
+- Formula path in tap: `Formula/kaede.rb`
+
+Users install via:
+
+```sh
+brew tap itto-hiramoto/kaede
+brew install kaede
+```
+
+## Cutting a release
+
+1. Tag the release on `main`:
+
+   ```sh
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+2. Compute the source tarball sha256:
+
+   ```sh
+   curl -sL "https://github.com/itto-hiramoto/kaede/archive/refs/tags/vX.Y.Z.tar.gz" \
+     | shasum -a 256
+   ```
+
+3. Update `kaede.rb` in the tap repo:
+   - `url` → the new `vX.Y.Z` tag URL
+   - `sha256` (top-level) → the value from step 2
+
+4. If the `library/bdwgc` submodule moved since the last release, also update
+   the bdwgc resource block:
+
+   ```sh
+   git -C library/bdwgc rev-parse HEAD                          # new commit
+   curl -sL "https://github.com/ivmai/bdwgc/archive/<commit>.tar.gz" | shasum -a 256
+   ```
+
+   Replace the `resource "bdwgc"` URL commit hash and `sha256` accordingly.
+
+5. Once the tap is live, prefer `brew bump-formula-pr` to automate steps 2–3
+   from a CI workflow:
+
+   ```sh
+   brew bump-formula-pr --strict \
+     --url="https://github.com/itto-hiramoto/kaede/archive/refs/tags/vX.Y.Z.tar.gz" \
+     itto-hiramoto/kaede/kaede
+   ```
+
+## Local testing (no tap repo required)
+
+From a clone of this repo, install the formula in-place:
+
+```sh
+brew install --build-from-source ./packaging/homebrew/kaede.rb
+brew test kaede
+brew audit --new --strict ./packaging/homebrew/kaede.rb
+```
+
+To test against the live tap once published:
+
+```sh
+brew untap itto-hiramoto/kaede 2>/dev/null
+brew tap itto-hiramoto/kaede
+brew install --verbose --debug kaede
+```
+
+## Why a `resource` for bdwgc?
+
+`library/bdwgc` is a git submodule, and GitHub release tarballs from
+`archive/refs/tags/...` do **not** include submodule contents. Without the
+resource block, `install.py` fails when cmake tries to build an empty
+`library/bdwgc/` directory. The resource stages the pinned bdwgc tarball
+into the build tree before `install.py` runs.

--- a/packaging/homebrew/kaede.rb
+++ b/packaging/homebrew/kaede.rb
@@ -1,0 +1,53 @@
+class Kaede < Formula
+  desc "Statically-typed compiled language with rich types"
+  homepage "https://github.com/itto-hiramoto/kaede"
+  url "https://github.com/itto-hiramoto/kaede/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "PUT_RELEASE_TARBALL_SHA256_HERE"
+  license any_of: ["Apache-2.0", "MIT"]
+  head "https://github.com/itto-hiramoto/kaede.git", branch: "main"
+
+  depends_on "cmake"      => :build
+  depends_on "pkg-config" => :build
+  depends_on "rust"       => :build
+  depends_on "llvm@17"
+  depends_on "openssl@3"
+
+  # Mirrors the library/bdwgc submodule. Keep the commit and sha256 in sync with
+  # `git -C library/bdwgc rev-parse HEAD` on each release.
+  resource "bdwgc" do
+    url "https://github.com/ivmai/bdwgc/archive/0f54cebfdc91b192e3ad253aa9a8ed801e985bb7.tar.gz"
+    sha256 "PUT_BDWGC_TARBALL_SHA256_HERE"
+  end
+
+  def install
+    (buildpath/"library/bdwgc").install resource("bdwgc")
+
+    ENV.prepend_path "PATH",            Formula["llvm@17"].opt_bin
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@3"].opt_lib/"pkgconfig"
+    ENV["LLVM_SYS_170_PREFIX"] = Formula["llvm@17"].opt_prefix
+
+    # install.py lays out bin/, lib/, third_party/ under its --prefix; stage that
+    # under libexec so the wrapper below can point KAEDE_DIR at it.
+    system "python3", "./install.py", "--prefix=#{libexec}"
+
+    # The kaede binary reads $KAEDE_DIR to locate libkd, autoload sources, and
+    # third_party/bdwgc; if unset it falls back to a path baked in when kaede
+    # itself was built, which is meaningless on the user's machine. It also
+    # shells out to llc/opt from the keg-only llvm@17 when compiling user
+    # programs. Wrap the binary so both are wired up without user setup.
+    (bin/"kaede").write_env_script libexec/"bin/kaede",
+                                   KAEDE_DIR: libexec,
+                                   PATH:      "#{Formula["llvm@17"].opt_bin}:$PATH"
+  end
+
+  test do
+    (testpath/"hello.kd").write <<~KAEDE
+      fun main() {
+          println("hello, world!")
+      }
+    KAEDE
+    system bin/"kaede", "--version"
+    system bin/"kaede", testpath/"hello.kd", "-o", testpath/"hello"
+    assert_equal "hello, world!", shell_output(testpath/"hello").strip
+  end
+end


### PR DESCRIPTION
## Summary

- Stage a draft `kaede` Homebrew formula at `packaging/homebrew/kaede.rb`. It delegates to `./install.py --prefix=#{libexec}` (added in #274 for external packagers), bundles the pinned `library/bdwgc` submodule as a Homebrew `resource` (since GitHub release tarballs do not include submodules), and wraps the installed binary with `KAEDE_DIR` plus the `llvm@17` `PATH` so the user's `kaede` invocations resolve `llc`/`opt` at runtime.
- Add `packaging/homebrew/README.md` documenting the cut-a-release workflow (tag → compute sha256 → update tap formula, with a `brew bump-formula-pr` shortcut once the tap is live) and local-test commands (`brew install --build-from-source ./packaging/homebrew/kaede.rb`, `brew audit --new --strict`).

The in-tree copy is the source-of-truth **template**. The canonical formula will live in a separate tap repo (`itto-hiramoto/homebrew-kaede`, to be created after merge). On each release the SHA256 placeholders (`PUT_RELEASE_TARBALL_SHA256_HERE`, `PUT_BDWGC_TARBALL_SHA256_HERE`) get filled in only in the tap copy — the in-tree template stays templated.

Closes #278.

## Follow-ups (out of scope for this PR)

- Cut and push the `v0.1.0` tag so the formula's `url` resolves.
- Create the public `itto-hiramoto/homebrew-kaede` repo and push `Formula/kaede.rb` with real SHA256s.
- Optional later: release-CI workflow (`brew bump-formula-pr` on tag push).

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy -- -D warnings`
- [ ] `cargo test --release --no-fail-fast`
- [ ] On macOS, smoke-test the formula in-place once the v0.1.0 tag is cut: `brew install --build-from-source ./packaging/homebrew/kaede.rb && brew test kaede && brew audit --new --strict ./packaging/homebrew/kaede.rb`