### PR TITLE
docs: document Homebrew tap as the macOS install path (#278)

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -6,7 +6,31 @@ sidebar_position: 2
 
 # Installation
 
-## Prerequisites
+## macOS (recommended)
+
+Install via the [`itto-hiramoto/kaede`](https://github.com/itto-hiramoto/homebrew-kaede) Homebrew tap:
+
+```bash
+brew tap itto-hiramoto/kaede
+brew install kaede
+kaede -h
+```
+
+Homebrew resolves LLVM 17, OpenSSL, CMake, and the Rust toolchain on its own. The first install compiles Kaede from source, which takes a few minutes.
+
+Supported architectures: x86-64, AArch64.
+
+:::note
+Homebrew on Linux ([Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux)) also works — the same `brew install kaede` command applies.
+:::
+
+Once `kaede -h` runs, continue to [First program](./first-program.md).
+
+## Build from source
+
+Use this path if you want to hack on the compiler, need a customized build, or your platform isn't covered by the Homebrew tap.
+
+### Prerequisites
 
 - LLVM 17
 - Rust toolchain (`rustc` and `cargo`)
@@ -27,7 +51,7 @@ Supported architectures:
 - x86-64
 - AArch64
 
-## macOS / Linux (Homebrew)
+### macOS / Linux (Homebrew for dependencies)
 
 ```bash
 brew install git llvm@17 cmake python pkg-config openssl@3
@@ -49,7 +73,7 @@ cd kaede
 kaede -h
 ```
 
-## Ubuntu / Debian
+### Ubuntu / Debian
 
 ```bash
 sudo apt update

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 # Installation
 
-## macOS (recommended)
+## macOS / Linux (recommended)
 
 Install via the [`itto-hiramoto/kaede`](https://github.com/itto-hiramoto/homebrew-kaede) Homebrew tap:
 
@@ -19,10 +19,6 @@ kaede -h
 Homebrew resolves LLVM 17, OpenSSL, CMake, and the Rust toolchain on its own. The first install compiles Kaede from source, which takes a few minutes.
 
 Supported architectures: x86-64, AArch64.
-
-:::note
-Homebrew on Linux ([Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux)) also works — the same `brew install kaede` command applies.
-:::
 
 Once `kaede -h` runs, continue to [First program](./first-program.md).
 
@@ -43,35 +39,6 @@ Use this path if you want to hack on the compiler, need a customized build, or y
 Optional:
 
 - Cargo nightly, when you want Rust interop support that depends on nightly tooling
-
-Run the block for your platform.
-
-Supported architectures:
-
-- x86-64
-- AArch64
-
-### macOS / Linux (Homebrew for dependencies)
-
-```bash
-brew install git llvm@17 cmake python pkg-config openssl@3
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-. "$HOME/.cargo/env"
-
-case "$(basename "$SHELL")" in
-  zsh)  PROFILE=~/.zprofile ;;
-  *)    PROFILE=~/.profile ;;
-esac
-echo 'export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib"' >> "$PROFILE"
-. "$PROFILE"
-
-git clone --recursive https://github.com/itto-hiramoto/kaede.git
-cd kaede
-
-./install.py
-. "$HOME/.kaede/env"
-kaede -h
-```
 
 ### Ubuntu / Debian
 


### PR DESCRIPTION
## Summary

- Add a top-level "macOS (recommended)" section to `website/docs/getting-started/installation.md` that shows the new `brew tap itto-hiramoto/kaede && brew install kaede` flow.
- Reorganize the existing instructions under a "Build from source" section for Linux users and contributors who want to hack on the compiler.
- Note that Linuxbrew also works with the same one-liner.

The tap repo (`itto-hiramoto/homebrew-kaede`) and the `v0.1.0` release tag are already published, so the documented commands work today.

Refs #278.

## Test plan

- [x] Preview locally: `cd website && npm run start` → open `/docs/getting-started/installation` and verify the new section renders with the Docusaurus `:::note` admonition.
- [x] Build: `cd website && npm run build` to catch broken links / sidebar regressions.
- [x] Smoke test from a fresh macOS shell: copy the new block, run `brew tap itto-hiramoto/kaede && brew install kaede && kaede -h`.