### PR TITLE
feat: allow integer consts in array repeat counts

### DIFF
--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -424,6 +424,14 @@ fn local_const_statement() -> anyhow::Result<()> {
 
     assert_eq!(exec(program)?, 58);
 
+    let program = r"fun main() -> i32 {
+        const len: u32 = 4
+        let xs = [58; len]
+        return xs[3]
+    }";
+
+    assert_eq!(exec(program)?, 58);
+
     Ok(())
 }
 

--- a/compiler/semantic/src/const_eval.rs
+++ b/compiler/semantic/src/const_eval.rs
@@ -1,0 +1,96 @@
+use kaede_ast as ast;
+use kaede_symbol_table::{ConstValue, SymbolTableValueKind};
+
+use crate::SemanticAnalyzer;
+
+impl SemanticAnalyzer {
+    pub(crate) fn is_const_initializer(&self, expr: &ast::expr::Expr) -> bool {
+        use ast::expr::{BinaryKind, ExprKind};
+
+        match &expr.kind {
+            ExprKind::Int(_)
+            | ExprKind::Float(_)
+            | ExprKind::StringLiteral(_)
+            | ExprKind::ByteStringLiteral(_)
+            | ExprKind::ByteLiteral(_)
+            | ExprKind::CharLiteral(_)
+            | ExprKind::True
+            | ExprKind::False => true,
+
+            ExprKind::Ident(ident) => self
+                .lookup_symbol_with_depth(ident.symbol())
+                .map(|(value, _)| match &value.borrow().kind {
+                    SymbolTableValueKind::Variable(info) => info.is_const,
+                    _ => false,
+                })
+                .unwrap_or(false),
+
+            ExprKind::LogicalNot(node) => self.is_const_initializer(&node.operand),
+            ExprKind::BitNot(node) => self.is_const_initializer(&node.operand),
+
+            ExprKind::Binary(node) => {
+                if matches!(node.kind, BinaryKind::Access | BinaryKind::ScopeResolution) {
+                    return false;
+                }
+
+                if matches!(node.kind, BinaryKind::Cast) {
+                    return self.is_const_initializer(&node.lhs);
+                }
+
+                self.is_const_initializer(&node.lhs) && self.is_const_initializer(&node.rhs)
+            }
+
+            ExprKind::TupleLiteral(node) => {
+                node.elements.iter().all(|e| self.is_const_initializer(e))
+            }
+
+            _ => false,
+        }
+    }
+
+    pub(crate) fn evaluate_integer_const_expr(&self, expr: &ast::expr::Expr) -> Option<i128> {
+        use ast::expr::{BinaryKind, ExprKind};
+
+        match &expr.kind {
+            ExprKind::Int(int) => Some(i128::from(int.as_u64())),
+
+            ExprKind::Ident(ident) => {
+                self.lookup_symbol_with_depth(ident.symbol())
+                    .and_then(|(value, _)| match &value.borrow().kind {
+                        SymbolTableValueKind::Variable(info) => info
+                            .const_value
+                            .as_ref()
+                            .map(|ConstValue::Integer(value)| *value),
+                        _ => None,
+                    })
+            }
+
+            ExprKind::BitNot(node) => self.evaluate_integer_const_expr(&node.operand).map(|v| !v),
+
+            ExprKind::Binary(node) => {
+                if matches!(node.kind, BinaryKind::Cast) {
+                    return self.evaluate_integer_const_expr(&node.lhs);
+                }
+
+                let lhs = self.evaluate_integer_const_expr(&node.lhs)?;
+                let rhs = self.evaluate_integer_const_expr(&node.rhs)?;
+
+                match node.kind {
+                    BinaryKind::Add => lhs.checked_add(rhs),
+                    BinaryKind::Sub => lhs.checked_sub(rhs),
+                    BinaryKind::Mul => lhs.checked_mul(rhs),
+                    BinaryKind::Div => lhs.checked_div(rhs),
+                    BinaryKind::Rem => lhs.checked_rem(rhs),
+                    BinaryKind::BitOr => Some(lhs | rhs),
+                    BinaryKind::BitXor => Some(lhs ^ rhs),
+                    BinaryKind::BitAnd => Some(lhs & rhs),
+                    BinaryKind::Shl => u32::try_from(rhs).ok().and_then(|rhs| lhs.checked_shl(rhs)),
+                    BinaryKind::Shr => u32::try_from(rhs).ok().and_then(|rhs| lhs.checked_shr(rhs)),
+                    _ => None,
+                }
+            }
+
+            _ => None,
+        }
+    }
+}

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -2659,21 +2659,21 @@ impl SemanticAnalyzer {
     }
 
     fn evaluate_array_repeat_count(&self, count: &ast::expr::Expr) -> anyhow::Result<u32> {
-        match &count.kind {
-            ast::expr::ExprKind::Int(int) => {
-                let value = int.as_u64();
+        let Some(value) = self.evaluate_integer_const_expr(count) else {
+            return Err(SemanticError::ArrayRepeatCountNotConst { span: count.span }.into());
+        };
 
-                let value =
-                    u32::try_from(value).map_err(|_| SemanticError::ArrayRepeatCountTooLarge {
-                        span: count.span,
-                        value,
-                    })?;
-
-                Ok(value)
-            }
-
-            _ => Err(SemanticError::ArrayRepeatCountNotConst { span: count.span }.into()),
+        if value < 0 {
+            return Err(SemanticError::ArrayRepeatCountNotConst { span: count.span }.into());
         }
+
+        u32::try_from(value).map_err(|_| {
+            SemanticError::ArrayRepeatCountTooLarge {
+                span: count.span,
+                value: u64::try_from(value).unwrap_or(u64::MAX),
+            }
+            .into()
+        })
     }
 
     fn analyze_int(&mut self, node: &ast::expr::Int) -> anyhow::Result<ir::expr::Expr> {

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -22,6 +22,7 @@ use kaede_symbol_table::{
     SymbolTableValueKind,
 };
 
+mod const_eval;
 mod context;
 mod error;
 mod expr;

--- a/compiler/semantic/src/stmt.rs
+++ b/compiler/semantic/src/stmt.rs
@@ -1,5 +1,5 @@
 use crate::{SemanticAnalyzer, SemanticError};
-use kaede_symbol_table::{SymbolTableValue, SymbolTableValueKind, VariableInfo};
+use kaede_symbol_table::{ConstValue, SymbolTableValue, SymbolTableValueKind, VariableInfo};
 
 use kaede_ast as ast;
 use kaede_ir::{self as ir, stmt::AssignOp};
@@ -138,11 +138,17 @@ impl SemanticAnalyzer {
         let annotated = self.analyze_type(&node.ty)?;
         let init = self.analyze_expr_with_expected_type(&node.init, annotated.clone())?;
         let const_ty = ir::ty::change_mutability_dup(annotated, ir::ty::Mutability::Not);
+        let const_value = self
+            .evaluate_integer_const_expr(&node.init)
+            .map(ConstValue::Integer);
 
         self.insert_symbol_to_current_scope(
             node.name.symbol(),
             SymbolTableValue::new(
-                SymbolTableValueKind::Variable(VariableInfo::new_const(const_ty.clone())),
+                SymbolTableValueKind::Variable(VariableInfo::new_const(
+                    const_ty.clone(),
+                    const_value,
+                )),
                 self.current_module_path().clone(),
             ),
             node.span,
@@ -156,50 +162,6 @@ impl SemanticAnalyzer {
             init: Some(init),
             span: node.span,
         })
-    }
-
-    fn is_const_initializer(&self, expr: &ast::expr::Expr) -> bool {
-        use ast::expr::{BinaryKind, ExprKind};
-
-        match &expr.kind {
-            ExprKind::Int(_)
-            | ExprKind::Float(_)
-            | ExprKind::StringLiteral(_)
-            | ExprKind::ByteStringLiteral(_)
-            | ExprKind::ByteLiteral(_)
-            | ExprKind::CharLiteral(_)
-            | ExprKind::True
-            | ExprKind::False => true,
-
-            ExprKind::Ident(ident) => self
-                .lookup_symbol_with_depth(ident.symbol())
-                .map(|(value, _)| match &value.borrow().kind {
-                    SymbolTableValueKind::Variable(info) => info.is_const,
-                    _ => false,
-                })
-                .unwrap_or(false),
-
-            ExprKind::LogicalNot(node) => self.is_const_initializer(&node.operand),
-            ExprKind::BitNot(node) => self.is_const_initializer(&node.operand),
-
-            ExprKind::Binary(node) => {
-                if matches!(node.kind, BinaryKind::Access | BinaryKind::ScopeResolution) {
-                    return false;
-                }
-
-                if matches!(node.kind, BinaryKind::Cast) {
-                    return self.is_const_initializer(&node.lhs);
-                }
-
-                self.is_const_initializer(&node.lhs) && self.is_const_initializer(&node.rhs)
-            }
-
-            ExprKind::TupleLiteral(node) => {
-                node.elements.iter().all(|e| self.is_const_initializer(e))
-            }
-
-            _ => false,
-        }
     }
 
     fn analyze_tuple_unpacking(

--- a/compiler/semantic/tests/stmt.rs
+++ b/compiler/semantic/tests/stmt.rs
@@ -74,6 +74,19 @@ fn local_const() -> anyhow::Result<()> {
 }
 
 #[test]
+fn local_const_array_repeat_count() -> anyhow::Result<()> {
+    semantic_analyze(
+        "fun f() {
+            const base: u32 = 2
+            const len: u32 = base + 2
+            let _ = [0; len]
+        }
+    ",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn local_const_rejects_runtime_initializer() -> anyhow::Result<()> {
     semantic_analyze_expect_error(
         "fun value() -> i32 {

--- a/compiler/symbol_table/src/lib.rs
+++ b/compiler/symbol_table/src/lib.rs
@@ -141,11 +141,19 @@ impl GenericInfo {
 }
 
 #[derive(Debug, Clone)]
+pub enum ConstValue {
+    Integer(i128),
+}
+
+#[derive(Debug, Clone)]
 pub struct VariableInfo {
     pub ty: Rc<ir_type::Ty>,
     /// True for `const` bindings. They still occupy the variable namespace, but
     /// semantic analysis uses this bit to validate const initializers.
     pub is_const: bool,
+    /// Compile-time value for const bindings where semantic analysis can fold
+    /// the initializer. Non-integer consts currently do not need a stored value.
+    pub const_value: Option<ConstValue>,
 }
 
 impl VariableInfo {
@@ -153,11 +161,16 @@ impl VariableInfo {
         Self {
             ty,
             is_const: false,
+            const_value: None,
         }
     }
 
-    pub fn new_const(ty: Rc<ir_type::Ty>) -> Self {
-        Self { ty, is_const: true }
+    pub fn new_const(ty: Rc<ir_type::Ty>, const_value: Option<ConstValue>) -> Self {
+        Self {
+            ty,
+            is_const: true,
+            const_value,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- store folded integer values for local const bindings in semantic symbol metadata
- allow integer const references and integer const expressions in array repeat counts, e.g. `[0; PAGE_SIZE]`
- keep non-integer consts valid as local const bindings, but only integer consts are usable where a compile-time size is required
- add semantic/codegen coverage and document the size use case

Refs #321

## Verification

- `nix develop -c cargo fmt --all`
- `nix develop -c cargo clippy -- -D warnings`
- `nix develop -c cargo test -p kaede_semantic local_const`
- `nix develop -c cargo test -p kaede_codegen local_const_statement`
- `nix develop -c cargo test --release --no-fail-fast`
