### PR TITLE
fix: preserve generated generic substitutions

### DIFF
--- a/compiler/ir/src/ty.rs
+++ b/compiler/ir/src/ty.rs
@@ -577,6 +577,13 @@ impl GenericInstanceInfo {
     }
 }
 
+pub fn collect_type_var_ids_in_order(ty: &Rc<Ty>) -> Vec<VarId> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    collect_type_var_ids(ty, &mut out, &mut seen);
+    out
+}
+
 fn collect_type_var_ids(ty: &Rc<Ty>, out: &mut Vec<VarId>, seen: &mut HashSet<VarId>) {
     match ty.kind.as_ref() {
         TyKind::Var(id) => {

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -286,6 +286,8 @@ impl SemanticAnalyzer {
             }
         }
 
+        self.ensure_generated_impl_method_body(&callee)?;
+
         let params_without_self = if callee.params.is_empty() {
             &[][..]
         } else {
@@ -2327,8 +2329,6 @@ impl SemanticAnalyzer {
             }
         };
 
-        self.generate_slice_impl(elem_ty.clone())?;
-
         let start_expr = match &node.start {
             Some(expr) => {
                 let analyzed = self.analyze_expr(expr)?;
@@ -3361,6 +3361,9 @@ impl SemanticAnalyzer {
             SymbolTableValueKind::Function(fn_) => fn_.clone(),
             _ => unreachable!(),
         };
+        drop(borrowed);
+
+        self.ensure_generated_impl_method_body(&method_decl)?;
 
         let (ordered_args, variadic_args) = self.resolve_call_arguments(
             &method_decl
@@ -4054,6 +4057,8 @@ impl SemanticAnalyzer {
                 return Err(SemanticError::CannotCallMutableMethodOnImmutableValue { span }.into());
             }
         }
+
+        self.ensure_generated_impl_method_body(&callee)?;
 
         let params_without_self = if callee.params.is_empty() {
             &[][..]

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -701,13 +701,25 @@ impl SemanticAnalyzer {
         self.pending_generic_instance.clone()
     }
 
-    fn generated_args_contain(
+    fn instantiation_already_registered(
         instantiations: &[Vec<Rc<ir_type::Ty>>],
         generic_args: &[Rc<ir_type::Ty>],
+        matches: impl Fn(&[Rc<ir_type::Ty>], &[Rc<ir_type::Ty>]) -> bool,
     ) -> bool {
         instantiations
             .iter()
-            .any(|args| Self::generic_args_match_exactly(args, generic_args))
+            .any(|args| matches(args, generic_args))
+    }
+
+    fn generic_instantiation_already_registered(
+        instantiations: &[Vec<Rc<ir_type::Ty>>],
+        generic_args: &[Rc<ir_type::Ty>],
+    ) -> bool {
+        Self::instantiation_already_registered(
+            instantiations,
+            generic_args,
+            Self::generic_args_match_exactly,
+        )
     }
 
     fn generic_args_match_exactly(left: &[Rc<ir_type::Ty>], right: &[Rc<ir_type::Ty>]) -> bool {
@@ -740,9 +752,11 @@ impl SemanticAnalyzer {
         instantiations: &[Vec<Rc<ir_type::Ty>>],
         generic_args: &[Rc<ir_type::Ty>],
     ) -> bool {
-        instantiations
-            .iter()
-            .any(|args| Self::slice_generic_args_match(args, generic_args))
+        Self::instantiation_already_registered(
+            instantiations,
+            generic_args,
+            Self::slice_generic_args_match,
+        )
     }
 
     fn apply_substitutions_to_generated_generics(&mut self) {

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -64,8 +64,8 @@ pub struct AnalyzeOptions {
 pub struct SliceIntrinsic {
     pub impl_info: GenericImplInfo,
     pub defining_module: ModulePath,
-    // Slice impl bodies are emitted eagerly when slice methods are needed.
-    pub generated_args: Vec<Vec<Rc<ir_type::Ty>>>,
+    /// Synthetic origin for `GenericInstanceInfo` on generated slice method declarations.
+    pub origin: QualifiedSymbol,
 }
 
 pub struct SemanticAnalyzer {
@@ -720,6 +720,29 @@ impl SemanticAnalyzer {
                     (ir_type::TyKind::Var(_), _) | (_, ir_type::TyKind::Var(_)) => false,
                     _ => a.kind == b.kind,
                 })
+    }
+
+    /// Slice monomorphization treats any two unresolved type variables as the same
+    /// instantiation so we only register `slice<_>` method declarations once.
+    fn slice_generic_args_match(left: &[Rc<ir_type::Ty>], right: &[Rc<ir_type::Ty>]) -> bool {
+        left.len() == right.len()
+            && left
+                .iter()
+                .zip(right)
+                .all(|(a, b)| match (a.kind.as_ref(), b.kind.as_ref()) {
+                    (ir_type::TyKind::Var(_), ir_type::TyKind::Var(_)) => true,
+                    (ir_type::TyKind::Var(_), _) | (_, ir_type::TyKind::Var(_)) => false,
+                    _ => a.kind == b.kind,
+                })
+    }
+
+    fn slice_instantiation_already_registered(
+        instantiations: &[Vec<Rc<ir_type::Ty>>],
+        generic_args: &[Rc<ir_type::Ty>],
+    ) -> bool {
+        instantiations
+            .iter()
+            .any(|args| Self::slice_generic_args_match(args, generic_args))
     }
 
     fn apply_substitutions_to_generated_generics(&mut self) {

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -80,7 +80,8 @@ pub struct SemanticAnalyzer {
     infer_context: InferContext,
     closure_capture_stack: Vec<ClosureCapture>,
     temp_symbol_counter: usize,
-    generic_fn_substitutions: HashMap<QualifiedSymbol, HashMap<ir_type::VarId, Rc<ir_type::Ty>>>,
+    generated_callable_substitutions:
+        HashMap<QualifiedSymbol, HashMap<ir_type::VarId, Rc<ir_type::Ty>>>,
     pending_generic_instance: Option<ir_type::GenericInstanceInfo>,
     slice_intrinsic: Option<SliceIntrinsic>,
 }
@@ -333,7 +334,7 @@ impl SemanticAnalyzer {
             infer_context: InferContext::default(),
             closure_capture_stack: Vec::new(),
             temp_symbol_counter: 0,
-            generic_fn_substitutions: HashMap::new(),
+            generated_callable_substitutions: HashMap::new(),
             pending_generic_instance: None,
             slice_intrinsic: None,
         }
@@ -360,7 +361,7 @@ impl SemanticAnalyzer {
             infer_context: InferContext::default(),
             closure_capture_stack: Vec::new(),
             temp_symbol_counter: 0,
-            generic_fn_substitutions: HashMap::new(),
+            generated_callable_substitutions: HashMap::new(),
             slice_intrinsic: None,
             pending_generic_instance: None,
         }
@@ -661,12 +662,12 @@ impl SemanticAnalyzer {
         compile_unit
     }
 
-    fn merge_generic_fn_substitutions(
+    fn merge_generated_callable_substitutions(
         &mut self,
         substitutions: HashMap<QualifiedSymbol, HashMap<ir_type::VarId, Rc<ir_type::Ty>>>,
     ) {
         for (name, subst) in substitutions {
-            self.generic_fn_substitutions
+            self.generated_callable_substitutions
                 .entry(name)
                 .or_default()
                 .extend(subst);
@@ -688,13 +689,13 @@ impl SemanticAnalyzer {
         self.pending_generic_instance.clone()
     }
 
-    fn apply_substitutions_to_generated_generic_functions(&mut self) {
-        if self.generic_fn_substitutions.is_empty() {
+    fn apply_substitutions_to_generated_generics(&mut self) {
+        if self.generated_callable_substitutions.is_empty() {
             return;
         }
 
         let global_subst = self
-            .generic_fn_substitutions
+            .generated_callable_substitutions
             .values()
             .flat_map(|m| m.iter())
             .map(|(k, v)| (*k, v.clone()))
@@ -711,7 +712,7 @@ impl SemanticAnalyzer {
                             substituter.apply_block(body);
                         }
                     }
-                    if let Some(subst) = self.generic_fn_substitutions.get(&fn_.decl.name) {
+                    if let Some(subst) = self.generated_callable_substitutions.get(&fn_.decl.name) {
                         let substituter = GenericSubstituter::new(subst);
                         substituter.apply_fn_decl(&mut fn_.decl);
                         if let Some(body) = &mut fn_.body {
@@ -745,7 +746,9 @@ impl SemanticAnalyzer {
                                 substituter.apply_block(body);
                             }
                         }
-                        if let Some(subst) = self.generic_fn_substitutions.get(&method.decl.name) {
+                        if let Some(subst) =
+                            self.generated_callable_substitutions.get(&method.decl.name)
+                        {
                             let substituter = GenericSubstituter::new(subst);
                             substituter.apply_fn_decl(&mut method.decl);
                             if let Some(body) = &mut method.body {
@@ -1193,7 +1196,9 @@ impl SemanticAnalyzer {
 
         // Apply inferred types back to the IR
         inferrer.apply_block(body)?;
-        self.merge_generic_fn_substitutions(inferrer.into_generic_fn_substitutions());
+        self.merge_generated_callable_substitutions(
+            inferrer.into_generated_callable_substitutions(),
+        );
 
         Ok(())
     }
@@ -1237,7 +1242,9 @@ impl SemanticAnalyzer {
         }
 
         inferrer.apply_block(body)?;
-        self.merge_generic_fn_substitutions(inferrer.into_generic_fn_substitutions());
+        self.merge_generated_callable_substitutions(
+            inferrer.into_generated_callable_substitutions(),
+        );
 
         Ok(())
     }
@@ -1309,7 +1316,7 @@ impl SemanticAnalyzer {
             self.build_main_function(&mut top_level_irs)?;
         }
 
-        self.apply_substitutions_to_generated_generic_functions();
+        self.apply_substitutions_to_generated_generics();
         self.infer_generated_generic_bodies_after_substitution()?;
 
         Ok(

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -64,12 +64,16 @@ pub struct AnalyzeOptions {
 pub struct SliceIntrinsic {
     pub impl_info: GenericImplInfo,
     pub defining_module: ModulePath,
+    // Slice impl bodies are emitted eagerly when slice methods are needed.
+    pub generated_args: Vec<Vec<Rc<ir_type::Ty>>>,
 }
 
 pub struct SemanticAnalyzer {
     modules: HashMap<ModulePath, ModuleContext>,
     context: AnalysisContext,
     generated_generics: Vec<ir::top::TopLevel>,
+    // Generated impl method bodies are emitted lazily when a method declaration is referenced.
+    generated_impl_method_bodies: HashSet<QualifiedSymbol>,
     generating_generics: HashSet<Symbol>,
     imported_module_paths: HashSet<PathBuf>,
     imported_rust_crates: HashSet<Symbol>,
@@ -324,6 +328,7 @@ impl SemanticAnalyzer {
             modules: HashMap::from([(module_path, module_context)]),
             context,
             generated_generics: Vec::new(),
+            generated_impl_method_bodies: HashSet::new(),
             generating_generics: HashSet::new(),
             imported_module_paths: HashSet::new(),
             imported_rust_crates: HashSet::new(),
@@ -351,6 +356,7 @@ impl SemanticAnalyzer {
             modules: HashMap::from([(module_path, module_context)]),
             context,
             generated_generics: Vec::new(),
+            generated_impl_method_bodies: HashSet::new(),
             generating_generics: HashSet::new(),
             imported_module_paths: HashSet::new(),
             imported_rust_crates: HashSet::new(),
@@ -654,12 +660,18 @@ impl SemanticAnalyzer {
     fn inject_generated_generics_to_compile_unit(
         &mut self,
         mut compile_unit: ir::CompileUnit,
-    ) -> ir::CompileUnit {
+    ) -> anyhow::Result<ir::CompileUnit> {
         for top_level in self.generated_generics.iter() {
+            if let Some(name) = Self::unresolved_generated_callable_name(top_level) {
+                let name = name.mangle();
+                anyhow::bail!(
+                    "internal compiler error: generated callable `{name}` still has unresolved type variables after inference",
+                );
+            }
             compile_unit.top_levels.push(top_level.clone());
         }
 
-        compile_unit
+        Ok(compile_unit)
     }
 
     fn merge_generated_callable_substitutions(
@@ -687,6 +699,27 @@ impl SemanticAnalyzer {
 
     fn pending_generic_instance(&self) -> Option<ir_type::GenericInstanceInfo> {
         self.pending_generic_instance.clone()
+    }
+
+    fn generated_args_contain(
+        instantiations: &[Vec<Rc<ir_type::Ty>>],
+        generic_args: &[Rc<ir_type::Ty>],
+    ) -> bool {
+        instantiations
+            .iter()
+            .any(|args| Self::generic_args_match_exactly(args, generic_args))
+    }
+
+    fn generic_args_match_exactly(left: &[Rc<ir_type::Ty>], right: &[Rc<ir_type::Ty>]) -> bool {
+        left.len() == right.len()
+            && left
+                .iter()
+                .zip(right)
+                .all(|(a, b)| match (a.kind.as_ref(), b.kind.as_ref()) {
+                    (ir_type::TyKind::Var(aid), ir_type::TyKind::Var(bid)) => aid == bid,
+                    (ir_type::TyKind::Var(_), _) | (_, ir_type::TyKind::Var(_)) => false,
+                    _ => a.kind == b.kind,
+                })
     }
 
     fn apply_substitutions_to_generated_generics(&mut self) {
@@ -1212,6 +1245,25 @@ impl SemanticAnalyzer {
                 .is_some_and(ir_type::GenericInstanceInfo::contains_type_var)
     }
 
+    fn unresolved_generated_callable_name(
+        top_level: &ir::top::TopLevel,
+    ) -> Option<QualifiedSymbol> {
+        match top_level {
+            ir::top::TopLevel::Fn(fn_) if Self::fn_decl_has_unresolved_types(&fn_.decl) => {
+                Some(fn_.decl.name.clone())
+            }
+            ir::top::TopLevel::Impl(impl_) => impl_
+                .methods
+                .iter()
+                .find(|method| Self::fn_decl_has_unresolved_types(&method.decl))
+                .map(|method| method.decl.name.clone()),
+            ir::top::TopLevel::Fn(_)
+            | ir::top::TopLevel::Struct(_)
+            | ir::top::TopLevel::Enum(_)
+            | ir::top::TopLevel::Interface(_) => None,
+        }
+    }
+
     fn infer_function_body_with_decl(
         &mut self,
         body: &mut kaede_ir::stmt::Block,
@@ -1319,10 +1371,8 @@ impl SemanticAnalyzer {
         self.apply_substitutions_to_generated_generics();
         self.infer_generated_generic_bodies_after_substitution()?;
 
-        Ok(
-            self.inject_generated_generics_to_compile_unit(ir::CompileUnit {
-                top_levels: top_level_irs,
-            }),
-        )
+        self.inject_generated_generics_to_compile_unit(ir::CompileUnit {
+            top_levels: top_level_irs,
+        })
     }
 }

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -502,6 +502,7 @@ impl SemanticAnalyzer {
                     self.slice_intrinsic = Some(crate::SliceIntrinsic {
                         impl_info: GenericImplInfo::new(node, resolved_generic_params, span),
                         defining_module: self.current_module_path().clone(),
+                        generated_args: Vec::new(),
                     });
                     return Ok(TopLevelAnalysisResult::GenericTopLevel);
                 }

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -499,10 +499,14 @@ impl SemanticAnalyzer {
                 }
 
                 ast_type::TyKind::Slice(_) => {
+                    let defining_module = self.current_module_path().clone();
                     self.slice_intrinsic = Some(crate::SliceIntrinsic {
                         impl_info: GenericImplInfo::new(node, resolved_generic_params, span),
-                        defining_module: self.current_module_path().clone(),
-                        generated_args: Vec::new(),
+                        defining_module: defining_module.clone(),
+                        origin: QualifiedSymbol::new(
+                            defining_module,
+                            Symbol::from("slice".to_owned()),
+                        ),
                     });
                     return Ok(TopLevelAnalysisResult::GenericTopLevel);
                 }

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -682,6 +682,14 @@ impl SemanticAnalyzer {
             return Ok(());
         };
 
+        if self
+            .slice_intrinsic
+            .as_ref()
+            .is_some_and(|slice| slice.origin == instance.origin)
+        {
+            return self.ensure_slice_impl_method_body(decl, &instance.args);
+        }
+
         let origin = instance.origin.clone();
         let generic_args = instance.args.clone();
 
@@ -753,6 +761,82 @@ impl SemanticAnalyzer {
                         Some(ir_type::GenericInstanceInfo::new(
                             origin.clone(),
                             generic_args.clone(),
+                        )),
+                        |analyzer| analyzer.analyze_impl(template.impl_),
+                    )
+                })
+            })
+        })?;
+
+        if let TopLevelAnalysisResult::TopLevel(top_level) = impl_ir {
+            assert!(matches!(top_level, ir::top::TopLevel::Impl(_)));
+            self.generated_generics.push(top_level);
+        }
+
+        Ok(())
+    }
+
+    fn ensure_slice_impl_method_body(
+        &mut self,
+        decl: &ir::top::FnDecl,
+        generic_args: &[Rc<ir_type::Ty>],
+    ) -> anyhow::Result<()> {
+        if self.generated_impl_method_bodies.contains(&decl.name) {
+            return Ok(());
+        }
+
+        let (defining_module, slice_origin, template_source) = {
+            let Some(slice) = self.slice_intrinsic.as_ref() else {
+                return Ok(());
+            };
+            (
+                slice.defining_module.clone(),
+                slice.origin.clone(),
+                Self::clone_generic_impl_template(&slice.impl_info),
+            )
+        };
+
+        let mut template = template_source;
+        let generic_params = template.generic_params.clone();
+        let resolved_generic_params = template.resolved_generic_params.clone();
+
+        self.generated_impl_method_bodies.insert(decl.name.clone());
+
+        self.verify_generic_argument_length(&generic_params, generic_args, generic_params.span)?;
+        self.verify_resolved_generic_bounds(
+            resolved_generic_params.as_ref(),
+            generic_args,
+            generic_params.span,
+        )?;
+
+        let parent_name = self.slice_method_parent_name(&generic_args[0]);
+        let target_name = decl.name.symbol();
+        template.impl_.generic_params = None;
+        template.impl_.items = Rc::new(Self::link_once_impl_methods_matching(
+            &template.impl_,
+            |fn_| {
+                self.create_method_key(
+                    parent_name,
+                    fn_.decl.name.symbol(),
+                    fn_.decl.self_.is_none(),
+                ) == target_name
+            },
+        ));
+
+        if template.impl_.items.is_empty() {
+            anyhow::bail!(
+                "internal compiler error: could not find generated slice impl method body for `{}`",
+                decl.name.mangle()
+            );
+        }
+
+        let impl_ir = self.with_root_module_and_fallback(defining_module, |analyzer| {
+            analyzer.with_generic_arguments(&generic_params, generic_args, |analyzer| {
+                analyzer.with_analyze_command(AnalyzeCommand::WithoutFnDeclare, |analyzer| {
+                    analyzer.with_pending_generic_instance(
+                        Some(ir_type::GenericInstanceInfo::new(
+                            slice_origin,
+                            generic_args.to_vec(),
                         )),
                         |analyzer| analyzer.analyze_impl(template.impl_),
                     )
@@ -944,11 +1028,15 @@ impl SemanticAnalyzer {
 
         let generic_args = vec![elem_ty.clone()];
 
-        if Self::generated_args_contain(&slice.generated_args, &generic_args) {
+        if Self::slice_instantiation_already_registered(
+            &slice.impl_info.method_decl_instantiations,
+            &generic_args,
+        ) {
             return Ok(());
         }
 
         let defining_module = slice.defining_module.clone();
+        let slice_origin = slice.origin.clone();
         let generic_params = slice
             .impl_info
             .impl_
@@ -969,29 +1057,27 @@ impl SemanticAnalyzer {
         self.slice_intrinsic
             .as_mut()
             .unwrap()
-            .generated_args
+            .impl_info
+            .method_decl_instantiations
             .push(generic_args.clone());
 
         impl_ast.generic_params = None;
         impl_ast.items = Rc::new(Self::link_once_impl_methods(&impl_ast));
 
-        // Fallback to the module that declared `impl<T>[T]` so method bodies can still
-        // reference symbols declared alongside the impl block — which the root module
-        // has no view of.
-        let impl_ir = self.with_root_module_and_fallback(defining_module, |analyzer| {
+        // Register method declarations only; bodies are emitted on demand at call sites.
+        self.with_root_module_and_fallback(defining_module, |analyzer| {
             analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {
-                analyzer.with_analyze_command(AnalyzeCommand::NoCommand, |analyzer| {
-                    analyzer.with_pending_generic_instance(None, |analyzer| {
-                        analyzer.analyze_impl(impl_ast.clone())
-                    })
+                analyzer.with_analyze_command(AnalyzeCommand::OnlyFnDeclare, |analyzer| {
+                    analyzer.with_pending_generic_instance(
+                        Some(ir_type::GenericInstanceInfo::new(
+                            slice_origin,
+                            generic_args.clone(),
+                        )),
+                        |analyzer| analyzer.analyze_impl(impl_ast),
+                    )
                 })
             })
         })?;
-
-        if let TopLevelAnalysisResult::TopLevel(top_level) = impl_ir {
-            assert!(matches!(top_level, ir::top::TopLevel::Impl(_)));
-            self.generated_generics.push(top_level);
-        }
 
         Ok(())
     }

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -13,7 +13,8 @@ use kaede_symbol_table::{
     GenericImplInfo, GenericKind, ResolvedGenericParams, SymbolTableValueKind,
 };
 
-struct GenericImplTemplate {
+/// `GenericImplInfo` fields copied for one monomorphization pass (decl or body).
+struct GenericImplSnapshot {
     generic_params: ast::top::GenericParams,
     resolved_generic_params: Option<ResolvedGenericParams>,
     impl_: ast::top::Impl,
@@ -44,8 +45,8 @@ impl SemanticAnalyzer {
         }
     }
 
-    fn clone_generic_impl_template(impl_info: &GenericImplInfo) -> GenericImplTemplate {
-        GenericImplTemplate {
+    fn create_generic_impl_snapshot(impl_info: &GenericImplInfo) -> GenericImplSnapshot {
+        GenericImplSnapshot {
             generic_params: impl_info.impl_.generic_params.as_ref().unwrap().clone(),
             resolved_generic_params: impl_info.resolved_generic_params.clone(),
             impl_: impl_info.impl_.clone(),
@@ -604,31 +605,31 @@ impl SemanticAnalyzer {
                         impl_info
                             .method_decl_instantiations
                             .push(generic_args.clone());
-                        Some(Self::clone_generic_impl_template(impl_info))
+                        Some(Self::create_generic_impl_snapshot(impl_info))
                     }
                 } else {
                     None
                 }
             };
 
-            if let Some(mut template) = decl_generation {
+            if let Some(mut snapshot) = decl_generation {
                 analyzer.verify_generic_argument_length(
-                    &template.generic_params,
+                    &snapshot.generic_params,
                     &generic_args,
-                    template.generic_params.span,
+                    snapshot.generic_params.span,
                 )?;
 
                 analyzer.verify_resolved_generic_bounds(
-                    template.resolved_generic_params.as_ref(),
+                    snapshot.resolved_generic_params.as_ref(),
                     &generic_args,
-                    template.generic_params.span,
+                    snapshot.generic_params.span,
                 )?;
 
-                template.impl_.generic_params = None;
-                template.impl_.items = Rc::new(Self::link_once_impl_methods(&template.impl_));
+                snapshot.impl_.generic_params = None;
+                snapshot.impl_.items = Rc::new(Self::link_once_impl_methods(&snapshot.impl_));
 
                 analyzer.with_generic_arguments(
-                    &template.generic_params,
+                    &snapshot.generic_params,
                     &generic_args,
                     |analyzer| {
                         analyzer.with_analyze_command(AnalyzeCommand::OnlyFnDeclare, |analyzer| {
@@ -637,7 +638,7 @@ impl SemanticAnalyzer {
                                     QualifiedSymbol::new(module_path.clone(), name.symbol()),
                                     generic_args.clone(),
                                 )),
-                                |analyzer| analyzer.analyze_impl(template.impl_),
+                                |analyzer| analyzer.analyze_impl(snapshot.impl_),
                             )?;
                             Ok::<(), anyhow::Error>(())
                         })
@@ -697,7 +698,7 @@ impl SemanticAnalyzer {
             return Ok(());
         }
 
-        let generation = {
+        let mut snapshot = {
             let symbol =
                 self.lookup_qualified_symbol(origin.clone())
                     .ok_or(SemanticError::Undeclared {
@@ -715,29 +716,28 @@ impl SemanticAnalyzer {
                 return Ok(());
             };
 
-            Self::clone_generic_impl_template(impl_info)
+            Self::create_generic_impl_snapshot(impl_info)
         };
 
         self.generated_impl_method_bodies.insert(decl.name.clone());
 
-        let mut template = generation;
         self.verify_generic_argument_length(
-            &template.generic_params,
+            &snapshot.generic_params,
             &generic_args,
-            template.generic_params.span,
+            snapshot.generic_params.span,
         )?;
 
         self.verify_resolved_generic_bounds(
-            template.resolved_generic_params.as_ref(),
+            snapshot.resolved_generic_params.as_ref(),
             &generic_args,
-            template.generic_params.span,
+            snapshot.generic_params.span,
         )?;
 
         let parent_name = self.create_generated_generic_key(origin.symbol(), &generic_args);
         let target_name = decl.name.symbol();
-        template.impl_.generic_params = None;
-        template.impl_.items = Rc::new(Self::link_once_impl_methods_matching(
-            &template.impl_,
+        snapshot.impl_.generic_params = None;
+        snapshot.impl_.items = Rc::new(Self::link_once_impl_methods_matching(
+            &snapshot.impl_,
             |fn_| {
                 self.create_method_key(
                     parent_name,
@@ -747,7 +747,7 @@ impl SemanticAnalyzer {
             },
         ));
 
-        if template.impl_.items.is_empty() {
+        if snapshot.impl_.items.is_empty() {
             anyhow::bail!(
                 "internal compiler error: could not find generated impl method body for `{}`",
                 decl.name.mangle()
@@ -755,14 +755,14 @@ impl SemanticAnalyzer {
         }
 
         let impl_ir = self.with_module(origin.module_path().clone(), |analyzer| {
-            analyzer.with_generic_arguments(&template.generic_params, &generic_args, |analyzer| {
+            analyzer.with_generic_arguments(&snapshot.generic_params, &generic_args, |analyzer| {
                 analyzer.with_analyze_command(AnalyzeCommand::WithoutFnDeclare, |analyzer| {
                     analyzer.with_pending_generic_instance(
                         Some(ir_type::GenericInstanceInfo::new(
                             origin.clone(),
                             generic_args.clone(),
                         )),
-                        |analyzer| analyzer.analyze_impl(template.impl_),
+                        |analyzer| analyzer.analyze_impl(snapshot.impl_),
                     )
                 })
             })
@@ -785,20 +785,19 @@ impl SemanticAnalyzer {
             return Ok(());
         }
 
-        let (defining_module, slice_origin, template_source) = {
+        let (defining_module, slice_origin, mut snapshot) = {
             let Some(slice) = self.slice_intrinsic.as_ref() else {
                 return Ok(());
             };
             (
                 slice.defining_module.clone(),
                 slice.origin.clone(),
-                Self::clone_generic_impl_template(&slice.impl_info),
+                Self::create_generic_impl_snapshot(&slice.impl_info),
             )
         };
 
-        let mut template = template_source;
-        let generic_params = template.generic_params.clone();
-        let resolved_generic_params = template.resolved_generic_params.clone();
+        let generic_params = snapshot.generic_params.clone();
+        let resolved_generic_params = snapshot.resolved_generic_params.clone();
 
         self.generated_impl_method_bodies.insert(decl.name.clone());
 
@@ -811,9 +810,9 @@ impl SemanticAnalyzer {
 
         let parent_name = self.slice_method_parent_name(&generic_args[0]);
         let target_name = decl.name.symbol();
-        template.impl_.generic_params = None;
-        template.impl_.items = Rc::new(Self::link_once_impl_methods_matching(
-            &template.impl_,
+        snapshot.impl_.generic_params = None;
+        snapshot.impl_.items = Rc::new(Self::link_once_impl_methods_matching(
+            &snapshot.impl_,
             |fn_| {
                 self.create_method_key(
                     parent_name,
@@ -823,7 +822,7 @@ impl SemanticAnalyzer {
             },
         ));
 
-        if template.impl_.items.is_empty() {
+        if snapshot.impl_.items.is_empty() {
             anyhow::bail!(
                 "internal compiler error: could not find generated slice impl method body for `{}`",
                 decl.name.mangle()
@@ -838,7 +837,7 @@ impl SemanticAnalyzer {
                             slice_origin,
                             generic_args.to_vec(),
                         )),
-                        |analyzer| analyzer.analyze_impl(template.impl_),
+                        |analyzer| analyzer.analyze_impl(snapshot.impl_),
                     )
                 })
             })

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -9,7 +9,15 @@ use kaede_symbol::{Ident, Symbol};
 
 use crate::context::AnalyzeCommand;
 use crate::{error::SemanticError, SemanticAnalyzer, TopLevelAnalysisResult};
-use kaede_symbol_table::{GenericKind, ResolvedGenericParams, SymbolTableValueKind};
+use kaede_symbol_table::{
+    GenericImplInfo, GenericKind, ResolvedGenericParams, SymbolTableValueKind,
+};
+
+struct GenericImplTemplate {
+    generic_params: ast::top::GenericParams,
+    resolved_generic_params: Option<ResolvedGenericParams>,
+    impl_: ast::top::Impl,
+}
 
 struct GenericTypeOps<T> {
     get_generic_params: fn(&T) -> &ast::top::GenericParams,
@@ -20,6 +28,30 @@ struct GenericTypeOps<T> {
 }
 
 impl SemanticAnalyzer {
+    fn generic_impl_info(kind: &GenericKind) -> Option<&GenericImplInfo> {
+        match kind {
+            GenericKind::Struct(info) => info.impl_info.as_ref(),
+            GenericKind::Enum(info) => info.impl_info.as_ref(),
+            GenericKind::Func(_) => None,
+        }
+    }
+
+    fn generic_impl_info_mut(kind: &mut GenericKind) -> Option<&mut GenericImplInfo> {
+        match kind {
+            GenericKind::Struct(info) => info.impl_info.as_mut(),
+            GenericKind::Enum(info) => info.impl_info.as_mut(),
+            GenericKind::Func(_) => None,
+        }
+    }
+
+    fn clone_generic_impl_template(impl_info: &GenericImplInfo) -> GenericImplTemplate {
+        GenericImplTemplate {
+            generic_params: impl_info.impl_.generic_params.as_ref().unwrap().clone(),
+            resolved_generic_params: impl_info.resolved_generic_params.clone(),
+            impl_: impl_info.impl_.clone(),
+        }
+    }
+
     pub(crate) fn verify_resolved_generic_bounds(
         &self,
         resolved_params: Option<&ResolvedGenericParams>,
@@ -493,6 +525,35 @@ impl SemanticAnalyzer {
         self.create_generic_type_with_args(udt.name, generic_args)
     }
 
+    fn link_once_impl_methods(impl_: &ast::top::Impl) -> Vec<ast::top::TopLevel> {
+        Self::link_once_impl_methods_matching(impl_, |_| true)
+    }
+
+    fn link_once_impl_methods_matching(
+        impl_: &ast::top::Impl,
+        mut include: impl FnMut(&ast::top::Fn) -> bool,
+    ) -> Vec<ast::top::TopLevel> {
+        impl_
+            .items
+            .iter()
+            .filter_map(|method| match &method.kind {
+                ast::top::TopLevelKind::Fn(fn_) if include(fn_) => {
+                    let mut fn_decl = fn_.decl.clone();
+                    fn_decl.link_once = true;
+                    Some(ast::top::TopLevel {
+                        kind: ast::top::TopLevelKind::Fn(ast::top::Fn {
+                            decl: fn_decl,
+                            body: fn_.body.clone(),
+                            span: fn_.span,
+                        }),
+                        span: fn_.span,
+                    })
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     fn create_generic_type_with_args(
         &mut self,
         name: Ident,
@@ -505,39 +566,27 @@ impl SemanticAnalyzer {
                 span: name.span(),
             })?;
 
-        let borrowed_symbol = symbol.borrow();
+        let module_path = {
+            let borrowed_symbol = symbol.borrow();
 
-        let generic_info = match &borrowed_symbol.kind {
-            SymbolTableValueKind::Generic(generic_info) => generic_info,
-            _ => unreachable!(),
-        };
-
-        self.verify_resolved_generic_bounds(
-            generic_info.resolved_generic_params(),
-            &generic_args,
-            name.span(),
-        )?;
-
-        let module_path = generic_info.module_path.clone();
-
-        self.with_module(module_path.clone(), |analyzer| {
             let generic_info = match &borrowed_symbol.kind {
                 SymbolTableValueKind::Generic(generic_info) => generic_info,
                 _ => unreachable!(),
             };
 
-            // Create the user defined type with the generic arguments
-            let impl_info = match &generic_info.kind {
-                GenericKind::Struct(info) => info.impl_info.as_ref(),
-                GenericKind::Enum(info) => info.impl_info.as_ref(),
-                _ => unreachable!(),
-            };
+            self.verify_resolved_generic_bounds(
+                generic_info.resolved_generic_params(),
+                &generic_args,
+                name.span(),
+            )?;
 
-            // Create methods
-            if impl_info.is_some() {
-                // To avoid borrow checker error
-                drop(borrowed_symbol);
+            generic_info.module_path.clone()
+        };
 
+        self.with_module(module_path.clone(), |analyzer| {
+            // Register method declarations for this generic instantiation. Bodies are emitted
+            // only when a method call actually references one of these declarations.
+            let decl_generation = {
                 let mut borrowed_mut_symbol = symbol.borrow_mut();
 
                 let generic_info = match &mut borrowed_mut_symbol.kind {
@@ -545,117 +594,55 @@ impl SemanticAnalyzer {
                     _ => unreachable!(),
                 };
 
-                let impl_info = match &mut generic_info.kind {
-                    GenericKind::Struct(info) => info.impl_info.as_mut().unwrap(),
-                    GenericKind::Enum(info) => info.impl_info.as_mut().unwrap(),
-                    _ => unreachable!(),
-                };
-
-                // Check if the impl has already been generated for the exact generic arguments.
-                // `Ty` equality treats type vars as wildcards, so we need a stricter comparison here.
-                let already_generated = impl_info.generateds.iter().any(|args| {
-                    args.len() == generic_args.len()
-                        && args.iter().zip(&generic_args).all(|(a, b)| {
-                            match (a.kind.as_ref(), b.kind.as_ref()) {
-                                (ir_type::TyKind::Var(aid), ir_type::TyKind::Var(bid)) => {
-                                    aid == bid
-                                }
-                                (ir_type::TyKind::Var(_), _) | (_, ir_type::TyKind::Var(_)) => {
-                                    false
-                                }
-                                _ => a.kind == b.kind,
-                            }
-                        })
-                });
-
-                if !already_generated {
-                    impl_info.generateds.push(generic_args.clone());
-
-                    let generic_params = impl_info.impl_.generic_params.as_ref().unwrap().clone();
-                    let resolved_generic_params = impl_info.resolved_generic_params.clone();
-
-                    // Check if the length of the generic arguments is the same as the number of generic parameters
-                    if generic_params.len() != generic_args.len() {
-                        return Err(SemanticError::GenericArgumentLengthMismatch {
-                            expected: generic_params.len(),
-                            actual: generic_args.len(),
-                            span: generic_params.span,
-                        }
-                        .into());
-                    }
-
-                    analyzer.verify_resolved_generic_bounds(
-                        resolved_generic_params.as_ref(),
+                if let Some(impl_info) = Self::generic_impl_info_mut(&mut generic_info.kind) {
+                    if Self::generated_args_contain(
+                        &impl_info.method_decl_instantiations,
                         &generic_args,
-                        generic_params.span,
-                    )?;
-
-                    let mut impl_ = impl_info.impl_.clone();
-                    impl_.generic_params = None;
-
-                    let mut methods = vec![];
-
-                    // Since the generic function is generated multiple times,
-                    // we need to set link_once to true to avoid errors
-                    for method in impl_.items.iter() {
-                        if let ast::top::TopLevelKind::Fn(fn_) = &method.kind {
-                            let mut fn_decl = fn_.decl.clone();
-                            fn_decl.link_once = true;
-
-                            methods.push(ast::top::TopLevel {
-                                kind: ast::top::TopLevelKind::Fn(ast::top::Fn {
-                                    decl: fn_decl,
-                                    body: fn_.body.clone(),
-                                    span: fn_.span,
-                                }),
-                                span: fn_.span,
-                            });
-                        }
+                    ) {
+                        None
+                    } else {
+                        impl_info
+                            .method_decl_instantiations
+                            .push(generic_args.clone());
+                        Some(Self::clone_generic_impl_template(impl_info))
                     }
-
-                    impl_.items = Rc::new(methods);
-
-                    // To avoid borrow checker error
-                    drop(borrowed_mut_symbol);
-
-                    analyzer.with_generic_arguments(
-                        &generic_params,
-                        &generic_args,
-                        |analyzer| {
-                            let generic_instance = ir_type::GenericInstanceInfo::new(
-                                QualifiedSymbol::new(module_path.clone(), name.symbol()),
-                                generic_args.clone(),
-                            );
-                            analyzer.with_analyze_command(
-                                AnalyzeCommand::OnlyFnDeclare,
-                                |analyzer| {
-                                    analyzer.with_pending_generic_instance(
-                                        Some(generic_instance.clone()),
-                                        |analyzer| analyzer.analyze_impl(impl_.clone()),
-                                    )?;
-                                    Ok::<(), anyhow::Error>(())
-                                },
-                            )?;
-
-                            let impl_ir = analyzer.with_analyze_command(
-                                AnalyzeCommand::WithoutFnDeclare,
-                                |analyzer| {
-                                    analyzer.with_pending_generic_instance(
-                                        Some(generic_instance),
-                                        |analyzer| analyzer.analyze_impl(impl_),
-                                    )
-                                },
-                            )?;
-
-                            if let TopLevelAnalysisResult::TopLevel(top_level) = impl_ir {
-                                assert!(matches!(top_level, ir::top::TopLevel::Impl(_)));
-                                analyzer.generated_generics.push(top_level);
-                            }
-
-                            Ok::<(), anyhow::Error>(())
-                        },
-                    )?;
+                } else {
+                    None
                 }
+            };
+
+            if let Some(mut template) = decl_generation {
+                analyzer.verify_generic_argument_length(
+                    &template.generic_params,
+                    &generic_args,
+                    template.generic_params.span,
+                )?;
+
+                analyzer.verify_resolved_generic_bounds(
+                    template.resolved_generic_params.as_ref(),
+                    &generic_args,
+                    template.generic_params.span,
+                )?;
+
+                template.impl_.generic_params = None;
+                template.impl_.items = Rc::new(Self::link_once_impl_methods(&template.impl_));
+
+                analyzer.with_generic_arguments(
+                    &template.generic_params,
+                    &generic_args,
+                    |analyzer| {
+                        analyzer.with_analyze_command(AnalyzeCommand::OnlyFnDeclare, |analyzer| {
+                            analyzer.with_pending_generic_instance(
+                                Some(ir_type::GenericInstanceInfo::new(
+                                    QualifiedSymbol::new(module_path.clone(), name.symbol()),
+                                    generic_args.clone(),
+                                )),
+                                |analyzer| analyzer.analyze_impl(template.impl_),
+                            )?;
+                            Ok::<(), anyhow::Error>(())
+                        })
+                    },
+                )?;
             }
 
             let borrowed_symbol = symbol.borrow();
@@ -683,6 +670,102 @@ impl SemanticAnalyzer {
                 unreachable!()
             }
         })
+    }
+
+    pub(crate) fn ensure_generated_impl_method_body(
+        &mut self,
+        decl: &ir::top::FnDecl,
+    ) -> anyhow::Result<()> {
+        // Generic type instantiation registers method declarations first. Emit the concrete
+        // method body only when the declaration is actually referenced by a call.
+        let Some(instance) = &decl.generic_instance else {
+            return Ok(());
+        };
+
+        let origin = instance.origin.clone();
+        let generic_args = instance.args.clone();
+
+        if self.generated_impl_method_bodies.contains(&decl.name) {
+            return Ok(());
+        }
+
+        let generation = {
+            let symbol =
+                self.lookup_qualified_symbol(origin.clone())
+                    .ok_or(SemanticError::Undeclared {
+                        name: origin.symbol(),
+                        span: Span::dummy(),
+                    })?;
+
+            let borrowed_symbol = symbol.borrow();
+            let generic_info = match &borrowed_symbol.kind {
+                SymbolTableValueKind::Generic(generic_info) => generic_info,
+                _ => return Ok(()),
+            };
+
+            let Some(impl_info) = Self::generic_impl_info(&generic_info.kind) else {
+                return Ok(());
+            };
+
+            Self::clone_generic_impl_template(impl_info)
+        };
+
+        self.generated_impl_method_bodies.insert(decl.name.clone());
+
+        let mut template = generation;
+        self.verify_generic_argument_length(
+            &template.generic_params,
+            &generic_args,
+            template.generic_params.span,
+        )?;
+
+        self.verify_resolved_generic_bounds(
+            template.resolved_generic_params.as_ref(),
+            &generic_args,
+            template.generic_params.span,
+        )?;
+
+        let parent_name = self.create_generated_generic_key(origin.symbol(), &generic_args);
+        let target_name = decl.name.symbol();
+        template.impl_.generic_params = None;
+        template.impl_.items = Rc::new(Self::link_once_impl_methods_matching(
+            &template.impl_,
+            |fn_| {
+                self.create_method_key(
+                    parent_name,
+                    fn_.decl.name.symbol(),
+                    fn_.decl.self_.is_none(),
+                ) == target_name
+            },
+        ));
+
+        if template.impl_.items.is_empty() {
+            anyhow::bail!(
+                "internal compiler error: could not find generated impl method body for `{}`",
+                decl.name.mangle()
+            );
+        }
+
+        let impl_ir = self.with_module(origin.module_path().clone(), |analyzer| {
+            analyzer.with_generic_arguments(&template.generic_params, &generic_args, |analyzer| {
+                analyzer.with_analyze_command(AnalyzeCommand::WithoutFnDeclare, |analyzer| {
+                    analyzer.with_pending_generic_instance(
+                        Some(ir_type::GenericInstanceInfo::new(
+                            origin.clone(),
+                            generic_args.clone(),
+                        )),
+                        |analyzer| analyzer.analyze_impl(template.impl_),
+                    )
+                })
+            })
+        })?;
+
+        if let TopLevelAnalysisResult::TopLevel(top_level) = impl_ir {
+            assert!(matches!(top_level, ir::top::TopLevel::Impl(_)));
+            self.generated_generics.push(top_level);
+        }
+
+        Ok(())
     }
 
     pub fn analyze_user_defined_type(
@@ -847,8 +930,6 @@ impl SemanticAnalyzer {
     ) -> anyhow::Result<ir_type::Ty> {
         let elem_ty = self.analyze_type(elem_ty)?;
 
-        self.generate_slice_impl(elem_ty.clone())?;
-
         Ok(ir_type::Ty {
             kind: ir_type::TyKind::Slice(elem_ty).into(),
             mutability,
@@ -863,17 +944,7 @@ impl SemanticAnalyzer {
 
         let generic_args = vec![elem_ty.clone()];
 
-        let already_generated = slice.impl_info.generateds.iter().any(|args| {
-            args.len() == generic_args.len()
-                && args.iter().zip(&generic_args).all(|(a, b)| {
-                    match (a.kind.as_ref(), b.kind.as_ref()) {
-                        (ir_type::TyKind::Var(_), ir_type::TyKind::Var(_)) => true,
-                        (ir_type::TyKind::Var(_), _) | (_, ir_type::TyKind::Var(_)) => false,
-                        _ => a.kind == b.kind,
-                    }
-                })
-        });
-        if already_generated {
+        if Self::generated_args_contain(&slice.generated_args, &generic_args) {
             return Ok(());
         }
 
@@ -898,32 +969,11 @@ impl SemanticAnalyzer {
         self.slice_intrinsic
             .as_mut()
             .unwrap()
-            .impl_info
-            .generateds
+            .generated_args
             .push(generic_args.clone());
 
         impl_ast.generic_params = None;
-
-        let methods = impl_ast
-            .items
-            .iter()
-            .filter_map(|method| match &method.kind {
-                ast::top::TopLevelKind::Fn(fn_) => {
-                    let mut fn_decl = fn_.decl.clone();
-                    fn_decl.link_once = true;
-                    Some(ast::top::TopLevel {
-                        kind: ast::top::TopLevelKind::Fn(ast::top::Fn {
-                            decl: fn_decl,
-                            body: fn_.body.clone(),
-                            span: fn_.span,
-                        }),
-                        span: fn_.span,
-                    })
-                }
-                _ => None,
-            })
-            .collect();
-        impl_ast.items = Rc::new(methods);
+        impl_ast.items = Rc::new(Self::link_once_impl_methods(&impl_ast));
 
         // Fallback to the module that declared `impl<T>[T]` so method bodies can still
         // reference symbols declared alongside the impl block — which the root module
@@ -931,7 +981,9 @@ impl SemanticAnalyzer {
         let impl_ir = self.with_root_module_and_fallback(defining_module, |analyzer| {
             analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {
                 analyzer.with_analyze_command(AnalyzeCommand::NoCommand, |analyzer| {
-                    analyzer.analyze_impl(impl_ast.clone())
+                    analyzer.with_pending_generic_instance(None, |analyzer| {
+                        analyzer.analyze_impl(impl_ast.clone())
+                    })
                 })
             })
         })?;

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -595,7 +595,7 @@ impl SemanticAnalyzer {
                 };
 
                 if let Some(impl_info) = Self::generic_impl_info_mut(&mut generic_info.kind) {
-                    if Self::generated_args_contain(
+                    if Self::generic_instantiation_already_registered(
                         &impl_info.method_decl_instantiations,
                         &generic_args,
                     ) {

--- a/compiler/semantic/tests/top.rs
+++ b/compiler/semantic/tests/top.rs
@@ -84,6 +84,20 @@ fn main_generic_callee_name(ir: &CompileUnit) -> kaede_ir::qualified_symbol::Qua
     find_generic_callee_in_block(body).expect("expected generated call in main body")
 }
 
+fn generated_impl_method_symbols(ir: &CompileUnit) -> Vec<String> {
+    ir.top_levels
+        .iter()
+        .flat_map(|top| match top {
+            TopLevel::Impl(impl_) => impl_
+                .methods
+                .iter()
+                .map(|method| method.decl.name.symbol().to_string())
+                .collect::<Vec<_>>(),
+            _ => Vec::new(),
+        })
+        .collect()
+}
+
 #[test]
 fn empty_function() -> anyhow::Result<()> {
     semantic_analyze("fun foo() {}")?;
@@ -418,6 +432,59 @@ fn generated_generic_impl_method_has_concrete_types_after_inference() -> anyhow:
             .as_ref()
             .is_some_and(|instance| !instance.contains_type_var()),
         "generated method should retain a concrete structural generic instance"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn generic_type_instantiation_does_not_emit_impl_method_bodies() -> anyhow::Result<()> {
+    let ir = semantic_analyze(
+        r#"
+        fun main() -> i32 {
+            let opt = Option::Some(58)
+            return 0
+        }
+        "#,
+    )?;
+
+    let generated_methods = generated_impl_method_symbols(&ir);
+    assert!(
+        generated_methods
+            .iter()
+            .all(|name| !name.contains("Option_")),
+        "type-only Option instantiation should not emit impl method bodies: {generated_methods:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn generic_impl_method_call_emits_only_referenced_method_body() -> anyhow::Result<()> {
+    let ir = semantic_analyze(
+        r#"
+        fun main() -> i32 {
+            let opt = Option::Some(58)
+            if opt.is_some() {
+                return 1
+            }
+            return 0
+        }
+        "#,
+    )?;
+
+    let generated_methods = generated_impl_method_symbols(&ir);
+    assert!(
+        generated_methods
+            .iter()
+            .any(|name| name.ends_with(".is_some")),
+        "expected generated Option.is_some body: {generated_methods:?}"
+    );
+    assert!(
+        generated_methods
+            .iter()
+            .all(|name| !name.ends_with(".is_none") && !name.ends_with(".unwrap")),
+        "unreferenced Option methods should not be emitted: {generated_methods:?}"
     );
 
     Ok(())

--- a/compiler/semantic/tests/top.rs
+++ b/compiler/semantic/tests/top.rs
@@ -491,6 +491,53 @@ fn generic_impl_method_call_emits_only_referenced_method_body() -> anyhow::Resul
 }
 
 #[test]
+fn slice_methods_on_distinct_type_variables_share_one_instantiation() -> anyhow::Result<()> {
+    semantic_analyze(
+        r#"
+        fun takes<T>(xs: [T]) -> u64 {
+            return xs.len()
+        }
+
+        fun also<U>(ys: [U]) -> u64 {
+            return ys.len()
+        }
+
+        fun main() -> i32 {
+            return 0
+        }
+        "#,
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn slice_method_call_emits_only_referenced_method_body() -> anyhow::Result<()> {
+    let ir = semantic_analyze(
+        r#"
+        fun main() -> i32 {
+            let buf: [u8] = [1, 2, 3]
+            return buf.len() as i32
+        }
+        "#,
+    )?;
+
+    let generated_methods = generated_impl_method_symbols(&ir);
+    assert!(
+        generated_methods.iter().any(|name| name == "slice<u8>.len"),
+        "expected generated slice<u8>.len body: {generated_methods:?}"
+    );
+    assert!(
+        !generated_methods
+            .iter()
+            .any(|name| name == "slice<u8>.as_ptr"),
+        "unreferenced slice<u8>.as_ptr should not be emitted: {generated_methods:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn static_method_on_generic_type_allows_omitted_type_args() -> anyhow::Result<()> {
     semantic_analyze(
         r#"

--- a/compiler/symbol_table/src/lib.rs
+++ b/compiler/symbol_table/src/lib.rs
@@ -18,8 +18,8 @@ pub struct GenericImplInfo {
     pub impl_: ast::top::Impl,
     pub resolved_generic_params: Option<ResolvedGenericParams>,
     pub span: Span,
-    // Contains already generated generic arguments
-    pub generateds: Vec<Vec<Rc<ir_type::Ty>>>,
+    // Generic arguments whose impl method declarations have been registered.
+    pub method_decl_instantiations: Vec<Vec<Rc<ir_type::Ty>>>,
 }
 
 impl GenericImplInfo {
@@ -32,7 +32,7 @@ impl GenericImplInfo {
             impl_,
             resolved_generic_params,
             span,
-            generateds: Vec::new(),
+            method_decl_instantiations: Vec::new(),
         }
     }
 }

--- a/compiler/type_infer/src/lib.rs
+++ b/compiler/type_infer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Bidirectional Type Inference
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::mem;
 use std::rc::Rc;
 
@@ -23,7 +23,7 @@ use kaede_ir::{
     top::Enum as IrEnum,
     ty::{
         FundamentalTypeKind, Mutability, ReferenceType, Ty, TyKind, UserDefinedTypeKind, VarId,
-        contains_type_var, make_fundamental_type,
+        collect_type_var_ids_in_order, contains_type_var, make_fundamental_type,
     },
 };
 mod context;
@@ -36,7 +36,7 @@ pub struct TypeInferrer {
     env: Env,
     function_return_ty: Rc<Ty>,
     specialized_enums: HashMap<QualifiedSymbol, Rc<IrEnum>>,
-    generic_fn_substitutions:
+    generated_callable_substitutions:
         HashMap<kaede_ir::qualified_symbol::QualifiedSymbol, HashMap<VarId, Rc<Ty>>>,
 }
 
@@ -67,14 +67,14 @@ impl TypeInferrer {
             env: Env::new(),
             function_return_ty,
             specialized_enums: HashMap::new(),
-            generic_fn_substitutions: HashMap::new(),
+            generated_callable_substitutions: HashMap::new(),
         }
     }
 
-    pub fn into_generic_fn_substitutions(
+    pub fn into_generated_callable_substitutions(
         self,
     ) -> HashMap<kaede_ir::qualified_symbol::QualifiedSymbol, HashMap<VarId, Rc<Ty>>> {
-        self.generic_fn_substitutions
+        self.generated_callable_substitutions
     }
 
     fn apply_fn_decl(
@@ -97,18 +97,49 @@ impl TypeInferrer {
     }
 
     /// Preserve the original type-variable-to-type mapping so semantic analysis
-    /// can substitute through the generated generic body after inference.
-    fn record_generic_fn_substitutions(&mut self, callee: &kaede_ir::top::FnDecl) {
-        let Some(instance) = &callee.generic_instance else {
-            return;
-        };
+    /// can substitute through generated function and method bodies after inference.
+    fn record_generated_callable_substitutions(&mut self, callee: &kaede_ir::top::FnDecl) {
+        let mut var_ids = Vec::new();
+        let mut seen = HashSet::new();
 
-        let bindings = self.context.bindings_for_generic_instance(instance);
+        if let Some(instance) = &callee.generic_instance {
+            for id in instance.collect_var_ids_in_order() {
+                if seen.insert(id) {
+                    var_ids.push(id);
+                }
+            }
+        }
+
+        for param in &callee.params {
+            for id in collect_type_var_ids_in_order(&param.ty) {
+                if seen.insert(id) {
+                    var_ids.push(id);
+                }
+            }
+        }
+        for id in collect_type_var_ids_in_order(&callee.return_ty) {
+            if seen.insert(id) {
+                var_ids.push(id);
+            }
+        }
+
+        let bindings = var_ids
+            .into_iter()
+            .filter_map(|id| {
+                let resolved = self.context.resolve_var(id);
+                if contains_type_var(&resolved) {
+                    None
+                } else {
+                    Some((id, resolved))
+                }
+            })
+            .collect::<HashMap<_, _>>();
+
         if bindings.is_empty() {
             return;
         }
 
-        self.generic_fn_substitutions
+        self.generated_callable_substitutions
             .entry(callee.name.clone())
             .or_default()
             .extend(bindings);
@@ -1979,7 +2010,7 @@ impl TypeInferrer {
 
                 let original_callee = fn_call.callee.clone();
                 fn_call.callee = Rc::new(self.apply_fn_decl(&fn_call.callee)?);
-                self.record_generic_fn_substitutions(&original_callee);
+                self.record_generated_callable_substitutions(&original_callee);
             }
             GenericFnCall(fn_call) => {
                 for arg in &mut fn_call.args.0 {
@@ -1994,7 +2025,7 @@ impl TypeInferrer {
                     .iter()
                     .map(|ty| self.context.apply(ty))
                     .collect();
-                self.record_generic_fn_substitutions(&original_callee);
+                self.record_generated_callable_substitutions(&original_callee);
 
                 if fn_call
                     .generic_args
@@ -2165,10 +2196,10 @@ mod tests {
 
     use kaede_common::LangLinkage;
     use kaede_ir::{
-        expr::{Args, Expr, ExprKind, GenericFnCall, UnresolvedFieldAccess, Variable},
+        expr::{Args, Expr, ExprKind, FnCall, GenericFnCall, UnresolvedFieldAccess, Variable},
         module_path::ModulePath,
         qualified_symbol::QualifiedSymbol,
-        top::{FnDecl, Struct, StructField},
+        top::{FnDecl, Param, Struct, StructField},
         ty::{
             FundamentalTypeKind, GenericInstanceInfo, Mutability, ReferenceType, Ty, TyKind,
             UserDefinedType, UserDefinedTypeKind, make_fundamental_type,
@@ -2193,6 +2224,33 @@ mod tests {
             FundamentalTypeKind::I32,
             Mutability::Not,
         ))
+    }
+
+    fn ptr_ty(pointee_ty: Rc<Ty>) -> Rc<Ty> {
+        Rc::new(Ty {
+            kind: TyKind::Pointer(kaede_ir::ty::PointerType { pointee_ty }).into(),
+            mutability: Mutability::Not,
+        })
+    }
+
+    fn slice_ty(elem_ty: Rc<Ty>) -> Rc<Ty> {
+        Rc::new(Ty {
+            kind: TyKind::Slice(elem_ty).into(),
+            mutability: Mutability::Not,
+        })
+    }
+
+    fn array_ref_ty(elem_ty: Rc<Ty>, len: u32) -> Rc<Ty> {
+        Rc::new(Ty {
+            kind: TyKind::Reference(ReferenceType {
+                refee_ty: Rc::new(Ty {
+                    kind: TyKind::Array((elem_ty, len)).into(),
+                    mutability: Mutability::Not,
+                }),
+            })
+            .into(),
+            mutability: Mutability::Mut,
+        })
     }
 
     fn make_inferrer() -> TypeInferrer {
@@ -2329,11 +2387,72 @@ mod tests {
         inferrer.check_expr(&expr, &i32_ty()).unwrap();
         inferrer.apply_expr(&mut expr).unwrap();
 
-        let substitutions = inferrer.into_generic_fn_substitutions();
+        let substitutions = inferrer.into_generated_callable_substitutions();
         let bindings = substitutions
             .get(&QualifiedSymbol::new(
                 ModulePath::root(),
                 Symbol::from("id".to_owned()),
+            ))
+            .unwrap();
+        assert!(matches!(
+            bindings.get(&0).unwrap().kind.as_ref(),
+            TyKind::Fundamental(fty) if fty.kind == FundamentalTypeKind::I32
+        ));
+    }
+
+    #[test]
+    fn fn_call_records_substitutions_from_decl_type_vars() {
+        let mut inferrer = make_inferrer();
+        let elem_ty = var_ty(0);
+        let receiver_ty = array_ref_ty(i32_ty(), 1);
+        inferrer.register_variable(Symbol::from("buf".to_owned()), receiver_ty.clone());
+
+        let callee = Rc::new(FnDecl {
+            lang_linkage: LangLinkage::Default,
+            link_once: true,
+            name: QualifiedSymbol::new(
+                ModulePath::root(),
+                Symbol::from("slice<_>.as_ptr".to_owned()),
+            ),
+            params: vec![Param {
+                name: Symbol::from("self".to_owned()),
+                ty: slice_ty(elem_ty.clone()),
+                default: None,
+            }],
+            is_c_variadic: false,
+            return_ty: ptr_ty(elem_ty),
+            generic_instance: None,
+        });
+
+        let mut expr = Expr {
+            kind: ExprKind::FnCall(FnCall {
+                callee,
+                args: Args(
+                    vec![Expr {
+                        kind: ExprKind::Variable(Variable {
+                            name: Symbol::from("buf".to_owned()),
+                            ty: receiver_ty.clone(),
+                            span: Span::dummy(),
+                        }),
+                        ty: receiver_ty,
+                        span: Span::dummy(),
+                    }],
+                    Span::dummy(),
+                ),
+                span: Span::dummy(),
+            }),
+            ty: ptr_ty(var_ty(0)),
+            span: Span::dummy(),
+        };
+
+        inferrer.infer_expr(&expr).unwrap();
+        inferrer.apply_expr(&mut expr).unwrap();
+
+        let substitutions = inferrer.into_generated_callable_substitutions();
+        let bindings = substitutions
+            .get(&QualifiedSymbol::new(
+                ModulePath::root(),
+                Symbol::from("slice<_>.as_ptr".to_owned()),
             ))
             .unwrap();
         assert!(matches!(


### PR DESCRIPTION
## Summary
- record inferred substitutions for generated calls whose type variables only appear in function params or return types
- keep unresolved generated callables out of the final compile unit while preserving generated type declarations
- expose a shared IR helper for collecting type variable ids from arbitrary types

## Verification
- nix develop -c cargo fmt --all -- --check
- nix develop -c cargo clippy -- -D warnings
- nix develop -c cargo test -p kaede_type_infer
- nix develop -c cargo test -p kaede_semantic
- nix develop -c cargo test --release --no-fail-fast