### PR TITLE
chore(example): show args & return values in rust interop sample

### DIFF
--- a/example/rust_interop/rust/src/lib.rs
+++ b/example/rust_interop/rust/src/lib.rs
@@ -1,8 +1,6 @@
-pub fn greetings() {
-    let url = "https://www.rust-lang.org";
+pub fn greetings(url: &str) -> String {
     let rc = reqwest::blocking::get(url).unwrap();
-    let contents = rc.text().unwrap();
-    println!("{}", contents);
+    rc.text().unwrap()
 }
 
 pub fn add(a: i32, b: i32) -> i32 {

--- a/example/rust_interop/src/main.kd
+++ b/example/rust_interop/src/main.kd
@@ -1,6 +1,7 @@
 import rust::rust_interop
 
 fun main() -> i32 {
-    rust::rust_interop::greetings()
+    contents := rust::rust_interop::greetings("https://rust-lang.org/")
+    println(contents)
     return rust::rust_interop::add(10, 20)
 }


### PR DESCRIPTION
## Summary
- `greetings` now takes the URL as a `&str` argument and returns the fetched body as `String` instead of printing it internally.
- `main.kd` passes the URL across the FFI boundary, receives the body, and prints it from the Kaede side, better demonstrating value flow in both directions.

## Test plan
- [ ] `cd example/rust_interop && kaede run` fetches the page and prints the body followed by exit code 30 from `add(10, 20)`.