### PR TITLE
Add Vector buffer helpers

### DIFF
--- a/compiler/codegen/src/expr.rs
+++ b/compiler/codegen/src/expr.rs
@@ -211,7 +211,7 @@ impl<'ctx> CodeGenerator<'ctx> {
 
             BuiltinFnCallKind::Format(parts) => self.build_format(node, parts),
 
-            BuiltinFnCallKind::SliceFromRawParts => {
+            BuiltinFnCallKind::SliceFromRawParts(mutability) => {
                 let data_ptr = self
                     .build_expr(&node.args.0[0])?
                     .unwrap()
@@ -235,7 +235,7 @@ impl<'ctx> CodeGenerator<'ctx> {
 
                 let slice_ty = Rc::new(Ty {
                     kind: TyKind::Slice(elem_ty).into(),
-                    mutability: Mutability::Not,
+                    mutability: *mutability,
                 });
                 let slice_llvm_ty = self.conv_to_llvm_type(&slice_ty);
                 let slice_ptr = self.create_gc_struct(

--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -3963,6 +3963,123 @@ fn vector_filter_accepts_capturing_closure() -> anyhow::Result<()> {
 }
 
 #[test]
+fn vector_with_capacity_and_filled() -> anyhow::Result<()> {
+    let program = r#"
+        fun main() -> i32 {
+            let mut reserved = Vector<i32>::with_capacity(8)
+            if reserved.len() != 0 {
+                return 1
+            }
+            if reserved.capacity() < 8 {
+                return 2
+            }
+
+            reserved.push(11)
+            reserved.push(31)
+            if reserved.len() != 2 {
+                return 3
+            }
+            if reserved.at(0).unwrap() != 11 {
+                return 4
+            }
+            if reserved.at(1).unwrap() != 31 {
+                return 5
+            }
+
+            let filled = Vector<i32>::filled(3, 7)
+            if filled.len() != 3 {
+                return 6
+            }
+            if filled.capacity() < 3 {
+                return 7
+            }
+            if filled.at(0).unwrap() != 7 {
+                return 8
+            }
+            if filled.at(2).unwrap() != 7 {
+                return 9
+            }
+
+            return 58
+        }
+    "#;
+
+    assert_eq!(exec(program)?, 58);
+    Ok(())
+}
+
+#[test]
+fn vector_resize_and_as_mut_slice() -> anyhow::Result<()> {
+    let program = r#"
+        fun main() -> i32 {
+            let mut v = Vector<u8>::filled(4, 7)
+            let mut s = v.as_mut_slice()
+            s[1] = 9
+
+            if v.at(1).unwrap() != 9 {
+                return 1
+            }
+
+            v.resize(6, 3)
+            if v.len() != 6 {
+                return 2
+            }
+            if v.capacity() < 6 {
+                return 3
+            }
+            if v.at(1).unwrap() != 9 {
+                return 4
+            }
+            if v.at(4).unwrap() != 3 {
+                return 5
+            }
+            if v.at(5).unwrap() != 3 {
+                return 6
+            }
+
+            let mut grown = v.as_mut_slice()
+            grown[5] = 12
+            if v.at(5).unwrap() != 12 {
+                return 7
+            }
+
+            v.resize(2, 0)
+            if v.len() != 2 {
+                return 8
+            }
+            if v.at(0).unwrap() != 7 {
+                return 9
+            }
+            if v.at(1).unwrap() != 9 {
+                return 10
+            }
+
+            return 58
+        }
+    "#;
+
+    assert_eq!(exec(program)?, 58);
+    Ok(())
+}
+
+#[test]
+fn vector_as_mut_slice_requires_mutable_receiver() {
+    let program = r#"
+        fun main() -> i32 {
+            let v = Vector<u8>::filled(2, 0)
+            let mut s = v.as_mut_slice()
+            s[0] = 1
+            return s[0] as i32
+        }
+    "#;
+
+    assert!(matches!(
+        extract_semantic_error(exec(program).unwrap_err()),
+        SemanticError::CannotCallMutableMethodOnImmutableValue { .. }
+    ));
+}
+
+#[test]
 fn string_push_line_appends_newline() -> anyhow::Result<()> {
     let program = r#"
         fun main() -> i32 {

--- a/compiler/ir/src/expr.rs
+++ b/compiler/ir/src/expr.rs
@@ -6,7 +6,7 @@ use kaede_symbol::Symbol;
 use crate::{
     stmt::Block,
     top::{Enum, FnDecl, Interface, InterfaceMethod, Struct},
-    ty::{Ty, UserDefinedType},
+    ty::{Mutability, Ty, UserDefinedType},
 };
 
 #[derive(Debug, Clone)]
@@ -320,7 +320,7 @@ pub enum BuiltinFnCallKind {
     Unreachable,
     Str,
     Format(Vec<FormatPart>),
-    SliceFromRawParts,
+    SliceFromRawParts(Mutability),
     PointerAdd,
     SizeOf,
     TypeSize(Rc<Ty>),

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -1882,10 +1882,16 @@ impl SemanticAnalyzer {
                 })())
             }
 
-            "__slice_from_raw_parts" => {
+            "__slice_from_raw_parts" | "__slice_from_raw_parts_mut" => {
                 if let Some(name) = keyword_arg {
                     return keyword_error(name);
                 }
+
+                let mutability = if callee.symbol().as_str() == "__slice_from_raw_parts_mut" {
+                    ir_type::Mutability::Mut
+                } else {
+                    ir_type::Mutability::Not
+                };
 
                 Some(
                     node.args
@@ -1921,19 +1927,18 @@ impl SemanticAnalyzer {
 
                             let slice_ty = Rc::new(ir_type::Ty {
                                 kind: ir_type::TyKind::Slice(elem_ty).into(),
-                                mutability: ir_type::Mutability::Not,
+                                mutability,
                             });
 
                             Ok(ir::expr::Expr {
                                 kind: ir::expr::ExprKind::BuiltinFnCall(ir::expr::BuiltinFnCall {
-                                    kind: ir::expr::BuiltinFnCallKind::SliceFromRawParts,
+                                    kind: ir::expr::BuiltinFnCallKind::SliceFromRawParts(
+                                        mutability,
+                                    ),
                                     args: ir::expr::Args(args, node.span),
                                     span: node.span,
                                 }),
-                                ty: Rc::new(ir_type::wrap_in_ref(
-                                    slice_ty,
-                                    ir_type::Mutability::Not,
-                                )),
+                                ty: Rc::new(ir_type::wrap_in_ref(slice_ty, mutability)),
                                 span: node.span,
                             })
                         }),

--- a/compiler/type_infer/src/lib.rs
+++ b/compiler/type_infer/src/lib.rs
@@ -1390,7 +1390,7 @@ impl TypeInferrer {
             BuiltinFnCallKind::Unreachable => Ok(Rc::new(Ty::new_never())),
             BuiltinFnCallKind::Str => Ok(Rc::new(Ty::new_str(Mutability::Not))),
             BuiltinFnCallKind::Format(_) => Ok(Rc::new(Ty::new_str(Mutability::Not))),
-            BuiltinFnCallKind::SliceFromRawParts => {
+            BuiltinFnCallKind::SliceFromRawParts(mutability) => {
                 let elem_ty = match builtin_call.args.0[0].ty.kind.as_ref() {
                     TyKind::Pointer(pty) => pty.pointee_ty.clone(),
                     TyKind::Reference(rty) => match rty.get_base_type().kind.as_ref() {
@@ -1402,11 +1402,11 @@ impl TypeInferrer {
 
                 let slice_ty = Rc::new(Ty {
                     kind: TyKind::Slice(elem_ty).into(),
-                    mutability: Mutability::Not,
+                    mutability: *mutability,
                 });
                 Ok(Rc::new(Ty {
                     kind: TyKind::Reference(ReferenceType { refee_ty: slice_ty }).into(),
-                    mutability: Mutability::Not,
+                    mutability: *mutability,
                 }))
             }
             BuiltinFnCallKind::PointerAdd => Ok(builtin_call.args.0[0].ty.clone()),

--- a/library/src/std/collections/vector.kd
+++ b/library/src/std/collections/vector.kd
@@ -16,12 +16,32 @@ impl<T> Vector<T> {
         return Vector<T> { ptr: __mem_alloc(0) as *T, len: 0, capacity: 0 }
     }
 
+    export fun with_capacity(capacity: u64) -> mut Vector<T> {
+        return Vector<T> {
+            ptr: __mem_alloc(__type_size<T>() * capacity) as *T,
+            len: 0,
+            capacity,
+        }
+    }
+
+    export fun filled(len: u64, value: T) -> mut Vector<T> {
+        let mut v = Vector<T>::with_capacity(len)
+        while v.len < len {
+            v.push(value)
+        }
+        return v
+    }
+
     export fun as_ptr(self) -> *T {
         return self.ptr
     }
 
     export fun as_slice(self) -> [T] {
         return __slice_from_raw_parts(self.ptr, self.len)
+    }
+
+    export fun as_mut_slice(mut self) -> mut [T] {
+        return __slice_from_raw_parts_mut(self.ptr, self.len)
     }
 
     export fun len(self) -> u64 {
@@ -39,6 +59,17 @@ impl<T> Vector<T> {
 
         self.ptr[self.len] = elem
         self.len += 1
+    }
+
+    export fun resize(mut self, len: u64, value: T) {
+        if len <= self.len {
+            self.len = len
+            return
+        }
+
+        while self.len < len {
+            self.push(value)
+        }
     }
 
     export fun pop(mut self) -> Option<T> {


### PR DESCRIPTION
## Summary

- Add `Vector::with_capacity`, `Vector::filled`, `Vector::resize`, and `Vector::as_mut_slice`.
- Add an internal mutable raw-slice builtin so `Vector::as_mut_slice` can return `mut [T]`.
- Cover capacity, filled initialization, resize growth/shrink, mutable slice writes, and immutable receiver rejection.

## Verification

- `cargo fmt --all`
- `./install.py --no-setenv`
- `cargo test -p kaede_codegen vector_`
- `cargo test -p kaede_codegen --lib`
- `cargo test -p kaede_semantic`
- `cargo test -p kaede_type_infer`
- `cargo clippy -- -D warnings`
- `cargo test --release --no-fail-fast` (with elevated permissions for HTTP/netpoll socket tests)
