### PR TITLE
feat: add std comparison ordering

### DIFF
--- a/compiler/driver/tests/bytes.rs
+++ b/compiler/driver/tests/bytes.rs
@@ -46,7 +46,7 @@ fun main() -> i32 {
 }
 
 #[test]
-fn std_bytes_copy_fill_and_compare_cover_lengths() -> anyhow::Result<()> {
+fn std_bytes_copy_fill_cover_lengths() -> anyhow::Result<()> {
     test(
         0,
         r#"import std.bytes
@@ -72,22 +72,6 @@ fun main() -> i32 {
     }
     if short[0] != 'w' as u8 || short[1] != 'x' as u8 {
         return 5
-    }
-
-    if std.bytes.compare(b"abc", b"abc") != 0 {
-        return 6
-    }
-    if std.bytes.compare(b"abc", b"abd") >= 0 {
-        return 7
-    }
-    if std.bytes.compare(b"abd", b"abc") <= 0 {
-        return 8
-    }
-    if std.bytes.compare(b"ab", b"abc") >= 0 {
-        return 9
-    }
-    if std.bytes.compare(b"abc", b"ab") <= 0 {
-        return 10
     }
 
     return 0

--- a/compiler/driver/tests/cmp.rs
+++ b/compiler/driver/tests/cmp.rs
@@ -1,0 +1,41 @@
+mod driver_test_support;
+
+use driver_test_support::run_program as test;
+
+#[test]
+fn std_cmp_byte_slice_compare_orders_lexicographically() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.cmp
+
+use std.cmp.Ordering
+use std.cmp.Ord
+
+fun same<T: Ord>(left: T, right: T) -> bool {
+    return left.compare(right) == Ordering::Equal
+}
+
+fun main() -> i32 {
+    if b"abc".compare(b"abc") != Ordering::Equal {
+        return 1
+    }
+    if b"abc".compare(b"abd") != Ordering::Less {
+        return 2
+    }
+    if b"abd".compare(b"abc") != Ordering::Greater {
+        return 3
+    }
+    if b"ab".compare(b"abc") != Ordering::Less {
+        return 4
+    }
+    if b"abc".compare(b"ab") != Ordering::Greater {
+        return 5
+    }
+    if !same(b"kaede", b"kaede") {
+        return 6
+    }
+
+    return 0
+}"#,
+    )
+}

--- a/library/src/std/bytes.kd
+++ b/library/src/std/bytes.kd
@@ -82,27 +82,3 @@ export fun copy(dst: mut [u8], src: [u8]) -> u64 {
     }
     return n
 }
-
-// Lexicographically compares byte slices, matching the ordering used by
-// database keys and binary protocol fields.
-export fun compare(left: [u8], right: [u8]) -> i32 {
-    let n = if left.len() < right.len() { left.len() } else { right.len() }
-    let mut i = 0
-    while i < n {
-        if left[i] < right[i] {
-            return -1
-        }
-        if left[i] > right[i] {
-            return 1
-        }
-        i += 1
-    }
-
-    if left.len() < right.len() {
-        return -1
-    }
-    if left.len() > right.len() {
-        return 1
-    }
-    return 0
-}

--- a/library/src/std/cmp.kd
+++ b/library/src/std/cmp.kd
@@ -1,0 +1,43 @@
+// Shared comparison primitives.
+//
+// `Ordering` mirrors Rust's result type for total ordering: callers can match
+// on the result instead of relying on magic integer values such as -1, 0, and 1.
+export enum Ordering {
+    Less,
+    Equal,
+    Greater,
+}
+
+// Types implementing `Ord` provide a total ordering against values of the same
+// concrete type. Implementations write the concrete type for `other`; the
+// compiler substitutes the interface name with the implementing type when
+// checking generic bounds.
+export interface Ord {
+    fun compare(self, other: Ord) -> Ordering
+}
+
+impl [u8] {
+    // Compares byte slices lexicographically. Bytes are compared first; when
+    // one slice is a prefix of the other, the shorter slice sorts first.
+    export fun compare(self, other: [u8]) -> Ordering {
+        let n = if self.len() < other.len() { self.len() } else { other.len() }
+        let mut i = 0
+        while i < n {
+            if self[i] < other[i] {
+                return Ordering::Less
+            }
+            if self[i] > other[i] {
+                return Ordering::Greater
+            }
+            i += 1
+        }
+
+        if self.len() < other.len() {
+            return Ordering::Less
+        }
+        if self.len() > other.len() {
+            return Ordering::Greater
+        }
+        return Ordering::Equal
+    }
+}


### PR DESCRIPTION
## Summary
- add std.cmp.Ordering and std.cmp.Ord
- add [u8].compare for lexicographic byte-slice ordering
- remove std.bytes.compare and move its coverage into cmp tests

## Verification
- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- KAEDE_DIR=/tmp/kaede-cmp-pr-check cargo test --release -p kaede_compiler_driver --test bytes --test cmp
- KAEDE_DIR=/tmp/kaede-cmp-pr-check cargo test --release --no-fail-fast

## Docs
- Not updated: the existing website does not document std.bytes.compare or std.cmp APIs.