### PR TITLE
feat: add std.fs file API

### DIFF
--- a/compiler/driver/tests/fs.rs
+++ b/compiler/driver/tests/fs.rs
@@ -1,0 +1,231 @@
+mod driver_test_support;
+
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+use std::fs;
+use std::process::Command;
+
+use driver_test_support::compile_project;
+
+fn compile_and_run_in_tempdir(program: &str) -> anyhow::Result<assert_fs::TempDir> {
+    let tempdir = assert_fs::TempDir::new()?;
+    let main = tempdir.child("main.kd");
+    main.write_str(program)?;
+
+    let (exe, _) = compile_project(&[main.path()], tempdir.path())?;
+    Command::new(exe.path())
+        .current_dir(tempdir.path())
+        .assert()
+        .success();
+
+    Ok(tempdir)
+}
+
+#[test]
+fn std_fs_open_options_cover_write_read_append_and_exclusive_create() -> anyhow::Result<()> {
+    let tempdir = compile_and_run_in_tempdir(
+        r#"import std.collections
+import std.fs
+import std.io
+import std.result
+import std.string
+
+use std.fs.OpenOptions
+use std.result.Result
+use std.string.bytes_eq
+
+fun main() -> i32 {
+    let mode = 420
+
+    let file = match std.fs.open_file("basic.txt", OpenOptions::write_create_truncate(mode)) {
+        Result::Ok(value) => value,
+        Result::Err(_) => return 1,
+    }
+
+    file.write_all(b"abc").unwrap()
+    file.sync_all().unwrap()
+    file.close().unwrap()
+
+    let append = match std.fs.open_file("basic.txt", OpenOptions::append_create(mode)) {
+        Result::Ok(value) => value,
+        Result::Err(_) => return 2,
+    }
+
+    append.write_all(b"de").unwrap()
+    append.sync_data().unwrap()
+    append.close().unwrap()
+
+    let read = match std.fs.open_file("basic.txt", OpenOptions::read_only()) {
+        Result::Ok(value) => value,
+        Result::Err(_) => return 3,
+    }
+
+    let bytes = match std.io.read_all(read, 100) {
+        Result::Ok(value) => value,
+        Result::Err(_) => return 4,
+    }
+    read.close().unwrap()
+
+    if !bytes_eq(bytes.as_slice(), b"abcde") {
+        return 5
+    }
+
+    let exclusive = std.fs.open_file("basic.txt", OpenOptions {
+        read: false,
+        write: true,
+        create: false,
+        create_new: true,
+        truncate: false,
+        append: false,
+        mode,
+    })
+    if exclusive.is_ok() {
+        return 6
+    }
+
+    return 0
+}
+"#,
+    )?;
+
+    tempdir
+        .child("basic.txt")
+        .assert(predicate::path::is_file());
+    assert_eq!(fs::read(tempdir.path().join("basic.txt"))?, b"abcde");
+
+    Ok(())
+}
+
+#[test]
+fn std_fs_dir_operations_support_temp_rename_sync_and_remove() -> anyhow::Result<()> {
+    let tempdir = compile_and_run_in_tempdir(
+        r#"import std.collections
+import std.fs
+import std.io
+import std.result
+import std.string
+
+use std.fs.OpenOptions
+use std.result.Result
+use std.string.bytes_eq
+
+fun main() -> i32 {
+    let dir = match std.fs.open_dir(".") {
+        Result::Ok(value) => value,
+        Result::Err(_) => return 1,
+    }
+
+    let tmp = match dir.create_temp("rename-*.tmp") {
+        Result::Ok(value) => value,
+        Result::Err(_) => return 2,
+    }
+
+    tmp.write_all(b"renamed").unwrap()
+    tmp.sync_all().unwrap()
+    tmp.close().unwrap()
+
+    dir.rename(tmp.name(), "renamed.txt").unwrap()
+    dir.sync().unwrap()
+
+    let read = match dir.open_file("renamed.txt", OpenOptions::read_only()) {
+        Result::Ok(value) => value,
+        Result::Err(_) => return 3,
+    }
+
+    let bytes = match std.io.read_all(read, 100) {
+        Result::Ok(value) => value,
+        Result::Err(_) => return 4,
+    }
+    read.close().unwrap()
+
+    if !bytes_eq(bytes.as_slice(), b"renamed") {
+        return 5
+    }
+
+    dir.remove_file("renamed.txt").unwrap()
+    dir.close().unwrap()
+
+    if std.fs.open_file("renamed.txt", OpenOptions::read_only()).is_ok() {
+        return 6
+    }
+
+    return 0
+}
+"#,
+    )?;
+
+    tempdir
+        .child("renamed.txt")
+        .assert(predicate::path::missing());
+    let leftovers = fs::read_dir(tempdir.path())?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("rename-"))
+        .count();
+    assert_eq!(leftovers, 0);
+
+    Ok(())
+}
+
+#[test]
+fn std_fs_write_atomic_replaces_or_preserves_existing_file() -> anyhow::Result<()> {
+    let tempdir = compile_and_run_in_tempdir(
+        r#"import std.collections
+import std.fs
+import std.io
+import std.result
+import std.string
+
+use std.fs.AtomicWriteOptions
+use std.fs.OpenOptions
+use std.result.Result
+use std.string.bytes_eq
+
+fun read_bytes(path: str) -> std.collections.Vector<u8> {
+    let file = std.fs.open_file(path, OpenOptions::read_only()).unwrap()
+    let bytes = std.io.read_all(file, 100).unwrap()
+    file.close().unwrap()
+    return bytes
+}
+
+fun main() -> i32 {
+    let options = AtomicWriteOptions::durable_replace(420)
+
+    std.fs.write_atomic("atomic.txt", b"first", options).unwrap()
+    if !bytes_eq(read_bytes("atomic.txt").as_slice(), b"first") {
+        return 1
+    }
+
+    std.fs.write_atomic("atomic.txt", b"second", options).unwrap()
+    if !bytes_eq(read_bytes("atomic.txt").as_slice(), b"second") {
+        return 2
+    }
+
+    let no_replace = std.fs.write_atomic("atomic.txt", b"third", AtomicWriteOptions {
+        mode: 420,
+        sync_file: true,
+        sync_dir: true,
+        replace: false,
+    })
+    if no_replace.is_ok() {
+        return 3
+    }
+
+    if !bytes_eq(read_bytes("atomic.txt").as_slice(), b"second") {
+        return 4
+    }
+
+    return 0
+}
+"#,
+    )?;
+
+    assert_eq!(fs::read(tempdir.path().join("atomic.txt"))?, b"second");
+    let leftovers = fs::read_dir(tempdir.path())?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp."))
+        .count();
+    assert_eq!(leftovers, 0);
+
+    Ok(())
+}

--- a/compiler/driver/tests/fs.rs
+++ b/compiler/driver/tests/fs.rs
@@ -43,7 +43,7 @@ fun main() -> i32 {
         Result::Err(_) => return 1,
     }
 
-    file.write_all(b"abc").unwrap()
+    file.write(b"abc").unwrap()
     file.sync_all().unwrap()
     file.close().unwrap()
 
@@ -52,7 +52,7 @@ fun main() -> i32 {
         Result::Err(_) => return 2,
     }
 
-    append.write_all(b"de").unwrap()
+    append.write(b"de").unwrap()
     append.sync_data().unwrap()
     append.close().unwrap()
 
@@ -121,7 +121,7 @@ fun main() -> i32 {
         Result::Err(_) => return 2,
     }
 
-    tmp.write_all(b"renamed").unwrap()
+    tmp.write(b"renamed").unwrap()
     tmp.sync_all().unwrap()
     tmp.close().unwrap()
 

