### PR TITLE
Support primitive static methods

### DIFF
--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -2420,6 +2420,23 @@ fn static_method() -> anyhow::Result<()> {
 }
 
 #[test]
+fn static_method_for_fundamental_type() -> anyhow::Result<()> {
+    let program = r#"impl u16 {
+        fun answer() -> u16 {
+            return 42
+        }
+    }
+
+    fun main() -> i32 {
+        return u16::answer() as i32
+    }"#;
+
+    assert_eq!(exec(program)?, 42);
+
+    Ok(())
+}
+
+#[test]
 fn create_simple_enum() -> anyhow::Result<()> {
     let program = r#"enum Simple {
         A,

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -3113,6 +3113,12 @@ impl SemanticAnalyzer {
             return Ok(expr);
         }
 
+        if let ast::expr::ExprKind::Ty(ty) = &node.lhs.kind {
+            if let Some(fty) = Self::fundamental_type_kind_from_ast_ty(ty) {
+                return self.analyze_static_fundamental_scope_rhs(fty, &node.rhs);
+            }
+        }
+
         let (left, generic_args) = match &node.lhs.kind {
             // Foo::Bar
             ast::expr::ExprKind::Ident(id) => (id, None),
@@ -3268,17 +3274,68 @@ impl SemanticAnalyzer {
         call_node: &ast::expr::FnCall,
     ) -> anyhow::Result<ir::expr::Expr> {
         let method_symbol = self.callee_symbol(call_node)?;
-        let method_name = self.create_method_key(udt.name(), method_symbol, true);
+        self.analyze_static_method_call_by_name(
+            udt.name(),
+            udt.qualified_symbol().module_path().clone(),
+            method_symbol,
+            call_node,
+        )
+    }
 
-        let qualified_method_name =
-            QualifiedSymbol::new(udt.qualified_symbol().module_path().clone(), method_name);
+    fn analyze_static_fundamental_method_call(
+        &mut self,
+        fty: ir_type::FundamentalTypeKind,
+        call_node: &ast::expr::FnCall,
+    ) -> anyhow::Result<ir::expr::Expr> {
+        let method_symbol = self.callee_symbol(call_node)?;
+        self.analyze_static_method_call_by_name(
+            Symbol::from(fty.to_string()),
+            ModulePath::root(),
+            method_symbol,
+            call_node,
+        )
+    }
+
+    fn analyze_static_fundamental_scope_rhs(
+        &mut self,
+        fty: ir_type::FundamentalTypeKind,
+        rhs: &ast::expr::Expr,
+    ) -> anyhow::Result<ir::expr::Expr> {
+        match &rhs.kind {
+            ast::expr::ExprKind::FnCall(right) => {
+                self.analyze_static_fundamental_method_call(fty, right)
+            }
+            _ => {
+                let method_name = Self::rhs_symbol(rhs)
+                    .map(|(name, _)| name)
+                    .unwrap_or_else(|| Symbol::from("<unknown>".to_owned()));
+                Err(SemanticError::NoMethod {
+                    method_name,
+                    parent_name: Symbol::from(fty.to_string()),
+                    span: rhs.span,
+                }
+                .into())
+            }
+        }
+    }
+
+    fn analyze_static_method_call_by_name(
+        &mut self,
+        parent_name: Symbol,
+        module_path: ModulePath,
+        method_symbol: Symbol,
+        call_node: &ast::expr::FnCall,
+    ) -> anyhow::Result<ir::expr::Expr> {
+        let method_name = self.create_method_key(parent_name, method_symbol, true);
+
+        let qualified_method_name = QualifiedSymbol::new(module_path, method_name);
 
         // Lookup method from symbol table
         let method_decl =
             self.lookup_qualified_symbol(qualified_method_name)
                 .ok_or(SemanticError::NoMethod {
                     method_name: method_symbol,
-                    parent_name: udt.name(),
+                    parent_name,
                     span: call_node.span,
                 })?;
 

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -289,21 +289,40 @@ impl SemanticAnalyzer {
         mutability: ir_type::Mutability,
     ) -> ir_type::Ty {
         let make = |kind| ir_type::make_fundamental_type(kind, mutability);
+        make(Self::fundamental_type_kind_from_ast_kind(fty.kind))
+    }
 
-        match fty.kind {
-            ast_type::FundamentalTypeKind::Str => make(ir_type::FundamentalTypeKind::Str),
-            ast_type::FundamentalTypeKind::Bool => make(ir_type::FundamentalTypeKind::Bool),
-            ast_type::FundamentalTypeKind::I8 => make(ir_type::FundamentalTypeKind::I8),
-            ast_type::FundamentalTypeKind::U8 => make(ir_type::FundamentalTypeKind::U8),
-            ast_type::FundamentalTypeKind::I16 => make(ir_type::FundamentalTypeKind::I16),
-            ast_type::FundamentalTypeKind::U16 => make(ir_type::FundamentalTypeKind::U16),
-            ast_type::FundamentalTypeKind::I32 => make(ir_type::FundamentalTypeKind::I32),
-            ast_type::FundamentalTypeKind::U32 => make(ir_type::FundamentalTypeKind::U32),
-            ast_type::FundamentalTypeKind::I64 => make(ir_type::FundamentalTypeKind::I64),
-            ast_type::FundamentalTypeKind::U64 => make(ir_type::FundamentalTypeKind::U64),
-            ast_type::FundamentalTypeKind::F32 => make(ir_type::FundamentalTypeKind::F32),
-            ast_type::FundamentalTypeKind::F64 => make(ir_type::FundamentalTypeKind::F64),
-            ast_type::FundamentalTypeKind::Char => make(ir_type::FundamentalTypeKind::Char),
+    pub(crate) fn fundamental_type_kind_from_ast_ty(
+        ty: &ast_type::Ty,
+    ) -> Option<ir_type::FundamentalTypeKind> {
+        match ty.kind.as_ref() {
+            ast_type::TyKind::Fundamental(fty) => {
+                Some(Self::fundamental_type_kind_from_ast_kind(fty.kind))
+            }
+            ast_type::TyKind::Reference(rty) => {
+                Self::fundamental_type_kind_from_ast_ty(&rty.get_base_type())
+            }
+            _ => None,
+        }
+    }
+
+    fn fundamental_type_kind_from_ast_kind(
+        kind: ast_type::FundamentalTypeKind,
+    ) -> ir_type::FundamentalTypeKind {
+        match kind {
+            ast_type::FundamentalTypeKind::Str => ir_type::FundamentalTypeKind::Str,
+            ast_type::FundamentalTypeKind::Bool => ir_type::FundamentalTypeKind::Bool,
+            ast_type::FundamentalTypeKind::I8 => ir_type::FundamentalTypeKind::I8,
+            ast_type::FundamentalTypeKind::U8 => ir_type::FundamentalTypeKind::U8,
+            ast_type::FundamentalTypeKind::I16 => ir_type::FundamentalTypeKind::I16,
+            ast_type::FundamentalTypeKind::U16 => ir_type::FundamentalTypeKind::U16,
+            ast_type::FundamentalTypeKind::I32 => ir_type::FundamentalTypeKind::I32,
+            ast_type::FundamentalTypeKind::U32 => ir_type::FundamentalTypeKind::U32,
+            ast_type::FundamentalTypeKind::I64 => ir_type::FundamentalTypeKind::I64,
+            ast_type::FundamentalTypeKind::U64 => ir_type::FundamentalTypeKind::U64,
+            ast_type::FundamentalTypeKind::F32 => ir_type::FundamentalTypeKind::F32,
+            ast_type::FundamentalTypeKind::F64 => ir_type::FundamentalTypeKind::F64,
+            ast_type::FundamentalTypeKind::Char => ir_type::FundamentalTypeKind::Char,
         }
     }
 


### PR DESCRIPTION
## Summary
- resolve calls like `u16::from_le_bytes(...)` against primitive `impl` methods
- share static method lookup between user-defined and primitive parent types
- add a codegen regression test for primitive static methods

## Verification
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo test -p kaede_codegen static_method_for_fundamental_type -- --nocapture`
- `nix develop -c cargo clippy -- -D warnings`