### PR TITLE
Omit redundant main returns in docs

### DIFF
--- a/website/docs/language/concurrency.md
+++ b/website/docs/language/concurrency.md
@@ -17,10 +17,9 @@ fun producer(ch: Channel<i32>) {
     ch.send(42)
 }
 
-fun main() -> i32 {
+fun main() {
     ch := Channel<i32>::new()
     spawn producer(ch)
-    return 0
 }
 ```
 

--- a/website/docs/language/files.md
+++ b/website/docs/language/files.md
@@ -19,7 +19,7 @@ import std.fs
 
 use std.fs.OpenOptions
 
-fun main() -> i32 {
+fun main() {
     let file = std.fs.open_file("db.log", OpenOptions {
         read: false,
         write: true,
@@ -33,7 +33,6 @@ fun main() -> i32 {
     file.write(b"entry\n").unwrap()
     file.sync_data().unwrap()
     file.close().unwrap()
-    return 0
 }
 ```
 


### PR DESCRIPTION
## Summary

- Remove `-> i32` and `return 0` from website examples where `main` does not need to return an exit code.
- Keep examples that intentionally return computed values or non-zero exit codes unchanged.

## Verification

- `git diff --cached --check`

Docs-only change; no compiler tests run.
