### PR TITLE
Add std.bytes helpers

### DIFF
--- a/compiler/driver/tests/bytes.rs
+++ b/compiler/driver/tests/bytes.rs
@@ -1,0 +1,121 @@
+mod driver_test_support;
+
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+use driver_test_support::{compile_project, run_program as test};
+
+#[test]
+fn std_bytes_primitive_endian_methods_round_trip() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.bytes
+
+fun main() -> i32 {
+    let mut buf = [0 as u8; 16]
+
+    let small: u16 = 0x1234
+    small.write_le_bytes(buf, 1)
+    if buf[1] != 0x34 {
+        return 1
+    }
+    if buf[2] != 0x12 {
+        return 2
+    }
+    if u16::from_le_bytes(buf, 1) != 0x1234 {
+        return 3
+    }
+
+    let wide: u64 = 0x0102030405060708
+    wide.write_le_bytes(buf, 4)
+    if buf[4] != 0x08 {
+        return 4
+    }
+    if buf[11] != 0x01 {
+        return 5
+    }
+    if u64::from_le_bytes(buf, 4) != 0x0102030405060708 {
+        return 6
+    }
+
+    return 0
+}"#,
+    )
+}
+
+#[test]
+fn std_bytes_copy_fill_and_compare_cover_lengths() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.bytes
+
+fun main() -> i32 {
+    let mut dst = [0 as u8; 5]
+    std.bytes.fill(dst, 9)
+    if dst[0] != 9 || dst[4] != 9 {
+        return 1
+    }
+
+    let copied = std.bytes.copy(dst[1:4], b"abc")
+    if copied != 3 {
+        return 2
+    }
+    if dst[0] != 9 || dst[1] != 'a' as u8 || dst[2] != 'b' as u8 || dst[3] != 'c' as u8 || dst[4] != 9 {
+        return 3
+    }
+
+    let mut short = [0 as u8; 2]
+    if std.bytes.copy(short, b"wxyz") != 2 {
+        return 4
+    }
+    if short[0] != 'w' as u8 || short[1] != 'x' as u8 {
+        return 5
+    }
+
+    if std.bytes.compare(b"abc", b"abc") != 0 {
+        return 6
+    }
+    if std.bytes.compare(b"abc", b"abd") >= 0 {
+        return 7
+    }
+    if std.bytes.compare(b"abd", b"abc") <= 0 {
+        return 8
+    }
+    if std.bytes.compare(b"ab", b"abc") >= 0 {
+        return 9
+    }
+    if std.bytes.compare(b"abc", b"ab") <= 0 {
+        return 10
+    }
+
+    return 0
+}"#,
+    )
+}
+
+#[test]
+fn std_bytes_range_checks_panic() -> anyhow::Result<()> {
+    let tempdir = assert_fs::TempDir::new()?;
+    let main = tempdir.child("main.kd");
+    main.write_str(
+        r#"import std.bytes
+
+fun main() -> i32 {
+    let buf = [0 as u8; 1]
+    u16::from_le_bytes(buf, 0)
+    return 0
+}"#,
+    )?;
+
+    let (exe, _) = compile_project(&[main.path()], tempdir.path())?;
+    Command::new(exe.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "panic: u16::from_le_bytes: buffer too small",
+        ));
+
+    Ok(())
+}

