### PR TITLE
feat: add local const declarations

### DIFF
--- a/compiler/ast/src/stmt.rs
+++ b/compiler/ast/src/stmt.rs
@@ -46,6 +46,14 @@ pub struct NormalLet {
 }
 
 #[derive(Debug, Clone)]
+pub struct Const {
+    pub name: Ident,
+    pub init: Rc<Expr>,
+    pub ty: Rc<Ty>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
 pub struct TupleUnpack {
     /// None if ignore field
     pub names: Vec<Option<(Ident, Mutability)>>,
@@ -64,6 +72,7 @@ pub struct Stmt {
 pub enum StmtKind {
     Expr(Rc<Expr>),
     Let(Let),
+    Const(Const),
 
     Assign(Box<Assign>),
 }

--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -415,6 +415,19 @@ fn let_statement() -> anyhow::Result<()> {
 }
 
 #[test]
+fn local_const_statement() -> anyhow::Result<()> {
+    let program = r"fun main() -> i32 {
+        const base: i32 = 48
+        const result: i32 = base + 10
+        return result
+    }";
+
+    assert_eq!(exec(program)?, 58);
+
+    Ok(())
+}
+
+#[test]
 fn short_decl_colon_eq() -> anyhow::Result<()> {
     let program = r"fun main() -> i32 {
         x := 48

--- a/compiler/lex/src/lib.rs
+++ b/compiler/lex/src/lib.rs
@@ -167,6 +167,7 @@ impl Cursor<'_> {
                     "fn" => self.create_token(TokenKind::OldFn),
                     "return" => self.create_token(TokenKind::Return),
                     "let" => self.create_token(TokenKind::Let),
+                    "const" => self.create_token(TokenKind::Const),
                     "if" => self.create_token(TokenKind::If),
                     "else" => self.create_token(TokenKind::Else),
                     "loop" => self.create_token(TokenKind::Loop),

--- a/compiler/lex/src/tests.rs
+++ b/compiler/lex/src/tests.rs
@@ -57,6 +57,23 @@ fn multi_floats() {
 }
 
 #[test]
+fn const_keyword() {
+    lex_test(
+        "const answer: i32 = 42",
+        vec![
+            Const,
+            Ident("answer".to_string()),
+            Colon,
+            Ident("i32".to_string()),
+            Eq,
+            Int("42".to_string()),
+            Semi,
+            Eoi,
+        ],
+    );
+}
+
+#[test]
 fn int_dot_ident_is_method_call() {
     // `1.foo` must remain `Int Dot Ident` so method calls on integer literals
     // keep tokenizing correctly.

--- a/compiler/lex/src/token.rs
+++ b/compiler/lex/src/token.rs
@@ -113,6 +113,8 @@ pub enum TokenKind {
     Return,
     /// "let"
     Let,
+    /// "const"
+    Const,
     /// "mut"
     Mut,
     /// "if"
@@ -230,6 +232,7 @@ impl std::fmt::Display for TokenKind {
                 OldFn => "'fn'",
                 Return => "'return'",
                 Let => "'let'",
+                Const => "'const'",
                 Mut => "'mut'",
                 If => "'if'",
                 Else => "'else'",

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -356,6 +356,7 @@ fn semantic_error_span(err: &SemanticError) -> Option<Span> {
         | SemanticError::IndexOutOfRange { span, .. }
         | SemanticError::ArrayRepeatCountNotConst { span }
         | SemanticError::ArrayRepeatCountTooLarge { span, .. }
+        | SemanticError::ConstInitializerNotConst { span }
         | SemanticError::NumberOfTupleFieldsDoesNotMatch { span, .. }
         | SemanticError::IfMustHaveElseUsedAsExpr { span }
         | SemanticError::IfAndElseHaveIncompatibleTypes { span, .. }

--- a/compiler/parse/src/stmt.rs
+++ b/compiler/parse/src/stmt.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use kaede_ast::{
     expr::{Expr, ExprKind},
-    stmt::{Assign, AssignOp, Block, Let, LetKind, NormalLet, Stmt, StmtKind, TupleUnpack},
+    stmt::{Assign, AssignOp, Block, Const, Let, LetKind, NormalLet, Stmt, StmtKind, TupleUnpack},
 };
 use kaede_ast_type::{Mutability, Ty};
 use kaede_lex::token::TokenKind;
@@ -49,6 +49,14 @@ impl Parser {
             return Ok(Stmt {
                 span: l.span,
                 kind: StmtKind::Let(l),
+            });
+        }
+
+        if self.check(&TokenKind::Const) {
+            let const_ = self.const_()?;
+            return Ok(Stmt {
+                span: const_.span,
+                kind: StmtKind::Const(const_),
             });
         }
 
@@ -204,6 +212,25 @@ impl Parser {
                 init,
                 ty: ty.into(),
             }),
+            span,
+        })
+    }
+
+    fn const_(&mut self) -> ParseResult<Const> {
+        let start = self.consume(&TokenKind::Const).unwrap().start;
+        let name = self.ident()?;
+
+        self.consume(&TokenKind::Colon)?;
+        let ty = self.ty()?;
+
+        self.consume(&TokenKind::Eq)?;
+        let init = self.expr()?;
+        let span = self.new_span(start, init.span.finish);
+
+        Ok(Const {
+            name,
+            init: init.into(),
+            ty: ty.into(),
             span,
         })
     }

--- a/compiler/semantic/src/error.rs
+++ b/compiler/semantic/src/error.rs
@@ -101,6 +101,9 @@ pub enum SemanticError {
     #[error("{}:{}:{} array repeat count `{}` is too large", span.file, span.start.line, span.start.column, value)]
     ArrayRepeatCountTooLarge { span: Span, value: u64 },
 
+    #[error("{}:{}:{} const initializer must be a compile-time constant", span.file, span.start.line, span.start.column)]
+    ConstInitializerNotConst { span: Span },
+
     #[error("{}:{}:{} number of tuple fields does not match: `{}` vs `{}`", span.file, span.start.line, span.start.column, lens.0, lens.1)]
     NumberOfTupleFieldsDoesNotMatch { lens: (usize, usize), span: Span },
 

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -817,9 +817,7 @@ impl SemanticAnalyzer {
                 self.insert_symbol_to_current_scope(
                     name,
                     SymbolTableValue::new(
-                        SymbolTableValueKind::Variable(VariableInfo {
-                            ty: variant_ty.clone(),
-                        }),
+                        SymbolTableValueKind::Variable(VariableInfo::new(variant_ty.clone())),
                         self.current_module_path().clone(),
                     ),
                     current_arm.pattern.span,
@@ -2214,7 +2212,7 @@ impl SemanticAnalyzer {
 
             SymbolTableValueKind::Generic(info) => self.analyze_generic_fn_call(info, node),
 
-            SymbolTableValueKind::Variable(VariableInfo { ty }) => {
+            SymbolTableValueKind::Variable(VariableInfo { ty, .. }) => {
                 self.analyze_callable_value(node, callee.symbol(), ty.clone(), None)
             }
 
@@ -2846,7 +2844,7 @@ impl SemanticAnalyzer {
             self.insert_symbol_to_current_scope(
                 param.symbol(),
                 SymbolTableValue::new(
-                    SymbolTableValueKind::Variable(VariableInfo { ty: ty.clone() }),
+                    SymbolTableValueKind::Variable(VariableInfo::new(ty.clone())),
                     self.current_module_path().clone(),
                 ),
                 param.span(),
@@ -4234,7 +4232,7 @@ impl SemanticAnalyzer {
         primary
             .or(fallback)
             .map(|(value, depth)| match &value.borrow().kind {
-                SymbolTableValueKind::Variable(VariableInfo { ty }) => {
+                SymbolTableValueKind::Variable(VariableInfo { ty, .. }) => {
                     self.register_capture(node.symbol(), depth);
                     Ok(ir::expr::Expr {
                         kind: ir::expr::ExprKind::Variable(ir::expr::Variable {

--- a/compiler/semantic/src/stmt.rs
+++ b/compiler/semantic/src/stmt.rs
@@ -23,6 +23,8 @@ impl SemanticAnalyzer {
                 }
             },
 
+            StmtKind::Const(node) => ir::stmt::Stmt::Let(self.analyze_const(node)?),
+
             StmtKind::Assign(node) => ir::stmt::Stmt::Assign(self.analyze_assign(node)?),
         })
     }
@@ -108,7 +110,7 @@ impl SemanticAnalyzer {
             self.insert_symbol_to_current_scope(
                 node.name.symbol(),
                 SymbolTableValue::new(
-                    SymbolTableValueKind::Variable(VariableInfo { ty: var_ty.clone() }),
+                    SymbolTableValueKind::Variable(VariableInfo::new(var_ty.clone())),
                     self.current_module_path().clone(),
                 ),
                 span,
@@ -122,6 +124,81 @@ impl SemanticAnalyzer {
             })
         } else {
             todo!()
+        }
+    }
+
+    fn analyze_const(&mut self, node: &ast::stmt::Const) -> anyhow::Result<ir::stmt::Let> {
+        if !self.is_const_initializer(&node.init) {
+            return Err(SemanticError::ConstInitializerNotConst {
+                span: node.init.span,
+            }
+            .into());
+        }
+
+        let annotated = self.analyze_type(&node.ty)?;
+        let init = self.analyze_expr_with_expected_type(&node.init, annotated.clone())?;
+        let const_ty = ir::ty::change_mutability_dup(annotated, ir::ty::Mutability::Not);
+
+        self.insert_symbol_to_current_scope(
+            node.name.symbol(),
+            SymbolTableValue::new(
+                SymbolTableValueKind::Variable(VariableInfo::new_const(const_ty.clone())),
+                self.current_module_path().clone(),
+            ),
+            node.span,
+        )?;
+
+        // Local consts share the existing immutable-local IR. The extra
+        // const-specific rules are enforced before this lowering step.
+        Ok(ir::stmt::Let {
+            name: node.name.symbol(),
+            ty: const_ty,
+            init: Some(init),
+            span: node.span,
+        })
+    }
+
+    fn is_const_initializer(&self, expr: &ast::expr::Expr) -> bool {
+        use ast::expr::{BinaryKind, ExprKind};
+
+        match &expr.kind {
+            ExprKind::Int(_)
+            | ExprKind::Float(_)
+            | ExprKind::StringLiteral(_)
+            | ExprKind::ByteStringLiteral(_)
+            | ExprKind::ByteLiteral(_)
+            | ExprKind::CharLiteral(_)
+            | ExprKind::True
+            | ExprKind::False => true,
+
+            ExprKind::Ident(ident) => self
+                .lookup_symbol_with_depth(ident.symbol())
+                .map(|(value, _)| match &value.borrow().kind {
+                    SymbolTableValueKind::Variable(info) => info.is_const,
+                    _ => false,
+                })
+                .unwrap_or(false),
+
+            ExprKind::LogicalNot(node) => self.is_const_initializer(&node.operand),
+            ExprKind::BitNot(node) => self.is_const_initializer(&node.operand),
+
+            ExprKind::Binary(node) => {
+                if matches!(node.kind, BinaryKind::Access | BinaryKind::ScopeResolution) {
+                    return false;
+                }
+
+                if matches!(node.kind, BinaryKind::Cast) {
+                    return self.is_const_initializer(&node.lhs);
+                }
+
+                self.is_const_initializer(&node.lhs) && self.is_const_initializer(&node.rhs)
+            }
+
+            ExprKind::TupleLiteral(node) => {
+                node.elements.iter().all(|e| self.is_const_initializer(e))
+            }
+
+            _ => false,
         }
     }
 
@@ -165,9 +242,9 @@ impl SemanticAnalyzer {
                     self.insert_symbol_to_current_scope(
                         name,
                         SymbolTableValue::new(
-                            SymbolTableValueKind::Variable(VariableInfo {
-                                ty: element_types[index].clone(),
-                            }),
+                            SymbolTableValueKind::Variable(VariableInfo::new(
+                                element_types[index].clone(),
+                            )),
                             self.current_module_path().clone(),
                         ),
                         node.span,

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -743,9 +743,7 @@ impl SemanticAnalyzer {
             let mut symbol_table = SymbolTable::new();
             for param in fn_decl.params.iter() {
                 let symbol_table_value = SymbolTableValue::new(
-                    SymbolTableValueKind::Variable(VariableInfo {
-                        ty: param.ty.clone(),
-                    }),
+                    SymbolTableValueKind::Variable(VariableInfo::new(param.ty.clone())),
                     self.current_module_path().clone(),
                 );
 

--- a/compiler/semantic/tests/stmt.rs
+++ b/compiler/semantic/tests/stmt.rs
@@ -59,3 +59,43 @@ fn let_and_access() -> anyhow::Result<()> {
     )?;
     Ok(())
 }
+
+#[test]
+fn local_const() -> anyhow::Result<()> {
+    semantic_analyze(
+        "fun f() -> i32 {
+            const base: i32 = 48
+            const result: i32 = base + 10
+            return result
+        }
+    ",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn local_const_rejects_runtime_initializer() -> anyhow::Result<()> {
+    semantic_analyze_expect_error(
+        "fun value() -> i32 {
+            return 1
+        }
+
+        fun f() {
+            const x: i32 = value()
+        }
+    ",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn local_const_rejects_assignment() -> anyhow::Result<()> {
+    semantic_analyze_expect_error(
+        "fun f() {
+            const x: i32 = 1
+            x = 2
+        }
+    ",
+    )?;
+    Ok(())
+}

--- a/compiler/symbol_table/src/lib.rs
+++ b/compiler/symbol_table/src/lib.rs
@@ -143,6 +143,22 @@ impl GenericInfo {
 #[derive(Debug, Clone)]
 pub struct VariableInfo {
     pub ty: Rc<ir_type::Ty>,
+    /// True for `const` bindings. They still occupy the variable namespace, but
+    /// semantic analysis uses this bit to validate const initializers.
+    pub is_const: bool,
+}
+
+impl VariableInfo {
+    pub fn new(ty: Rc<ir_type::Ty>) -> Self {
+        Self {
+            ty,
+            is_const: false,
+        }
+    }
+
+    pub fn new_const(ty: Rc<ir_type::Ty>) -> Self {
+        Self { ty, is_const: true }
+    }
 }
 
 #[derive(Debug)]

--- a/website/docs/language/overview.md
+++ b/website/docs/language/overview.md
@@ -53,6 +53,7 @@ Kaede supports both the short declaration form and `let` bindings:
 vec := Vector<i32>::new()
 mut app := std.net.http.App::new()
 let count: i32 = 3
+const page_size: u64 = 4096
 ```
 
 In practice, current Kaede code tends to use:
@@ -60,8 +61,9 @@ In practice, current Kaede code tends to use:
 - `:=` for local bindings when the type is obvious from the right-hand side
 - `mut ... :=` for mutable locals with inferred types
 - `let` when you want the explicit `let` form, especially with a type annotation such as `let count: i32 = 3`
+- `const` for typed local compile-time constants
 
-`let x = 1` and `let mut x = 1` are also valid.
+`let x = 1` and `let mut x = 1` are also valid. `const` currently requires a type annotation and a compile-time constant initializer.
 
 ## Functions and return types
 


### PR DESCRIPTION
## Summary

- add `const NAME: Ty = expr` as a typed local declaration
- reject runtime expressions in const initializers while allowing literals, const references, casts, unary operators, binary operators, and tuple literals built from const expressions
- track const bindings in semantic symbol metadata and lower them to existing immutable local IR
- document local const syntax in the language overview

Refs #321

## Verification

- `nix develop -c cargo fmt --all`
- `nix develop -c cargo clippy -- -D warnings`
- `nix develop -c cargo test -p kaede_lex const_keyword`
- `nix develop -c cargo test -p kaede_semantic local_const`
- `nix develop -c cargo test -p kaede_codegen local_const_statement`
- `nix develop -c cargo test --release --no-fail-fast`