--- a/library/ffi/sys/sys.c
+++ b/library/ffi/sys/sys.c
@@ -583,32 +583,36 @@ int kaede_sys_write_atomic(const unsigned char *path, size_t path_len,
 
   char *parent_path = NULL;
   char *base_name = NULL;
-  if (split_parent_and_basename(owned_path, &parent_path, &base_name) < 0) {
-    free(owned_path);
-    return -1;
-  }
-
-  int dir_fd = open(parent_path, O_RDONLY | O_DIRECTORY);
-  if (dir_fd < 0) {
-    free(owned_path);
-    return -1;
-  }
-
-  char temp_name[256];
+  int dir_fd = -1;
   int fd = -1;
+  int temp_created = 0;
+  int saved_errno = 0;
+  char temp_name[256];
+
+  if (split_parent_and_basename(owned_path, &parent_path, &base_name) < 0) {
+    saved_errno = errno;
+    goto fail;
+  }
+
+  dir_fd = open(parent_path, O_RDONLY | O_DIRECTORY);
+  if (dir_fd < 0) {
+    saved_errno = errno;
+    goto fail;
+  }
+
   for (unsigned attempt = 0; attempt < 1000; ++attempt) {
     int written = snprintf(temp_name, sizeof(temp_name), ".%s.tmp.%ld-%u",
                            base_name, (long)getpid(), attempt);
     if (written < 0 || (size_t)written >= sizeof(temp_name)) {
-      retry_close_preserve_errno(dir_fd);
-      free(owned_path);
-      errno = ENAMETOOLONG;
-      return -1;
+      saved_errno = ENAMETOOLONG;
+      goto fail;
     }
 
     fd = openat(dir_fd, temp_name, O_WRONLY | O_CREAT | O_EXCL, (mode_t)mode);
-    if (fd >= 0)
+    if (fd >= 0) {
+      temp_created = 1;
       break;
+    }
     if (errno == EINTR) {
       --attempt;
       continue;
@@ -616,94 +620,80 @@ int kaede_sys_write_atomic(const unsigned char *path, size_t path_len,
     if (errno == EEXIST)
       continue;
 
-    int saved_errno = errno;
-    retry_close_preserve_errno(dir_fd);
-    free(owned_path);
-    errno = saved_errno;
-    return -1;
+    saved_errno = errno;
+    goto fail;
   }
 
   if (fd < 0) {
-    int saved_errno = errno;
-    retry_close_preserve_errno(dir_fd);
-    free(owned_path);
-    errno = saved_errno;
-    return -1;
+    saved_errno = EEXIST;
+    goto fail;
   }
 
   if (write_all_blocking(fd, data, data_len) < 0) {
-    int saved_errno = errno;
-    retry_close_preserve_errno(fd);
-    unlinkat(dir_fd, temp_name, 0);
-    retry_close_preserve_errno(dir_fd);
-    free(owned_path);
-    errno = saved_errno;
-    return -1;
+    saved_errno = errno;
+    goto fail;
   }
 
   if (sync_file && kaede_sys_fsync((sys_fd_t)fd) < 0) {
-    int saved_errno = errno;
-    retry_close_preserve_errno(fd);
-    unlinkat(dir_fd, temp_name, 0);
-    retry_close_preserve_errno(dir_fd);
-    free(owned_path);
-    errno = saved_errno;
-    return -1;
+    saved_errno = errno;
+    goto fail;
   }
 
   if (close(fd) < 0) {
-    int saved_errno = errno;
-    unlinkat(dir_fd, temp_name, 0);
-    retry_close_preserve_errno(dir_fd);
-    free(owned_path);
-    errno = saved_errno;
-    return -1;
+    saved_errno = errno;
+    fd = -1;
+    goto fail;
   }
+  fd = -1;
 
   if (replace) {
     if (renameat(dir_fd, temp_name, dir_fd, base_name) < 0) {
-      int saved_errno = errno;
-      unlinkat(dir_fd, temp_name, 0);
-      retry_close_preserve_errno(dir_fd);
-      free(owned_path);
-      errno = saved_errno;
-      return -1;
+      saved_errno = errno;
+      goto fail;
     }
+    temp_created = 0;
   } else {
     if (linkat(dir_fd, temp_name, dir_fd, base_name, 0) < 0) {
-      int saved_errno = errno;
-      unlinkat(dir_fd, temp_name, 0);
-      retry_close_preserve_errno(dir_fd);
-      free(owned_path);
-      errno = saved_errno;
-      return -1;
+      saved_errno = errno;
+      goto fail;
     }
     if (unlinkat(dir_fd, temp_name, 0) < 0) {
-      int saved_errno = errno;
-      retry_close_preserve_errno(dir_fd);
-      free(owned_path);
-      errno = saved_errno;
-      return -1;
+      saved_errno = errno;
+      goto fail;
     }
+    temp_created = 0;
   }
 
   if (sync_dir_if_requested(dir_fd, sync_dir) < 0) {
-    int saved_errno = errno;
-    retry_close_preserve_errno(dir_fd);
-    free(owned_path);
-    errno = saved_errno;
-    return -1;
+    saved_errno = errno;
+    goto fail;
   }
 
   if (close(dir_fd) < 0) {
-    int saved_errno = errno;
-    free(owned_path);
-    errno = saved_errno;
-    return -1;
+    saved_errno = errno;
+    dir_fd = -1;
+    goto fail;
   }
+  dir_fd = -1;
 
   free(owned_path);
   return 0;
+
+fail:
+  // Every jump here captures the original failure in saved_errno first. Cleanup
+  // is best-effort; restore saved_errno so callers see the real cause.
+  if (fd >= 0) {
+    retry_close_preserve_errno(fd);
+  }
+  if (temp_created && dir_fd >= 0) {
+    unlinkat(dir_fd, temp_name, 0);
+  }
+  if (dir_fd >= 0) {
+    retry_close_preserve_errno(dir_fd);
+  }
+  free(owned_path);
+  errno = saved_errno;
+  return -1;
 }
 
 int kaede_sys_close(sys_fd_t fd) {

--- a/library/ffi/sys/sys.c
+++ b/library/ffi/sys/sys.c
@@ -281,24 +281,6 @@ sys_fd_t kaede_sys_accept(sys_fd_t listen_fd) {
   }
 }
 
-sys_fd_t kaede_sys_open_read(const unsigned char *path, size_t path_len) {
-  unsigned char *owned_path = path_slice_to_c_string(path, path_len);
-  if (owned_path == NULL)
-    return (sys_fd_t)-1;
-
-  for (;;) {
-    int fd = open((const char *)owned_path, O_RDONLY);
-    if (fd >= 0) {
-      free(owned_path);
-      return (sys_fd_t)fd;
-    }
-    if (errno == EINTR)
-      continue;
-    free(owned_path);
-    return (sys_fd_t)-1;
-  }
-}
-
 sys_fd_t kaede_sys_open_file(const unsigned char *path, size_t path_len,
                              int read, int write, int create, int create_new,
                              int truncate, int append, uint32_t mode) {

--- a/library/ffi/sys/sys.c
+++ b/library/ffi/sys/sys.c
@@ -107,14 +107,9 @@ static int retry_close_preserve_errno(int fd) {
   return close_result;
 }
 
-// Directory fsync is what makes a successful rename/unlink durable across a
-// crash on common Unix filesystems. It is optional because some callers may not
-// need the extra durability cost.
-static int sync_dir_if_requested(int dir_fd, int sync_dir) {
-  if (!sync_dir) {
-    return 0;
-  }
-
+// Directory fsync is what makes a successful rename/link durable across a crash
+// on common Unix filesystems.
+static int fsync_dir(int dir_fd) {
   for (;;) {
     if (fsync(dir_fd) == 0) {
       return 0;
@@ -664,7 +659,7 @@ int kaede_sys_write_atomic(const unsigned char *path, size_t path_len,
     temp_created = 0;
   }
 
-  if (sync_dir_if_requested(dir_fd, sync_dir) < 0) {
+  if (sync_dir && fsync_dir(dir_fd) < 0) {
     saved_errno = errno;
     goto fail;
   }

--- a/library/ffi/sys/sys.c
+++ b/library/ffi/sys/sys.c
@@ -15,6 +15,159 @@
 #include <time.h>
 #include <unistd.h>
 
+#ifndef O_DIRECTORY
+#define O_DIRECTORY 0
+#endif
+
+static unsigned char *copy_path(const unsigned char *path, size_t path_len) {
+  if (path == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  unsigned char *owned_path = (unsigned char *)malloc(path_len + 1);
+  if (owned_path == NULL) {
+    return NULL;
+  }
+
+  memcpy(owned_path, path, path_len);
+  owned_path[path_len] = '\0';
+  return owned_path;
+}
+
+static int build_open_flags(int read, int write, int create, int create_new,
+                            int truncate, int append) {
+  int flags;
+
+  if (read && write) {
+    flags = O_RDWR;
+  } else if (write) {
+    flags = O_WRONLY;
+  } else {
+    flags = O_RDONLY;
+  }
+
+  if (create) {
+    flags |= O_CREAT;
+  }
+  if (create_new) {
+    flags |= O_CREAT | O_EXCL;
+  }
+  if (truncate) {
+    flags |= O_TRUNC;
+  }
+  if (append) {
+    flags |= O_APPEND;
+  }
+
+  return flags;
+}
+
+static ssize_t write_all_blocking(int fd, const unsigned char *buf,
+                                  size_t len) {
+  size_t off = 0;
+
+  while (off < len) {
+    ssize_t n = write(fd, buf + off, len - off);
+    if (n > 0) {
+      off += (size_t)n;
+      continue;
+    }
+    if (n == 0) {
+      errno = EIO;
+      return -1;
+    }
+    if (errno == EINTR) {
+      continue;
+    }
+    return -1;
+  }
+
+  return (ssize_t)off;
+}
+
+static int retry_close_preserve_errno(int fd) {
+  int saved_errno = errno;
+  int close_result;
+  do {
+    close_result = close(fd);
+  } while (close_result < 0 && errno == EINTR);
+  errno = saved_errno;
+  return close_result;
+}
+
+static int sync_dir_if_requested(int dir_fd, int sync_dir) {
+  if (!sync_dir) {
+    return 0;
+  }
+
+  for (;;) {
+    if (fsync(dir_fd) == 0) {
+      return 0;
+    }
+    if (errno != EINTR) {
+      return -1;
+    }
+  }
+}
+
+static int split_parent_and_basename(unsigned char *path, char **parent_out,
+                                     char **base_out) {
+  char *path_str = (char *)path;
+  char *last_slash = strrchr(path_str, '/');
+
+  if (last_slash == NULL) {
+    *parent_out = ".";
+    *base_out = path_str;
+    return 0;
+  }
+
+  if (last_slash[1] == '\0') {
+    errno = EINVAL;
+    return -1;
+  }
+
+  *base_out = last_slash + 1;
+
+  if (last_slash == path_str) {
+    last_slash[1] = '\0';
+    *parent_out = path_str;
+    return 0;
+  }
+
+  *last_slash = '\0';
+  *parent_out = path_str;
+  return 0;
+}
+
+static int make_temp_name(const char *pattern, unsigned attempt, char *out,
+                          size_t out_cap) {
+  char suffix[64];
+  int suffix_len =
+      snprintf(suffix, sizeof(suffix), "%ld-%u", (long)getpid(), attempt);
+  if (suffix_len < 0 || (size_t)suffix_len >= sizeof(suffix)) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  const char *star = strchr(pattern, '*');
+  int written;
+  if (star != NULL) {
+    size_t prefix_len = (size_t)(star - pattern);
+    written = snprintf(out, out_cap, "%.*s%s%s", (int)prefix_len, pattern,
+                       suffix, star + 1);
+  } else {
+    written = snprintf(out, out_cap, "%s%s", pattern, suffix);
+  }
+
+  if (written < 0 || (size_t)written >= out_cap) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+
+  return written;
+}
+
 // Socket I/O has to be non-blocking so EAGAIN can park the current task
 // without blocking the whole worker thread in the kernel.
 static int set_nonblocking(int fd) {
@@ -110,12 +263,9 @@ sys_fd_t kaede_sys_accept(sys_fd_t listen_fd) {
 }
 
 sys_fd_t kaede_sys_open_read(const unsigned char *path, size_t path_len) {
-  unsigned char *owned_path = (unsigned char *)malloc(path_len + 1);
+  unsigned char *owned_path = copy_path(path, path_len);
   if (owned_path == NULL)
     return (sys_fd_t)-1;
-
-  memcpy(owned_path, path, path_len);
-  owned_path[path_len] = '\0';
 
   for (;;) {
     int fd = open((const char *)owned_path, O_RDONLY);
@@ -128,6 +278,124 @@ sys_fd_t kaede_sys_open_read(const unsigned char *path, size_t path_len) {
     free(owned_path);
     return (sys_fd_t)-1;
   }
+}
+
+sys_fd_t kaede_sys_open_file(const unsigned char *path, size_t path_len,
+                             int read, int write, int create, int create_new,
+                             int truncate, int append, uint32_t mode) {
+  unsigned char *owned_path = copy_path(path, path_len);
+  if (owned_path == NULL)
+    return (sys_fd_t)-1;
+
+  int flags = build_open_flags(read, write, create, create_new, truncate, append);
+
+  for (;;) {
+    int fd = open((const char *)owned_path, flags, (mode_t)mode);
+    if (fd >= 0) {
+      free(owned_path);
+      return (sys_fd_t)fd;
+    }
+    if (errno == EINTR)
+      continue;
+    free(owned_path);
+    return (sys_fd_t)-1;
+  }
+}
+
+sys_fd_t kaede_sys_open_dir(const unsigned char *path, size_t path_len) {
+  unsigned char *owned_path = copy_path(path, path_len);
+  if (owned_path == NULL)
+    return (sys_fd_t)-1;
+
+  for (;;) {
+    int fd = open((const char *)owned_path, O_RDONLY | O_DIRECTORY);
+    if (fd >= 0) {
+      free(owned_path);
+      return (sys_fd_t)fd;
+    }
+    if (errno == EINTR)
+      continue;
+    free(owned_path);
+    return (sys_fd_t)-1;
+  }
+}
+
+sys_fd_t kaede_sys_open_file_at(sys_fd_t dir_fd, const unsigned char *path,
+                                size_t path_len, int read, int write,
+                                int create, int create_new, int truncate,
+                                int append, uint32_t mode) {
+  unsigned char *owned_path = copy_path(path, path_len);
+  if (owned_path == NULL)
+    return (sys_fd_t)-1;
+
+  int flags = build_open_flags(read, write, create, create_new, truncate, append);
+
+  for (;;) {
+    int fd = openat((int)dir_fd, (const char *)owned_path, flags, (mode_t)mode);
+    if (fd >= 0) {
+      free(owned_path);
+      return (sys_fd_t)fd;
+    }
+    if (errno == EINTR)
+      continue;
+    free(owned_path);
+    return (sys_fd_t)-1;
+  }
+}
+
+sys_fd_t kaede_sys_create_temp_at(sys_fd_t dir_fd,
+                                  const unsigned char *pattern,
+                                  size_t pattern_len, uint32_t mode,
+                                  unsigned char *name_out, size_t name_cap) {
+  unsigned char *owned_pattern = copy_path(pattern, pattern_len);
+  if (owned_pattern == NULL)
+    return (sys_fd_t)-1;
+
+  if (name_out == NULL || name_cap == 0) {
+    free(owned_pattern);
+    errno = EINVAL;
+    return (sys_fd_t)-1;
+  }
+
+  char candidate[256];
+  for (unsigned attempt = 0; attempt < 1000; attempt++) {
+    int candidate_len =
+        make_temp_name((const char *)owned_pattern, attempt, candidate,
+                       sizeof(candidate));
+    if (candidate_len < 0) {
+      free(owned_pattern);
+      return (sys_fd_t)-1;
+    }
+
+    if ((size_t)candidate_len >= name_cap) {
+      free(owned_pattern);
+      errno = ENAMETOOLONG;
+      return (sys_fd_t)-1;
+    }
+
+    int fd = openat((int)dir_fd, candidate, O_WRONLY | O_CREAT | O_EXCL,
+                    (mode_t)mode);
+    if (fd >= 0) {
+      memcpy(name_out, candidate, (size_t)candidate_len + 1);
+      free(owned_pattern);
+      return (sys_fd_t)fd;
+    }
+
+    if (errno == EINTR) {
+      attempt--;
+      continue;
+    }
+    if (errno == EEXIST) {
+      continue;
+    }
+
+    free(owned_pattern);
+    return (sys_fd_t)-1;
+  }
+
+  free(owned_pattern);
+  errno = EEXIST;
+  return (sys_fd_t)-1;
 }
 
 long kaede_sys_read(sys_fd_t fd, unsigned char *buf, size_t len) {
@@ -176,6 +444,250 @@ int kaede_sys_is_regular_file(sys_fd_t fd) {
     return -1;
 
   return S_ISREG(st.st_mode) ? 1 : 0;
+}
+
+int kaede_sys_fsync(sys_fd_t fd) {
+  for (;;) {
+    if (fsync((int)fd) == 0)
+      return 0;
+    if (errno != EINTR)
+      return -1;
+  }
+}
+
+int kaede_sys_fdatasync(sys_fd_t fd) {
+#if defined(__APPLE__)
+  return kaede_sys_fsync(fd);
+#else
+  for (;;) {
+    if (fdatasync((int)fd) == 0)
+      return 0;
+    if (errno != EINTR)
+      return -1;
+  }
+#endif
+}
+
+int kaede_sys_rename(const unsigned char *old_path, size_t old_path_len,
+                     const unsigned char *new_path, size_t new_path_len) {
+  unsigned char *owned_old_path = copy_path(old_path, old_path_len);
+  if (owned_old_path == NULL)
+    return -1;
+
+  unsigned char *owned_new_path = copy_path(new_path, new_path_len);
+  if (owned_new_path == NULL) {
+    free(owned_old_path);
+    return -1;
+  }
+
+  for (;;) {
+    if (rename((const char *)owned_old_path, (const char *)owned_new_path) == 0) {
+      free(owned_old_path);
+      free(owned_new_path);
+      return 0;
+    }
+    if (errno == EINTR)
+      continue;
+    free(owned_old_path);
+    free(owned_new_path);
+    return -1;
+  }
+}
+
+int kaede_sys_rename_at(sys_fd_t dir_fd, const unsigned char *old_path,
+                        size_t old_path_len, const unsigned char *new_path,
+                        size_t new_path_len) {
+  unsigned char *owned_old_path = copy_path(old_path, old_path_len);
+  if (owned_old_path == NULL)
+    return -1;
+
+  unsigned char *owned_new_path = copy_path(new_path, new_path_len);
+  if (owned_new_path == NULL) {
+    free(owned_old_path);
+    return -1;
+  }
+
+  for (;;) {
+    if (renameat((int)dir_fd, (const char *)owned_old_path, (int)dir_fd,
+                 (const char *)owned_new_path) == 0) {
+      free(owned_old_path);
+      free(owned_new_path);
+      return 0;
+    }
+    if (errno == EINTR)
+      continue;
+    free(owned_old_path);
+    free(owned_new_path);
+    return -1;
+  }
+}
+
+int kaede_sys_unlink(const unsigned char *path, size_t path_len) {
+  unsigned char *owned_path = copy_path(path, path_len);
+  if (owned_path == NULL)
+    return -1;
+
+  for (;;) {
+    if (unlink((const char *)owned_path) == 0) {
+      free(owned_path);
+      return 0;
+    }
+    if (errno == EINTR)
+      continue;
+    free(owned_path);
+    return -1;
+  }
+}
+
+int kaede_sys_unlink_at(sys_fd_t dir_fd, const unsigned char *path,
+                        size_t path_len) {
+  unsigned char *owned_path = copy_path(path, path_len);
+  if (owned_path == NULL)
+    return -1;
+
+  for (;;) {
+    if (unlinkat((int)dir_fd, (const char *)owned_path, 0) == 0) {
+      free(owned_path);
+      return 0;
+    }
+    if (errno == EINTR)
+      continue;
+    free(owned_path);
+    return -1;
+  }
+}
+
+int kaede_sys_write_atomic(const unsigned char *path, size_t path_len,
+                           const unsigned char *data, size_t data_len,
+                           uint32_t mode, int sync_file, int sync_dir,
+                           int replace) {
+  unsigned char *owned_path = copy_path(path, path_len);
+  if (owned_path == NULL)
+    return -1;
+
+  char *parent_path = NULL;
+  char *base_name = NULL;
+  if (split_parent_and_basename(owned_path, &parent_path, &base_name) < 0) {
+    free(owned_path);
+    return -1;
+  }
+
+  int dir_fd = open(parent_path, O_RDONLY | O_DIRECTORY);
+  if (dir_fd < 0) {
+    free(owned_path);
+    return -1;
+  }
+
+  char temp_name[256];
+  int fd = -1;
+  for (unsigned attempt = 0; attempt < 1000; attempt++) {
+    int written = snprintf(temp_name, sizeof(temp_name), ".%s.tmp.%ld-%u",
+                           base_name, (long)getpid(), attempt);
+    if (written < 0 || (size_t)written >= sizeof(temp_name)) {
+      retry_close_preserve_errno(dir_fd);
+      free(owned_path);
+      errno = ENAMETOOLONG;
+      return -1;
+    }
+
+    fd = openat(dir_fd, temp_name, O_WRONLY | O_CREAT | O_EXCL, (mode_t)mode);
+    if (fd >= 0)
+      break;
+    if (errno == EINTR) {
+      attempt--;
+      continue;
+    }
+    if (errno == EEXIST)
+      continue;
+
+    int saved_errno = errno;
+    retry_close_preserve_errno(dir_fd);
+    free(owned_path);
+    errno = saved_errno;
+    return -1;
+  }
+
+  if (fd < 0) {
+    int saved_errno = errno;
+    retry_close_preserve_errno(dir_fd);
+    free(owned_path);
+    errno = saved_errno;
+    return -1;
+  }
+
+  if (write_all_blocking(fd, data, data_len) < 0) {
+    int saved_errno = errno;
+    retry_close_preserve_errno(fd);
+    unlinkat(dir_fd, temp_name, 0);
+    retry_close_preserve_errno(dir_fd);
+    free(owned_path);
+    errno = saved_errno;
+    return -1;
+  }
+
+  if (sync_file && kaede_sys_fsync((sys_fd_t)fd) < 0) {
+    int saved_errno = errno;
+    retry_close_preserve_errno(fd);
+    unlinkat(dir_fd, temp_name, 0);
+    retry_close_preserve_errno(dir_fd);
+    free(owned_path);
+    errno = saved_errno;
+    return -1;
+  }
+
+  if (close(fd) < 0) {
+    int saved_errno = errno;
+    unlinkat(dir_fd, temp_name, 0);
+    retry_close_preserve_errno(dir_fd);
+    free(owned_path);
+    errno = saved_errno;
+    return -1;
+  }
+
+  if (replace) {
+    if (renameat(dir_fd, temp_name, dir_fd, base_name) < 0) {
+      int saved_errno = errno;
+      unlinkat(dir_fd, temp_name, 0);
+      retry_close_preserve_errno(dir_fd);
+      free(owned_path);
+      errno = saved_errno;
+      return -1;
+    }
+  } else {
+    if (linkat(dir_fd, temp_name, dir_fd, base_name, 0) < 0) {
+      int saved_errno = errno;
+      unlinkat(dir_fd, temp_name, 0);
+      retry_close_preserve_errno(dir_fd);
+      free(owned_path);
+      errno = saved_errno;
+      return -1;
+    }
+    if (unlinkat(dir_fd, temp_name, 0) < 0) {
+      int saved_errno = errno;
+      retry_close_preserve_errno(dir_fd);
+      free(owned_path);
+      errno = saved_errno;
+      return -1;
+    }
+  }
+
+  if (sync_dir_if_requested(dir_fd, sync_dir) < 0) {
+    int saved_errno = errno;
+    retry_close_preserve_errno(dir_fd);
+    free(owned_path);
+    errno = saved_errno;
+    return -1;
+  }
+
+  if (close(dir_fd) < 0) {
+    int saved_errno = errno;
+    free(owned_path);
+    errno = saved_errno;
+    return -1;
+  }
+
+  free(owned_path);
+  return 0;
 }
 
 int kaede_sys_close(sys_fd_t fd) {

--- a/library/ffi/sys/sys.c
+++ b/library/ffi/sys/sys.c
@@ -359,7 +359,7 @@ sys_fd_t kaede_sys_create_temp_at(sys_fd_t dir_fd,
   }
 
   char candidate[256];
-  for (unsigned attempt = 0; attempt < 1000; attempt++) {
+  for (unsigned attempt = 0; attempt < 1000; ++attempt) {
     int candidate_len =
         make_temp_name((const char *)owned_pattern, attempt, candidate,
                        sizeof(candidate));
@@ -383,7 +383,7 @@ sys_fd_t kaede_sys_create_temp_at(sys_fd_t dir_fd,
     }
 
     if (errno == EINTR) {
-      attempt--;
+      --attempt;
       continue;
     }
     if (errno == EEXIST) {
@@ -585,7 +585,7 @@ int kaede_sys_write_atomic(const unsigned char *path, size_t path_len,
 
   char temp_name[256];
   int fd = -1;
-  for (unsigned attempt = 0; attempt < 1000; attempt++) {
+  for (unsigned attempt = 0; attempt < 1000; ++attempt) {
     int written = snprintf(temp_name, sizeof(temp_name), ".%s.tmp.%ld-%u",
                            base_name, (long)getpid(), attempt);
     if (written < 0 || (size_t)written >= sizeof(temp_name)) {
@@ -599,7 +599,7 @@ int kaede_sys_write_atomic(const unsigned char *path, size_t path_len,
     if (fd >= 0)
       break;
     if (errno == EINTR) {
-      attempt--;
+      --attempt;
       continue;
     }
     if (errno == EEXIST)

--- a/library/ffi/sys/sys.c
+++ b/library/ffi/sys/sys.c
@@ -19,7 +19,11 @@
 #define O_DIRECTORY 0
 #endif
 
-static unsigned char *copy_path(const unsigned char *path, size_t path_len) {
+// Kaede paths cross the FFI boundary as pointer + length slices. POSIX file
+// APIs require NUL-terminated strings, so every path passed to open/rename/etc.
+// must first be copied into an owned C string.
+static unsigned char *path_slice_to_c_string(const unsigned char *path,
+                                             size_t path_len) {
   if (path == NULL) {
     errno = EINVAL;
     return NULL;
@@ -35,6 +39,8 @@ static unsigned char *copy_path(const unsigned char *path, size_t path_len) {
   return owned_path;
 }
 
+// Translate the structured std.fs OpenOptions fields into POSIX open flags.
+// Keeping this mapping here keeps raw OS bit flags out of the Kaede API.
 static int build_open_flags(int read, int write, int create, int create_new,
                             int truncate, int append) {
   int flags;
@@ -63,6 +69,9 @@ static int build_open_flags(int read, int write, int create, int create_new,
   return flags;
 }
 
+// write(2) may write fewer bytes than requested, or return EINTR before
+// writing anything. Keep writing until the full temp file body is on disk
+// before the atomic rename step.
 static ssize_t write_all_blocking(int fd, const unsigned char *buf,
                                   size_t len) {
   size_t off = 0;
@@ -86,6 +95,8 @@ static ssize_t write_all_blocking(int fd, const unsigned char *buf,
   return (ssize_t)off;
 }
 
+// Error paths often close a temporary fd after another syscall has already set
+// errno. Preserve that original errno so callers see the real failure cause.
 static int retry_close_preserve_errno(int fd) {
   int saved_errno = errno;
   int close_result;
@@ -96,6 +107,9 @@ static int retry_close_preserve_errno(int fd) {
   return close_result;
 }
 
+// Directory fsync is what makes a successful rename/unlink durable across a
+// crash on common Unix filesystems. It is optional because some callers may not
+// need the extra durability cost.
 static int sync_dir_if_requested(int dir_fd, int sync_dir) {
   if (!sync_dir) {
     return 0;
@@ -111,6 +125,8 @@ static int sync_dir_if_requested(int dir_fd, int sync_dir) {
   }
 }
 
+// Split an owned, mutable C path into parent directory and basename. This edits
+// the path buffer in place by replacing the final slash with NUL.
 static int split_parent_and_basename(unsigned char *path, char **parent_out,
                                      char **base_out) {
   char *path_str = (char *)path;
@@ -140,6 +156,9 @@ static int split_parent_and_basename(unsigned char *path, char **parent_out,
   return 0;
 }
 
+// Build a deterministic candidate name from a user pattern. The caller opens it
+// with O_EXCL and retries on EEXIST, so predictability here does not overwrite
+// existing files.
 static int make_temp_name(const char *pattern, unsigned attempt, char *out,
                           size_t out_cap) {
   char suffix[64];
@@ -263,7 +282,7 @@ sys_fd_t kaede_sys_accept(sys_fd_t listen_fd) {
 }
 
 sys_fd_t kaede_sys_open_read(const unsigned char *path, size_t path_len) {
-  unsigned char *owned_path = copy_path(path, path_len);
+  unsigned char *owned_path = path_slice_to_c_string(path, path_len);
   if (owned_path == NULL)
     return (sys_fd_t)-1;
 
@@ -283,7 +302,7 @@ sys_fd_t kaede_sys_open_read(const unsigned char *path, size_t path_len) {
 sys_fd_t kaede_sys_open_file(const unsigned char *path, size_t path_len,
                              int read, int write, int create, int create_new,
                              int truncate, int append, uint32_t mode) {
-  unsigned char *owned_path = copy_path(path, path_len);
+  unsigned char *owned_path = path_slice_to_c_string(path, path_len);
   if (owned_path == NULL)
     return (sys_fd_t)-1;
 
@@ -303,7 +322,7 @@ sys_fd_t kaede_sys_open_file(const unsigned char *path, size_t path_len,
 }
 
 sys_fd_t kaede_sys_open_dir(const unsigned char *path, size_t path_len) {
-  unsigned char *owned_path = copy_path(path, path_len);
+  unsigned char *owned_path = path_slice_to_c_string(path, path_len);
   if (owned_path == NULL)
     return (sys_fd_t)-1;
 
@@ -324,7 +343,7 @@ sys_fd_t kaede_sys_open_file_at(sys_fd_t dir_fd, const unsigned char *path,
                                 size_t path_len, int read, int write,
                                 int create, int create_new, int truncate,
                                 int append, uint32_t mode) {
-  unsigned char *owned_path = copy_path(path, path_len);
+  unsigned char *owned_path = path_slice_to_c_string(path, path_len);
   if (owned_path == NULL)
     return (sys_fd_t)-1;
 
@@ -347,7 +366,7 @@ sys_fd_t kaede_sys_create_temp_at(sys_fd_t dir_fd,
                                   const unsigned char *pattern,
                                   size_t pattern_len, uint32_t mode,
                                   unsigned char *name_out, size_t name_cap) {
-  unsigned char *owned_pattern = copy_path(pattern, pattern_len);
+  unsigned char *owned_pattern = path_slice_to_c_string(pattern, pattern_len);
   if (owned_pattern == NULL)
     return (sys_fd_t)-1;
 
@@ -470,11 +489,13 @@ int kaede_sys_fdatasync(sys_fd_t fd) {
 
 int kaede_sys_rename(const unsigned char *old_path, size_t old_path_len,
                      const unsigned char *new_path, size_t new_path_len) {
-  unsigned char *owned_old_path = copy_path(old_path, old_path_len);
+  unsigned char *owned_old_path =
+      path_slice_to_c_string(old_path, old_path_len);
   if (owned_old_path == NULL)
     return -1;
 
-  unsigned char *owned_new_path = copy_path(new_path, new_path_len);
+  unsigned char *owned_new_path =
+      path_slice_to_c_string(new_path, new_path_len);
   if (owned_new_path == NULL) {
     free(owned_old_path);
     return -1;
@@ -497,11 +518,13 @@ int kaede_sys_rename(const unsigned char *old_path, size_t old_path_len,
 int kaede_sys_rename_at(sys_fd_t dir_fd, const unsigned char *old_path,
                         size_t old_path_len, const unsigned char *new_path,
                         size_t new_path_len) {
-  unsigned char *owned_old_path = copy_path(old_path, old_path_len);
+  unsigned char *owned_old_path =
+      path_slice_to_c_string(old_path, old_path_len);
   if (owned_old_path == NULL)
     return -1;
 
-  unsigned char *owned_new_path = copy_path(new_path, new_path_len);
+  unsigned char *owned_new_path =
+      path_slice_to_c_string(new_path, new_path_len);
   if (owned_new_path == NULL) {
     free(owned_old_path);
     return -1;
@@ -523,7 +546,7 @@ int kaede_sys_rename_at(sys_fd_t dir_fd, const unsigned char *old_path,
 }
 
 int kaede_sys_unlink(const unsigned char *path, size_t path_len) {
-  unsigned char *owned_path = copy_path(path, path_len);
+  unsigned char *owned_path = path_slice_to_c_string(path, path_len);
   if (owned_path == NULL)
     return -1;
 
@@ -541,7 +564,7 @@ int kaede_sys_unlink(const unsigned char *path, size_t path_len) {
 
 int kaede_sys_unlink_at(sys_fd_t dir_fd, const unsigned char *path,
                         size_t path_len) {
-  unsigned char *owned_path = copy_path(path, path_len);
+  unsigned char *owned_path = path_slice_to_c_string(path, path_len);
   if (owned_path == NULL)
     return -1;
 
@@ -561,7 +584,7 @@ int kaede_sys_write_atomic(const unsigned char *path, size_t path_len,
                            const unsigned char *data, size_t data_len,
                            uint32_t mode, int sync_file, int sync_dir,
                            int replace) {
-  unsigned char *owned_path = copy_path(path, path_len);
+  unsigned char *owned_path = path_slice_to_c_string(path, path_len);
   if (owned_path == NULL)
     return -1;
 

--- a/library/ffi/sys/sys.c
+++ b/library/ffi/sys/sys.c
@@ -70,8 +70,8 @@ static int build_open_flags(int read, int write, int create, int create_new,
 }
 
 // write(2) may write fewer bytes than requested, or return EINTR before
-// writing anything. Keep writing until the full temp file body is on disk
-// before the atomic rename step.
+// writing anything. Keep writing until the full temp file body has been
+// accepted by the kernel; durable storage is handled separately by fsync.
 static ssize_t write_all_blocking(int fd, const unsigned char *buf,
                                   size_t len) {
   size_t off = 0;
@@ -562,6 +562,17 @@ int kaede_sys_unlink_at(sys_fd_t dir_fd, const unsigned char *path,
   }
 }
 
+// Write data through a temp file in the target file's parent directory, then
+// publish it with an atomic directory operation. Creating the temp file in the
+// same directory keeps the final rename/link on the same filesystem.
+//
+// With replace=true, renameat(temp, final) atomically replaces the destination.
+// With replace=false, linkat(temp, final) fails if the destination already
+// exists, then the temp name is unlinked after the final name is created.
+//
+// sync_file controls whether the temp file contents are fsynced before publish.
+// sync_dir controls whether the parent directory is fsynced after publish so
+// the new directory entry is durable across a crash.
 int kaede_sys_write_atomic(const unsigned char *path, size_t path_len,
                            const unsigned char *data, size_t data_len,
                            uint32_t mode, int sync_file, int sync_dir,

--- a/library/ffi/sys/sys.h
+++ b/library/ffi/sys/sys.h
@@ -18,7 +18,6 @@ sys_fd_t kaede_sys_accept(sys_fd_t listen_fd); // returns client fd, -1 on error
 int kaede_sys_somaxconn(void); // best-effort SOMAXCONN, falls back to 128
 
 /* --- I/O (EINTR hidden, socket I/O parks on EAGAIN) --- */
-sys_fd_t kaede_sys_open_read(const unsigned char *path, size_t path_len);
 sys_fd_t kaede_sys_open_file(const unsigned char *path, size_t path_len,
                              int read, int write, int create, int create_new,
                              int truncate, int append, uint32_t mode);

--- a/library/ffi/sys/sys.h
+++ b/library/ffi/sys/sys.h
@@ -19,11 +19,38 @@ int kaede_sys_somaxconn(void); // best-effort SOMAXCONN, falls back to 128
 
 /* --- I/O (EINTR hidden, socket I/O parks on EAGAIN) --- */
 sys_fd_t kaede_sys_open_read(const unsigned char *path, size_t path_len);
+sys_fd_t kaede_sys_open_file(const unsigned char *path, size_t path_len,
+                             int read, int write, int create, int create_new,
+                             int truncate, int append, uint32_t mode);
+sys_fd_t kaede_sys_open_dir(const unsigned char *path, size_t path_len);
+sys_fd_t kaede_sys_open_file_at(sys_fd_t dir_fd, const unsigned char *path,
+                                size_t path_len, int read, int write,
+                                int create, int create_new, int truncate,
+                                int append, uint32_t mode);
+sys_fd_t kaede_sys_create_temp_at(sys_fd_t dir_fd,
+                                  const unsigned char *pattern,
+                                  size_t pattern_len, uint32_t mode,
+                                  unsigned char *name_out,
+                                  size_t name_cap);
 long kaede_sys_read(sys_fd_t fd, unsigned char *buf,
                     size_t len); // returns n>=0, -1 on error
 long kaede_sys_write(sys_fd_t fd, const unsigned char *buf,
                      size_t len); // returns n>=0, -1 on error
 int kaede_sys_is_regular_file(sys_fd_t fd);
+int kaede_sys_fsync(sys_fd_t fd);
+int kaede_sys_fdatasync(sys_fd_t fd);
+int kaede_sys_rename(const unsigned char *old_path, size_t old_path_len,
+                     const unsigned char *new_path, size_t new_path_len);
+int kaede_sys_rename_at(sys_fd_t dir_fd, const unsigned char *old_path,
+                        size_t old_path_len, const unsigned char *new_path,
+                        size_t new_path_len);
+int kaede_sys_unlink(const unsigned char *path, size_t path_len);
+int kaede_sys_unlink_at(sys_fd_t dir_fd, const unsigned char *path,
+                        size_t path_len);
+int kaede_sys_write_atomic(const unsigned char *path, size_t path_len,
+                           const unsigned char *data, size_t data_len,
+                           uint32_t mode, int sync_file, int sync_dir,
+                           int replace);
 int kaede_sys_close(sys_fd_t fd);
 int kaede_sys_sleep_ms(uint64_t ms);
 

--- a/library/src/std/ffi/sys.kd
+++ b/library/src/std/ffi/sys.kd
@@ -3,7 +3,6 @@ export extern "C" fun kaede_sys_set_reuseaddr(fd: i32) -> i32
 export extern "C" fun kaede_sys_bind_ipv4(fd: i32, ip_or_null: *u8, port: u16) -> i32
 export extern "C" fun kaede_sys_listen(fd: i32, backlog: i32) -> i32
 export extern "C" fun kaede_sys_accept(listen_fd: i32) -> i32
-export extern "C" fun kaede_sys_open_read(path: *u8, path_len: u64) -> i32
 export extern "C" fun kaede_sys_open_file(
     path: *u8,
     path_len: u64,
@@ -85,10 +84,6 @@ export fun __sys_listen(fd: i32, backlog: i32) -> i32 {
 
 export fun __sys_accept(listen_fd: i32) -> i32 {
     return kaede_sys_accept(listen_fd)
-}
-
-export fun __sys_open_read(path: *u8, path_len: u64) -> i32 {
-    return kaede_sys_open_read(path, path_len)
 }
 
 export fun __sys_open_file(

--- a/library/src/std/ffi/sys.kd
+++ b/library/src/std/ffi/sys.kd
@@ -4,9 +4,63 @@ export extern "C" fun kaede_sys_bind_ipv4(fd: i32, ip_or_null: *u8, port: u16) -
 export extern "C" fun kaede_sys_listen(fd: i32, backlog: i32) -> i32
 export extern "C" fun kaede_sys_accept(listen_fd: i32) -> i32
 export extern "C" fun kaede_sys_open_read(path: *u8, path_len: u64) -> i32
+export extern "C" fun kaede_sys_open_file(
+    path: *u8,
+    path_len: u64,
+    read: i32,
+    write: i32,
+    create: i32,
+    create_new: i32,
+    truncate: i32,
+    append: i32,
+    mode: u32,
+) -> i32
+export extern "C" fun kaede_sys_open_dir(path: *u8, path_len: u64) -> i32
+export extern "C" fun kaede_sys_open_file_at(
+    dir_fd: i32,
+    path: *u8,
+    path_len: u64,
+    read: i32,
+    write: i32,
+    create: i32,
+    create_new: i32,
+    truncate: i32,
+    append: i32,
+    mode: u32,
+) -> i32
+export extern "C" fun kaede_sys_create_temp_at(
+    dir_fd: i32,
+    pattern: *u8,
+    pattern_len: u64,
+    mode: u32,
+    name_out: *u8,
+    name_cap: u64,
+) -> i32
 export extern "C" fun kaede_sys_read(fd: i32, buf: *u8, len: u64) -> i64
 export extern "C" fun kaede_sys_write(fd: i32, buf: *u8, len: u64) -> i64
 export extern "C" fun kaede_sys_is_regular_file(fd: i32) -> i32
+export extern "C" fun kaede_sys_fsync(fd: i32) -> i32
+export extern "C" fun kaede_sys_fdatasync(fd: i32) -> i32
+export extern "C" fun kaede_sys_rename(old_path: *u8, old_path_len: u64, new_path: *u8, new_path_len: u64) -> i32
+export extern "C" fun kaede_sys_rename_at(
+    dir_fd: i32,
+    old_path: *u8,
+    old_path_len: u64,
+    new_path: *u8,
+    new_path_len: u64,
+) -> i32
+export extern "C" fun kaede_sys_unlink(path: *u8, path_len: u64) -> i32
+export extern "C" fun kaede_sys_unlink_at(dir_fd: i32, path: *u8, path_len: u64) -> i32
+export extern "C" fun kaede_sys_write_atomic(
+    path: *u8,
+    path_len: u64,
+    data: *u8,
+    data_len: u64,
+    mode: u32,
+    sync_file: i32,
+    sync_dir: i32,
+    replace: i32,
+) -> i32
 export extern "C" fun kaede_sys_close(fd: i32) -> i32
 export extern "C" fun kaede_sys_sleep_ms(ms: u64) -> i32
 export extern "C" fun kaede_sys_errno() -> i32
@@ -37,6 +91,78 @@ export fun __sys_open_read(path: *u8, path_len: u64) -> i32 {
     return kaede_sys_open_read(path, path_len)
 }
 
+export fun __sys_open_file(
+    path: *u8,
+    path_len: u64,
+    read: i32,
+    write: i32,
+    create: i32,
+    create_new: i32,
+    truncate: i32,
+    append: i32,
+    mode: u32,
+) -> i32 {
+    return kaede_sys_open_file(
+        path,
+        path_len,
+        read,
+        write,
+        create,
+        create_new,
+        truncate,
+        append,
+        mode,
+    )
+}
+
+export fun __sys_open_dir(path: *u8, path_len: u64) -> i32 {
+    return kaede_sys_open_dir(path, path_len)
+}
+
+export fun __sys_open_file_at(
+    dir_fd: i32,
+    path: *u8,
+    path_len: u64,
+    read: i32,
+    write: i32,
+    create: i32,
+    create_new: i32,
+    truncate: i32,
+    append: i32,
+    mode: u32,
+) -> i32 {
+    return kaede_sys_open_file_at(
+        dir_fd,
+        path,
+        path_len,
+        read,
+        write,
+        create,
+        create_new,
+        truncate,
+        append,
+        mode,
+    )
+}
+
+export fun __sys_create_temp_at(
+    dir_fd: i32,
+    pattern: *u8,
+    pattern_len: u64,
+    mode: u32,
+    name_out: *u8,
+    name_cap: u64,
+) -> i32 {
+    return kaede_sys_create_temp_at(
+        dir_fd,
+        pattern,
+        pattern_len,
+        mode,
+        name_out,
+        name_cap,
+    )
+}
+
 export fun __sys_read(fd: i32, buf: *u8, len: u64) -> i64 {
     return kaede_sys_read(fd, buf, len)
 }
@@ -47,6 +173,52 @@ export fun __sys_write(fd: i32, buf: *u8, len: u64) -> i64 {
 
 export fun __sys_is_regular_file(fd: i32) -> i32 {
     return kaede_sys_is_regular_file(fd)
+}
+
+export fun __sys_fsync(fd: i32) -> i32 {
+    return kaede_sys_fsync(fd)
+}
+
+export fun __sys_fdatasync(fd: i32) -> i32 {
+    return kaede_sys_fdatasync(fd)
+}
+
+export fun __sys_rename(old_path: *u8, old_path_len: u64, new_path: *u8, new_path_len: u64) -> i32 {
+    return kaede_sys_rename(old_path, old_path_len, new_path, new_path_len)
+}
+
+export fun __sys_rename_at(dir_fd: i32, old_path: *u8, old_path_len: u64, new_path: *u8, new_path_len: u64) -> i32 {
+    return kaede_sys_rename_at(dir_fd, old_path, old_path_len, new_path, new_path_len)
+}
+
+export fun __sys_unlink(path: *u8, path_len: u64) -> i32 {
+    return kaede_sys_unlink(path, path_len)
+}
+
+export fun __sys_unlink_at(dir_fd: i32, path: *u8, path_len: u64) -> i32 {
+    return kaede_sys_unlink_at(dir_fd, path, path_len)
+}
+
+export fun __sys_write_atomic(
+    path: *u8,
+    path_len: u64,
+    data: *u8,
+    data_len: u64,
+    mode: u32,
+    sync_file: i32,
+    sync_dir: i32,
+    replace: i32,
+) -> i32 {
+    return kaede_sys_write_atomic(
+        path,
+        path_len,
+        data,
+        data_len,
+        mode,
+        sync_file,
+        sync_dir,
+        replace,
+    )
 }
 
 export fun __sys_close(fd: i32) -> i32 {

--- a/library/src/std/fs.kd
+++ b/library/src/std/fs.kd
@@ -9,7 +9,6 @@ use std.io.IoError
 use std.io.IoErrorKind
 use std.result.Result
 use std.string.String
-use std.ffi.sys.__sys_open_read
 use std.ffi.sys.__sys_open_file
 use std.ffi.sys.__sys_open_dir
 use std.ffi.sys.__sys_open_file_at
@@ -329,7 +328,18 @@ export fun write_atomic(path: str, body: [u8], options: AtomicWriteOptions) -> R
 }
 
 export fun open_read(path: str) -> Result<Fd, IoError> {
-    let fd = __sys_open_read(path.as_ptr(), path.len())
+    let options = OpenOptions::read_only()
+    let fd = __sys_open_file(
+        path.as_ptr(),
+        path.len(),
+        bool_to_i32(options.read),
+        bool_to_i32(options.write),
+        bool_to_i32(options.create),
+        bool_to_i32(options.create_new),
+        bool_to_i32(options.truncate),
+        bool_to_i32(options.append),
+        options.mode,
+    )
     if fd < 0 {
         return Result::Err(IoError::from_errno(__sys_errno()))
     }

--- a/library/src/std/fs.kd
+++ b/library/src/std/fs.kd
@@ -1,14 +1,332 @@
 import std.sys
 import std.io
 import std.result
+import std.string
 import std.ffi.sys
 
 use std.sys.Fd
 use std.io.IoError
+use std.io.IoErrorKind
 use std.result.Result
+use std.string.String
 use std.ffi.sys.__sys_open_read
+use std.ffi.sys.__sys_open_file
+use std.ffi.sys.__sys_open_dir
+use std.ffi.sys.__sys_open_file_at
+use std.ffi.sys.__sys_create_temp_at
 use std.ffi.sys.__sys_errno
 use std.ffi.sys.__sys_is_regular_file
+use std.ffi.sys.__sys_rename
+use std.ffi.sys.__sys_rename_at
+use std.ffi.sys.__sys_unlink
+use std.ffi.sys.__sys_unlink_at
+use std.ffi.sys.__sys_write_atomic
+
+export struct OpenOptions {
+    read: bool,
+    write: bool,
+    create: bool,
+    create_new: bool,
+    truncate: bool,
+    append: bool,
+    mode: u32,
+}
+
+impl OpenOptions {
+    export fun read_only() -> OpenOptions {
+        return OpenOptions {
+            read: true,
+            write: false,
+            create: false,
+            create_new: false,
+            truncate: false,
+            append: false,
+            mode: 0,
+        }
+    }
+
+    export fun write_create_truncate(mode: u32) -> OpenOptions {
+        return OpenOptions {
+            read: false,
+            write: true,
+            create: true,
+            create_new: false,
+            truncate: true,
+            append: false,
+            mode,
+        }
+    }
+
+    export fun append_create(mode: u32) -> OpenOptions {
+        return OpenOptions {
+            read: false,
+            write: true,
+            create: true,
+            create_new: false,
+            truncate: false,
+            append: true,
+            mode,
+        }
+    }
+}
+
+export struct AtomicWriteOptions {
+    mode: u32,
+    sync_file: bool,
+    sync_dir: bool,
+    replace: bool,
+}
+
+impl AtomicWriteOptions {
+    export fun durable_replace(mode: u32) -> AtomicWriteOptions {
+        return AtomicWriteOptions {
+            mode,
+            sync_file: true,
+            sync_dir: true,
+            replace: true,
+        }
+    }
+}
+
+export struct File {
+    fd: Fd,
+}
+
+impl File {
+    export fun from_fd(fd: Fd) -> File {
+        return File { fd }
+    }
+
+    export fun raw(self) -> i32 {
+        return self.fd.raw()
+    }
+
+    export fun read(self, buf: mut [u8]) -> Result<u64, IoError> {
+        return self.fd.read(buf)
+    }
+
+    export fun write(self, buf: [u8]) -> Result<u64, IoError> {
+        return self.fd.write(buf)
+    }
+
+    export fun write_all(self, buf: [u8]) -> Result<u64, IoError> {
+        return self.fd.write(buf)
+    }
+
+    export fun sync_all(self) -> Result<bool, IoError> {
+        return self.fd.sync_all()
+    }
+
+    export fun sync_data(self) -> Result<bool, IoError> {
+        return self.fd.sync_data()
+    }
+
+    export fun is_regular_file(self) -> bool {
+        return __sys_is_regular_file(self.fd.raw()) == 1
+    }
+
+    export fun close(self) -> Result<bool, IoError> {
+        if std.sys.close_quiet(self.fd) {
+            return Result::Ok(true)
+        }
+        return Result::Err(IoError::from_errno(__sys_errno()))
+    }
+}
+
+export struct Dir {
+    fd: Fd,
+}
+
+impl Dir {
+    export fun raw(self) -> i32 {
+        return self.fd.raw()
+    }
+
+    export fun open_file(self, path: str, options: OpenOptions) -> Result<File, IoError> {
+        let fd = __sys_open_file_at(
+            self.fd.raw(),
+            path.as_ptr(),
+            path.len(),
+            bool_to_i32(options.read),
+            bool_to_i32(options.write),
+            bool_to_i32(options.create),
+            bool_to_i32(options.create_new),
+            bool_to_i32(options.truncate),
+            bool_to_i32(options.append),
+            options.mode,
+        )
+        return fd_to_file(fd)
+    }
+
+    export fun create_file(self, path: str, mode: u32) -> Result<File, IoError> {
+        return self.open_file(path, OpenOptions::write_create_truncate(mode))
+    }
+
+    export fun create_temp(self, pattern: str) -> Result<TempFile, IoError> {
+        return self.create_temp_mode(pattern, 384)
+    }
+
+    export fun create_temp_mode(self, pattern: str, mode: u32) -> Result<TempFile, IoError> {
+        let mut name_buf = [0 as u8; 256]
+        let fd = __sys_create_temp_at(
+            self.fd.raw(),
+            pattern.as_ptr(),
+            pattern.len(),
+            mode,
+            name_buf.as_ptr(),
+            name_buf.len(),
+        )
+        if fd < 0 {
+            return Result::Err(IoError::from_errno(__sys_errno()))
+        }
+
+        let name = String::from_bytes(name_buf[0:cstring_len(name_buf)])
+        return Result::Ok(TempFile {
+            file: File::from_fd(Fd::new(fd)),
+            name,
+        })
+    }
+
+    export fun rename(self, old_path: str, new_path: str) -> Result<bool, IoError> {
+        if __sys_rename_at(self.fd.raw(), old_path.as_ptr(), old_path.len(), new_path.as_ptr(), new_path.len()) < 0 {
+            return Result::Err(IoError::from_errno(__sys_errno()))
+        }
+        return Result::Ok(true)
+    }
+
+    export fun remove_file(self, path: str) -> Result<bool, IoError> {
+        if __sys_unlink_at(self.fd.raw(), path.as_ptr(), path.len()) < 0 {
+            return Result::Err(IoError::from_errno(__sys_errno()))
+        }
+        return Result::Ok(true)
+    }
+
+    export fun sync(self) -> Result<bool, IoError> {
+        return self.fd.sync_all()
+    }
+
+    export fun close(self) -> Result<bool, IoError> {
+        if std.sys.close_quiet(self.fd) {
+            return Result::Ok(true)
+        }
+        return Result::Err(IoError::from_errno(__sys_errno()))
+    }
+}
+
+export struct TempFile {
+    file: File,
+    name: String,
+}
+
+impl TempFile {
+    export fun name(self) -> str {
+        return self.name.as_str()
+    }
+
+    export fun read(self, buf: mut [u8]) -> Result<u64, IoError> {
+        return self.file.read(buf)
+    }
+
+    export fun write(self, buf: [u8]) -> Result<u64, IoError> {
+        return self.file.write(buf)
+    }
+
+    export fun write_all(self, buf: [u8]) -> Result<u64, IoError> {
+        return self.file.write_all(buf)
+    }
+
+    export fun sync_all(self) -> Result<bool, IoError> {
+        return self.file.sync_all()
+    }
+
+    export fun sync_data(self) -> Result<bool, IoError> {
+        return self.file.sync_data()
+    }
+
+    export fun close(self) -> Result<bool, IoError> {
+        return self.file.close()
+    }
+}
+
+fun bool_to_i32(value: bool) -> i32 {
+    if value {
+        return 1
+    }
+    return 0
+}
+
+fun cstring_len(buf: [u8]) -> u64 {
+    let mut i = 0
+    while i < buf.len() {
+        if buf[i] == 0 {
+            return i
+        }
+        i += 1
+    }
+    return buf.len()
+}
+
+fun fd_to_file(fd: i32) -> Result<File, IoError> {
+    if fd < 0 {
+        return Result::Err(IoError::from_errno(__sys_errno()))
+    }
+
+    return Result::Ok(File::from_fd(Fd::new(fd)))
+}
+
+export fun open_file(path: str, options: OpenOptions) -> Result<File, IoError> {
+    let fd = __sys_open_file(
+        path.as_ptr(),
+        path.len(),
+        bool_to_i32(options.read),
+        bool_to_i32(options.write),
+        bool_to_i32(options.create),
+        bool_to_i32(options.create_new),
+        bool_to_i32(options.truncate),
+        bool_to_i32(options.append),
+        options.mode,
+    )
+    return fd_to_file(fd)
+}
+
+export fun open_dir(path: str) -> Result<Dir, IoError> {
+    let fd = __sys_open_dir(path.as_ptr(), path.len())
+    if fd < 0 {
+        return Result::Err(IoError::from_errno(__sys_errno()))
+    }
+
+    return Result::Ok(Dir { fd: Fd::new(fd) })
+}
+
+export fun rename(old_path: str, new_path: str) -> Result<bool, IoError> {
+    if __sys_rename(old_path.as_ptr(), old_path.len(), new_path.as_ptr(), new_path.len()) < 0 {
+        return Result::Err(IoError::from_errno(__sys_errno()))
+    }
+    return Result::Ok(true)
+}
+
+export fun remove_file(path: str) -> Result<bool, IoError> {
+    if __sys_unlink(path.as_ptr(), path.len()) < 0 {
+        return Result::Err(IoError::from_errno(__sys_errno()))
+    }
+    return Result::Ok(true)
+}
+
+export fun write_atomic(path: str, body: [u8], options: AtomicWriteOptions) -> Result<bool, IoError> {
+    if __sys_write_atomic(
+        path.as_ptr(),
+        path.len(),
+        body.as_ptr(),
+        body.len(),
+        options.mode,
+        bool_to_i32(options.sync_file),
+        bool_to_i32(options.sync_dir),
+        bool_to_i32(options.replace),
+    ) < 0 {
+        return Result::Err(IoError::from_errno(__sys_errno()))
+    }
+    return Result::Ok(true)
+}
 
 export fun open_read(path: str) -> Result<Fd, IoError> {
     let fd = __sys_open_read(path.as_ptr(), path.len())

--- a/library/src/std/fs.kd
+++ b/library/src/std/fs.kd
@@ -9,6 +9,7 @@ use std.io.IoError
 use std.io.IoErrorKind
 use std.result.Result
 use std.string.String
+use std.string.cstring_len
 use std.ffi.sys.__sys_open_file
 use std.ffi.sys.__sys_open_dir
 use std.ffi.sys.__sys_open_file_at
@@ -142,12 +143,12 @@ impl Dir {
             self.fd.raw(),
             path.as_ptr(),
             path.len(),
-            bool_to_i32(options.read),
-            bool_to_i32(options.write),
-            bool_to_i32(options.create),
-            bool_to_i32(options.create_new),
-            bool_to_i32(options.truncate),
-            bool_to_i32(options.append),
+            options.read as i32,
+            options.write as i32,
+            options.create as i32,
+            options.create_new as i32,
+            options.truncate as i32,
+            options.append as i32,
             options.mode,
         )
         return fd_to_file(fd)
@@ -239,24 +240,6 @@ impl TempFile {
     }
 }
 
-fun bool_to_i32(value: bool) -> i32 {
-    if value {
-        return 1
-    }
-    return 0
-}
-
-fun cstring_len(buf: [u8]) -> u64 {
-    let mut i = 0
-    while i < buf.len() {
-        if buf[i] == 0 {
-            return i
-        }
-        i += 1
-    }
-    return buf.len()
-}
-
 fun fd_to_file(fd: i32) -> Result<File, IoError> {
     if fd < 0 {
         return Result::Err(IoError::from_errno(__sys_errno()))
@@ -269,12 +252,12 @@ export fun open_file(path: str, options: OpenOptions) -> Result<File, IoError> {
     let fd = __sys_open_file(
         path.as_ptr(),
         path.len(),
-        bool_to_i32(options.read),
-        bool_to_i32(options.write),
-        bool_to_i32(options.create),
-        bool_to_i32(options.create_new),
-        bool_to_i32(options.truncate),
-        bool_to_i32(options.append),
+        options.read as i32,
+        options.write as i32,
+        options.create as i32,
+        options.create_new as i32,
+        options.truncate as i32,
+        options.append as i32,
         options.mode,
     )
     return fd_to_file(fd)
@@ -310,9 +293,9 @@ export fun write_atomic(path: str, body: [u8], options: AtomicWriteOptions) -> R
         body.as_ptr(),
         body.len(),
         options.mode,
-        bool_to_i32(options.sync_file),
-        bool_to_i32(options.sync_dir),
-        bool_to_i32(options.replace),
+        options.sync_file as i32,
+        options.sync_dir as i32,
+        options.replace as i32,
     ) < 0 {
         return Result::Err(IoError::from_errno(__sys_errno()))
     }
@@ -324,12 +307,12 @@ export fun open_read(path: str) -> Result<Fd, IoError> {
     let fd = __sys_open_file(
         path.as_ptr(),
         path.len(),
-        bool_to_i32(options.read),
-        bool_to_i32(options.write),
-        bool_to_i32(options.create),
-        bool_to_i32(options.create_new),
-        bool_to_i32(options.truncate),
-        bool_to_i32(options.append),
+        options.read as i32,
+        options.write as i32,
+        options.create as i32,
+        options.create_new as i32,
+        options.truncate as i32,
+        options.append as i32,
         options.mode,
     )
     if fd < 0 {

--- a/library/src/std/fs.kd
+++ b/library/src/std/fs.kd
@@ -108,10 +108,6 @@ impl File {
         return self.fd.write(buf)
     }
 
-    export fun write_all(self, buf: [u8]) -> Result<u64, IoError> {
-        return self.fd.write(buf)
-    }
-
     export fun sync_all(self) -> Result<bool, IoError> {
         return self.fd.sync_all()
     }
@@ -228,10 +224,6 @@ impl TempFile {
 
     export fun write(self, buf: [u8]) -> Result<u64, IoError> {
         return self.file.write(buf)
-    }
-
-    export fun write_all(self, buf: [u8]) -> Result<u64, IoError> {
-        return self.file.write_all(buf)
     }
 
     export fun sync_all(self) -> Result<bool, IoError> {

--- a/library/src/std/string.kd
+++ b/library/src/std/string.kd
@@ -33,6 +33,17 @@ export fun bytes_eq(left: [u8], right: [u8]) -> bool {
     return true
 }
 
+export fun cstring_len(buf: [u8]) -> u64 {
+    let mut i = 0
+    while i < buf.len() {
+        if buf[i] == 0 {
+            return i
+        }
+        i += 1
+    }
+    return buf.len()
+}
+
 extern "C" fun kaede_utf8_char_at(s: *u8, len: u64, index: u64) -> char
 extern "C" fun kaede_utf8_char_count(s: *u8, len: u64) -> u64
 extern "C" fun kaede_utf8_byte_index_of_char(s: *u8, len: u64, index: u64) -> u64

--- a/library/src/std/sys.kd
+++ b/library/src/std/sys.kd
@@ -9,6 +9,8 @@ use std.result.Result
 use std.ffi.sys.__sys_read
 use std.ffi.sys.__sys_write
 use std.ffi.sys.__sys_errno
+use std.ffi.sys.__sys_fsync
+use std.ffi.sys.__sys_fdatasync
 use std.ffi.sys.__sys_close
 use std.ffi.sys.__sys_sleep_ms
 
@@ -59,6 +61,20 @@ impl Fd {
         }
 
         return Result::Ok(total)
+    }
+
+    export fun sync_all(self) -> Result<bool, IoError> {
+        if __sys_fsync(self.raw) < 0 {
+            return Result::Err(IoError::from_errno(__sys_errno()))
+        }
+        return Result::Ok(true)
+    }
+
+    export fun sync_data(self) -> Result<bool, IoError> {
+        if __sys_fdatasync(self.raw) < 0 {
+            return Result::Err(IoError::from_errno(__sys_errno()))
+        }
+        return Result::Ok(true)
     }
 }
 

--- a/website/docs/language/files.md
+++ b/website/docs/language/files.md
@@ -30,7 +30,7 @@ fun main() -> i32 {
         mode: 420,
     }).unwrap()
 
-    file.write_all(b"entry\n").unwrap()
+    file.write(b"entry\n").unwrap()
     file.sync_data().unwrap()
     file.close().unwrap()
     return 0
@@ -53,7 +53,7 @@ renames and parent-directory syncs.
 ```rust
 dir := std.fs.open_dir("data").unwrap()
 tmp := dir.create_temp("main.tmp-*").unwrap()
-tmp.write_all(bytes).unwrap()
+tmp.write(bytes).unwrap()
 tmp.sync_all().unwrap()
 tmp.close().unwrap()
 dir.rename(tmp.name(), "main").unwrap()

--- a/website/docs/language/files.md
+++ b/website/docs/language/files.md
@@ -1,0 +1,80 @@
+---
+title: Files
+description: Durable file I/O patterns available through std.fs.
+sidebar_position: 11
+---
+
+# Files
+
+`std.fs` provides typed file APIs for ordinary file I/O, directory-relative
+operations, and durable replacement writes.
+
+## Opening Files
+
+Use `OpenOptions` when you need explicit control over creation, truncation, and
+append behavior.
+
+```rust
+import std.fs
+
+use std.fs.OpenOptions
+
+fun main() -> i32 {
+    let file = std.fs.open_file("db.log", OpenOptions {
+        read: false,
+        write: true,
+        create: true,
+        create_new: false,
+        truncate: false,
+        append: true,
+        mode: 420,
+    }).unwrap()
+
+    file.write_all(b"entry\n").unwrap()
+    file.sync_data().unwrap()
+    file.close().unwrap()
+    return 0
+}
+```
+
+Common constructors are available for the usual cases:
+
+```rust
+OpenOptions::read_only()
+OpenOptions::write_create_truncate(420)
+OpenOptions::append_create(420)
+```
+
+## Directory Operations
+
+Use `Dir` for operations that should be scoped to a parent directory, including
+renames and parent-directory syncs.
+
+```rust
+dir := std.fs.open_dir("data").unwrap()
+tmp := dir.create_temp("main.tmp-*").unwrap()
+tmp.write_all(bytes).unwrap()
+tmp.sync_all().unwrap()
+tmp.close().unwrap()
+dir.rename(tmp.name(), "main").unwrap()
+dir.sync().unwrap()
+dir.close().unwrap()
+```
+
+## Atomic Replacement
+
+For the common durable replace pattern, `write_atomic` writes a temporary file,
+syncs it when requested, renames it into place, and optionally syncs the parent
+directory.
+
+```rust
+std.fs.write_atomic("data/main", bytes, std.fs.AtomicWriteOptions {
+    mode: 420,
+    sync_file: true,
+    sync_dir: true,
+    replace: true,
+}).unwrap()
+```
+
+`AtomicWriteOptions::durable_replace(mode)` is a shortcut for the fully durable
+replace case.


### PR DESCRIPTION
## Summary
- add low-level filesystem sys primitives for open/openat, temp files, sync, rename, unlink, and atomic writes
- add Rust/Zig-style std.fs APIs: OpenOptions, File, Dir, TempFile, AtomicWriteOptions, write_atomic
- add integration coverage for open options, directory-relative operations, and atomic writes
- document the new file APIs on the website

Closes #311

## Commit split
- filesystem sys primitives
- std.fs public API
- std.fs integration tests
- website docs

## Verification
- cargo fmt --all
- ./install.py --no-setenv
- cargo test -p kaede_compiler_driver --test fs -- --nocapture
- cargo clippy -- -D warnings
- cargo test --release --no-fail-fast

Note: the first sandboxed release test hit Operation not permitted in network-related tests; reran the same command with elevated permissions and it passed.