--- a/library/src/std/bytes.kd
+++ b/library/src/std/bytes.kd
@@ -1,0 +1,104 @@
+// Byte-slice helpers for binary formats. These functions operate on explicit
+// offsets so callers can work with fixed-size pages and protocol buffers
+// without allocating temporary slices for every field.
+
+fun check_range(len: u64, offset: u64, width: u64, name: str) {
+    // Avoid `offset + width` overflow by subtracting after checking offset.
+    if offset > len || width > len - offset {
+        panic(name)
+    }
+}
+
+impl u16 {
+    // Constructs a u16 from two little-endian bytes starting at `offset`.
+    // This mirrors Rust's `u16::from_le_bytes`, but accepts a slice plus offset
+    // so callers can read fields from fixed-size pages without allocating.
+    export fun from_le_bytes(buf: [u8], offset: u64) -> u16 {
+        check_range(buf.len(), offset, 2, "u16::from_le_bytes: buffer too small")
+        return (buf[offset] as u16) | ((buf[offset + 1] as u16) << 8)
+    }
+
+    // Stores `self` as two little-endian bytes starting at `offset`.
+    // The name uses `write` rather than Rust's `to_le_bytes` because this API
+    // mutates an existing page or protocol buffer instead of returning an array.
+    export fun write_le_bytes(self, buf: mut [u8], offset: u64) {
+        check_range(buf.len(), offset, 2, "u16.write_le_bytes: buffer too small")
+        buf[offset] = self as u8
+        buf[offset + 1] = (self >> 8) as u8
+    }
+}
+
+impl u64 {
+    // Constructs a u64 from eight little-endian bytes starting at `offset`.
+    // This keeps page-header and pointer decoding next to the integer type that
+    // defines the binary representation.
+    export fun from_le_bytes(buf: [u8], offset: u64) -> u64 {
+        check_range(buf.len(), offset, 8, "u64::from_le_bytes: buffer too small")
+        return (buf[offset] as u64) |
+            ((buf[offset + 1] as u64) << 8) |
+            ((buf[offset + 2] as u64) << 16) |
+            ((buf[offset + 3] as u64) << 24) |
+            ((buf[offset + 4] as u64) << 32) |
+            ((buf[offset + 5] as u64) << 40) |
+            ((buf[offset + 6] as u64) << 48) |
+            ((buf[offset + 7] as u64) << 56)
+    }
+
+    // Stores `self` as eight little-endian bytes starting at `offset`.
+    // This is the in-place counterpart to `from_le_bytes` for database pages.
+    export fun write_le_bytes(self, buf: mut [u8], offset: u64) {
+        check_range(buf.len(), offset, 8, "u64.write_le_bytes: buffer too small")
+        buf[offset] = self as u8
+        buf[offset + 1] = (self >> 8) as u8
+        buf[offset + 2] = (self >> 16) as u8
+        buf[offset + 3] = (self >> 24) as u8
+        buf[offset + 4] = (self >> 32) as u8
+        buf[offset + 5] = (self >> 40) as u8
+        buf[offset + 6] = (self >> 48) as u8
+        buf[offset + 7] = (self >> 56) as u8
+    }
+}
+
+// Replaces every byte in `buf` with `value`.
+export fun fill(buf: mut [u8], value: u8) {
+    let mut i = 0
+    while i < buf.len() {
+        buf[i] = value
+        i += 1
+    }
+}
+
+// Copies up to `dst.len()` bytes from `src` and returns the number copied.
+export fun copy(dst: mut [u8], src: [u8]) -> u64 {
+    let n = if dst.len() < src.len() { dst.len() } else { src.len() }
+    let mut i = 0
+    while i < n {
+        dst[i] = src[i]
+        i += 1
+    }
+    return n
+}
+
+// Lexicographically compares byte slices, matching the ordering used by
+// database keys and binary protocol fields.
+export fun compare(left: [u8], right: [u8]) -> i32 {
+    let n = if left.len() < right.len() { left.len() } else { right.len() }
+    let mut i = 0
+    while i < n {
+        if left[i] < right[i] {
+            return -1
+        }
+        if left[i] > right[i] {
+            return 1
+        }
+        i += 1
+    }
+
+    if left.len() < right.len() {
+        return -1
+    }
+    if left.len() > right.len() {
+        return 1
+    }
+    return 0
+}

--- a/library/src/std/bytes.kd
+++ b/library/src/std/bytes.kd
@@ -23,8 +23,10 @@ impl u16 {
     // mutates an existing page or protocol buffer instead of returning an array.
     export fun write_le_bytes(self, buf: mut [u8], offset: u64) {
         check_range(buf.len(), offset, 2, "u16.write_le_bytes: buffer too small")
-        buf[offset] = self as u8
-        buf[offset + 1] = (self >> 8) as u8
+        // Casting to u8 keeps the low 8 bits, so mask after shifting to make
+        // the selected byte explicit.
+        buf[offset] = (self & 0xff) as u8
+        buf[offset + 1] = ((self >> 8) & 0xff) as u8
     }
 }
 
@@ -48,14 +50,16 @@ impl u64 {
     // This is the in-place counterpart to `from_le_bytes` for database pages.
     export fun write_le_bytes(self, buf: mut [u8], offset: u64) {
         check_range(buf.len(), offset, 8, "u64.write_le_bytes: buffer too small")
-        buf[offset] = self as u8
-        buf[offset + 1] = (self >> 8) as u8
-        buf[offset + 2] = (self >> 16) as u8
-        buf[offset + 3] = (self >> 24) as u8
-        buf[offset + 4] = (self >> 32) as u8
-        buf[offset + 5] = (self >> 40) as u8
-        buf[offset + 6] = (self >> 48) as u8
-        buf[offset + 7] = (self >> 56) as u8
+        // Casting to u8 keeps the low 8 bits, so mask after shifting to make
+        // the selected byte explicit.
+        buf[offset] = (self & 0xff) as u8
+        buf[offset + 1] = ((self >> 8) & 0xff) as u8
+        buf[offset + 2] = ((self >> 16) & 0xff) as u8
+        buf[offset + 3] = ((self >> 24) & 0xff) as u8
+        buf[offset + 4] = ((self >> 32) & 0xff) as u8
+        buf[offset + 5] = ((self >> 40) & 0xff) as u8
+        buf[offset + 6] = ((self >> 48) & 0xff) as u8
+        buf[offset + 7] = ((self >> 56) & 0xff) as u8
     }
 }
 


### PR DESCRIPTION
## Summary
- add `std.bytes` with primitive little-endian integer helpers plus byte-slice fill/copy/compare
- expose endian reads as `u16::from_le_bytes` / `u64::from_le_bytes` and endian writes as `value.write_le_bytes(...)`
- cover bytes helpers with driver integration tests

Stacked on #318 for primitive static method resolution.

## Verification
- `cargo fmt --all -- --check`
- `./install.py --no-setenv`
- `cargo test -p kaede_compiler_driver --test bytes -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test --release --no-fail-fast`
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c ./install.py --no-setenv`
- `nix develop -c cargo test -p kaede_compiler_driver --test bytes -- --nocapture`