### PR TITLE
fix: allow multiline parser lists

### DIFF
--- a/compiler/parse/src/expr.rs
+++ b/compiler/parse/src/expr.rs
@@ -1263,7 +1263,7 @@ impl Parser {
 
             args.push_back(Arg { name, value, span });
 
-            if !self.consume_b(&TokenKind::Comma) {
+            if !self.consume_list_separator(&TokenKind::CloseParen)? {
                 break;
             }
         }

--- a/compiler/parse/src/lib.rs
+++ b/compiler/parse/src/lib.rs
@@ -175,6 +175,27 @@ impl Parser {
         false
     }
 
+    fn consume_semis(&mut self) {
+        while self.consume_b(&TokenKind::Semi) {}
+    }
+
+    /// Consume the separator after an item in a comma-separated list.
+    ///
+    /// Newlines may be inserted as `Semi` tokens before the comma or closing
+    /// delimiter. Returning `false` means the caller is positioned at `end`.
+    fn consume_list_separator(&mut self, end: &TokenKind) -> ParseResult<bool> {
+        self.consume_semis();
+
+        if self.check(end) {
+            return Ok(false);
+        }
+
+        self.consume(&TokenKind::Comma)?;
+        self.consume_semis();
+
+        Ok(!self.check(end))
+    }
+
     /// Consume a semicolon
     /// ')' or '}', then success (Following Golang's rules)
     fn consume_semi(&mut self) -> ParseResult<Span> {

--- a/compiler/parse/src/top.rs
+++ b/compiler/parse/src/top.rs
@@ -174,7 +174,7 @@ impl Parser {
             };
             params.push(GenericParam { name, bound });
 
-            if !self.consume_b(&TokenKind::Comma) {
+            if !self.consume_list_separator(&TokenKind::Gt)? {
                 break;
             }
         }
@@ -380,13 +380,13 @@ impl Parser {
             todo!("`mut is not allowed not in type");
         }
         let first_param = if has_self {
-            let _ = self.consume(&TokenKind::Comma);
+            let _ = self.consume_list_separator(&TokenKind::CloseParen)?;
             None
         } else if self.check(&TokenKind::CloseParen) {
             None
         } else {
             let param = self.fn_param()?;
-            let _ = self.consume(&TokenKind::Comma);
+            let _ = self.consume_list_separator(&TokenKind::CloseParen)?;
             Some(param)
         };
 
@@ -448,6 +448,7 @@ impl Parser {
 
         loop {
             if let Some(variadic) = self.vararg() {
+                let _ = self.consume_list_separator(&TokenKind::CloseParen)?;
                 let finish = self.consume(&TokenKind::CloseParen)?.finish;
                 break Ok(Params {
                     v: params,
@@ -458,7 +459,7 @@ impl Parser {
 
             params.push_back(self.fn_param()?);
 
-            if !self.consume_b(&TokenKind::Comma) {
+            if !self.consume_list_separator(&TokenKind::CloseParen)? {
                 let finish = self.consume(&TokenKind::CloseParen)?.finish;
                 break Ok(Params {
                     v: params,
@@ -701,13 +702,13 @@ impl Parser {
         }
 
         let first_param = if has_self {
-            let _ = self.consume(&TokenKind::Comma);
+            let _ = self.consume_list_separator(&TokenKind::CloseParen)?;
             None
         } else if self.check(&TokenKind::CloseParen) {
             None
         } else {
             let param = self.fn_param()?;
-            let _ = self.consume(&TokenKind::Comma);
+            let _ = self.consume_list_separator(&TokenKind::CloseParen)?;
             Some(param)
         };
 

--- a/compiler/parse/src/ty.rs
+++ b/compiler/parse/src/ty.rs
@@ -42,8 +42,13 @@ impl Parser {
                 }
             }
 
-            if !self.consume_b(&TokenKind::Comma) {
-                break;
+            match self.consume_list_separator(&TokenKind::Gt) {
+                Ok(true) => {}
+                Ok(false) => break,
+                Err(_) => {
+                    self.backtrack();
+                    return Ok(None);
+                }
             }
         }
 
@@ -296,15 +301,14 @@ impl Parser {
         loop {
             field_types.push(self.ty()?.into());
 
-            if let Ok(span) = self.consume(&TokenKind::CloseParen) {
+            if !self.consume_list_separator(&TokenKind::CloseParen)? {
+                let span = self.consume(&TokenKind::CloseParen)?;
                 return Ok(wrap_in_reference(Ty {
                     kind: TyKind::Tuple(field_types).into(),
                     mutability: Mutability::Not,
                     span: self.new_span(start, span.finish),
                 }));
             }
-
-            self.consume(&TokenKind::Comma)?;
         }
     }
 
@@ -325,11 +329,10 @@ impl Parser {
             loop {
                 param_tys.push(self.ty()?.into());
 
-                if let Ok(span) = self.consume(&TokenKind::CloseParen) {
+                if !self.consume_list_separator(&TokenKind::CloseParen)? {
+                    let span = self.consume(&TokenKind::CloseParen)?;
                     break span.finish;
                 }
-
-                self.consume(&TokenKind::Comma)?;
             }
         } else {
             self.consume(&TokenKind::CloseParen)?.finish

--- a/compiler/parse/tests/multiline_lists.rs
+++ b/compiler/parse/tests/multiline_lists.rs
@@ -1,0 +1,130 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use kaede_ast::{expr::ExprKind, top::TopLevelKind, ModuleItem};
+use kaede_parse::Parser;
+use kaede_span::file::FilePath;
+use kaede_symbol::Symbol;
+
+fn file() -> FilePath {
+    FilePath::from(PathBuf::from("test.kd"))
+}
+
+#[test]
+fn parse_multiline_call_arguments_without_trailing_comma() -> Result<()> {
+    let mut parser = Parser::new(
+        r#"
+foo(
+    1,
+    bar = 2
+)
+"#,
+        file(),
+    );
+    let expr = parser.expr()?;
+
+    let call = match expr.kind {
+        ExprKind::FnCall(call) => call,
+        other => panic!("expected fn call, got {other:?}"),
+    };
+
+    let args: Vec<_> = call.args.args.iter().collect();
+    assert_eq!(args.len(), 2);
+    assert!(args[0].name.is_none());
+    assert_eq!(
+        args[1].name.as_ref().expect("keyword argument").symbol(),
+        Symbol::from("bar".to_string())
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parse_multiline_call_arguments_with_trailing_comma() -> Result<()> {
+    let mut parser = Parser::new(
+        r#"
+foo(
+    1,
+    bar = 2,
+)
+"#,
+        file(),
+    );
+    let expr = parser.expr()?;
+
+    let call = match expr.kind {
+        ExprKind::FnCall(call) => call,
+        other => panic!("expected fn call, got {other:?}"),
+    };
+
+    assert_eq!(call.args.args.len(), 2);
+
+    Ok(())
+}
+
+#[test]
+fn parse_multiline_fn_params_without_trailing_comma() -> Result<()> {
+    let mut parser = Parser::new(
+        r#"
+fun f(
+    a: i32,
+    b: i32 = 2
+) {}
+"#,
+        file(),
+    );
+    let compile_unit = parser.run()?;
+
+    let ModuleItem::Decl(top_level) = compile_unit.items.front().unwrap() else {
+        panic!("expected top-level declaration");
+    };
+    let TopLevelKind::Fn(func) = &top_level.kind else {
+        panic!("expected function top-level");
+    };
+
+    assert_eq!(func.decl.params.v.len(), 2);
+
+    Ok(())
+}
+
+#[test]
+fn parse_multiline_fn_params_and_generics_with_trailing_commas() -> Result<()> {
+    let mut parser = Parser::new(
+        r#"
+fun f<
+    T,
+    U,
+>(
+    value: Result<
+        T,
+        U,
+    >,
+) -> Result<
+    U,
+    T,
+> {}
+"#,
+        file(),
+    );
+    let compile_unit = parser.run()?;
+
+    let ModuleItem::Decl(top_level) = compile_unit.items.front().unwrap() else {
+        panic!("expected top-level declaration");
+    };
+    let TopLevelKind::Fn(func) = &top_level.kind else {
+        panic!("expected function top-level");
+    };
+
+    assert_eq!(
+        func.decl
+            .generic_params
+            .as_ref()
+            .expect("generic params")
+            .params
+            .len(),
+        2
+    );
+    assert_eq!(func.decl.params.v.len(), 1);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- allow newline-inserted semicolons inside comma-separated parser lists
- allow trailing commas for multiline call args, function params, and generic params/args
- add parser regression tests for multiline calls, params, and generics

## Verification
- cargo fmt --all
- cargo test -p kaede_parse
- cargo clippy -- -D warnings