### PR TITLE
feat: add top-level const declarations

### DIFF
--- a/compiler/ast/src/top.rs
+++ b/compiler/ast/src/top.rs
@@ -223,6 +223,15 @@ pub struct TypeAlias {
     pub span: Span,
 }
 
+#[derive(Debug, Clone)]
+pub struct TopConst {
+    pub vis: Visibility,
+    pub name: Ident,
+    pub ty: Rc<Ty>,
+    pub init: Rc<Expr>,
+    pub span: Span,
+}
+
 #[derive(Debug)]
 pub struct TopLevel {
     pub kind: TopLevelKind,
@@ -240,4 +249,5 @@ pub enum TopLevelKind {
     Use(Use),
     TypeAlias(TypeAlias),
     Interface(Interface),
+    Const(TopConst),
 }

--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -415,6 +415,30 @@ fn let_statement() -> anyhow::Result<()> {
 }
 
 #[test]
+fn top_level_const_statement() -> anyhow::Result<()> {
+    let program = r"const BNODE_LEAF: u16 = 2
+
+    fun main() -> i32 {
+        let kind: u16 = BNODE_LEAF
+        return kind as i32
+    }";
+
+    assert_eq!(exec(program)?, 2);
+
+    let program = r"const BASE: u32 = 2
+    const LEN: u32 = BASE + 2
+
+    fun main() -> i32 {
+        let xs = [58; LEN]
+        return xs[3]
+    }";
+
+    assert_eq!(exec(program)?, 58);
+
+    Ok(())
+}
+
+#[test]
 fn local_const_statement() -> anyhow::Result<()> {
     let program = r"fun main() -> i32 {
         const base: i32 = 48

--- a/compiler/driver/tests/import.rs
+++ b/compiler/driver/tests/import.rs
@@ -27,6 +27,28 @@ fn write_rust_import_crate(root_dir: &Path, crate_name: &str, lib_src: &str) -> 
 }
 
 #[test]
+fn import_top_level_const() -> anyhow::Result<()> {
+    let tempdir = assert_fs::TempDir::new()?;
+
+    let constants = tempdir.child("constants.kd");
+    constants.write_str(
+        r#"export const BASE: u32 = 48
+        export const OFFSET: u32 = 10
+        export const SUM: u32 = BASE + OFFSET"#,
+    )?;
+
+    let main = tempdir.child("main.kd");
+    main.write_str(
+        r#"import constants
+        fun main() -> i32 {
+            return constants.SUM as i32
+        }"#,
+    )?;
+
+    test(58, &[constants.path(), main.path()], &tempdir)
+}
+
+#[test]
 fn import_functions() -> anyhow::Result<()> {
     let tempdir = assert_fs::TempDir::new()?;
 

--- a/compiler/parse/src/top.rs
+++ b/compiler/parse/src/top.rs
@@ -91,6 +91,11 @@ impl Parser {
                 (kind.span, TopLevelKind::Interface(kind))
             }
 
+            TokenKind::Const => {
+                let kind = self.top_level_const(vis)?;
+                (kind.span, TopLevelKind::Const(kind))
+            }
+
             _ => {
                 return Err(ParseError::ExpectedError {
                     expected: "top-level declaration".to_string(),
@@ -129,7 +134,28 @@ impl Parser {
                 | TokenKind::Use
                 | TokenKind::Type
                 | TokenKind::Interface
+                | TokenKind::Const
         )
+    }
+
+    fn top_level_const(&mut self, vis: Visibility) -> ParseResult<kaede_ast::top::TopConst> {
+        let start = self.consume(&TokenKind::Const).unwrap().start;
+        let name = self.ident()?;
+
+        self.consume(&TokenKind::Colon)?;
+        let ty = self.ty()?;
+
+        self.consume(&TokenKind::Eq)?;
+        let init = self.expr()?;
+        let span = self.new_span(start, init.span.finish);
+
+        Ok(kaede_ast::top::TopConst {
+            vis,
+            name,
+            init: init.into(),
+            ty: ty.into(),
+            span,
+        })
     }
 
     fn type_alias(&mut self, vis: Visibility) -> ParseResult<TypeAlias> {

--- a/compiler/semantic/src/const_eval.rs
+++ b/compiler/semantic/src/const_eval.rs
@@ -1,4 +1,8 @@
+use std::rc::Rc;
+
 use kaede_ast as ast;
+use kaede_ir::{self as ir, ty as ir_type};
+use kaede_span::Span;
 use kaede_symbol_table::{ConstValue, SymbolTableValueKind};
 
 use crate::SemanticAnalyzer;
@@ -92,5 +96,36 @@ impl SemanticAnalyzer {
 
             _ => None,
         }
+    }
+
+    pub(crate) fn module_const_integer_literal(
+        &self,
+        value: i128,
+        ty: &Rc<ir_type::Ty>,
+        span: Span,
+    ) -> Option<ir::expr::Expr> {
+        let int_kind = match ty.kind.as_ref() {
+            ir_type::TyKind::Fundamental(kind) => match kind.kind {
+                ir_type::FundamentalTypeKind::I8 => ir::expr::IntKind::I8(value as i8),
+                ir_type::FundamentalTypeKind::U8 => ir::expr::IntKind::U8(value as u8),
+                ir_type::FundamentalTypeKind::I16 => ir::expr::IntKind::I16(value as i16),
+                ir_type::FundamentalTypeKind::U16 => ir::expr::IntKind::U16(value as u16),
+                ir_type::FundamentalTypeKind::I32 => ir::expr::IntKind::I32(value as i32),
+                ir_type::FundamentalTypeKind::U32 => ir::expr::IntKind::U32(value as u32),
+                ir_type::FundamentalTypeKind::I64 => ir::expr::IntKind::I64(value as i64),
+                ir_type::FundamentalTypeKind::U64 => ir::expr::IntKind::U64(value as u64),
+                _ => return None,
+            },
+            _ => return None,
+        };
+
+        Some(ir::expr::Expr {
+            kind: ir::expr::ExprKind::Int(ir::expr::Int {
+                kind: int_kind,
+                span,
+            }),
+            ty: ty.clone(),
+            span,
+        })
     }
 }

--- a/compiler/semantic/src/const_eval.rs
+++ b/compiler/semantic/src/const_eval.rs
@@ -98,7 +98,8 @@ impl SemanticAnalyzer {
         }
     }
 
-    pub(crate) fn module_const_integer_literal(
+    /// Build a typed integer literal for a top-level `const` referenced at a use site.
+    pub(crate) fn inline_top_level_const_int(
         &self,
         value: i128,
         ty: &Rc<ir_type::Ty>,

--- a/compiler/semantic/src/const_eval.rs
+++ b/compiler/semantic/src/const_eval.rs
@@ -3,11 +3,58 @@ use std::rc::Rc;
 use kaede_ast as ast;
 use kaede_ir::{self as ir, ty as ir_type};
 use kaede_span::Span;
-use kaede_symbol_table::{ConstValue, SymbolTableValueKind};
+use kaede_symbol_table::{ConstValue, SymbolTableValue, SymbolTableValueKind};
 
 use crate::SemanticAnalyzer;
 
 impl SemanticAnalyzer {
+    fn const_integer_from_symbol(value: &SymbolTableValue) -> Option<i128> {
+        match &value.kind {
+            SymbolTableValueKind::Variable(info) if info.is_const => info
+                .const_value
+                .as_ref()
+                .map(|ConstValue::Integer(value)| *value),
+            _ => None,
+        }
+    }
+
+    /// Resolve `module.path.CONST` / `module::CONST` to an exported top-level integer const.
+    fn evaluate_imported_module_const_expr(&self, node: &ast::expr::Binary) -> Option<i128> {
+        use ast::expr::BinaryKind;
+
+        let ast::expr::ExprKind::Ident(const_name) = &node.rhs.kind else {
+            return None;
+        };
+
+        let mut module_segments = Vec::new();
+        match node.kind {
+            BinaryKind::Access => node.lhs.collect_access_chain(&mut module_segments),
+            BinaryKind::ScopeResolution => node
+                .lhs
+                .collect_scope_resolution_chain(&mut module_segments),
+            _ => return None,
+        }
+
+        if module_segments.is_empty() {
+            return None;
+        }
+
+        let (_, module_path) = self
+            .create_module_path_from_access_chain(
+                &module_segments
+                    .iter()
+                    .map(|ident| ident.symbol())
+                    .collect::<Vec<_>>(),
+                node.lhs.span,
+            )
+            .ok()?;
+
+        let module = self.modules.get(&module_path)?;
+        let value = module.lookup_public_symbol(&const_name.symbol())?;
+        let borrowed = value.borrow();
+        Self::const_integer_from_symbol(&borrowed)
+    }
+
     pub(crate) fn is_const_initializer(&self, expr: &ast::expr::Expr) -> bool {
         use ast::expr::{BinaryKind, ExprKind};
 
@@ -34,7 +81,7 @@ impl SemanticAnalyzer {
 
             ExprKind::Binary(node) => {
                 if matches!(node.kind, BinaryKind::Access | BinaryKind::ScopeResolution) {
-                    return false;
+                    return self.evaluate_imported_module_const_expr(node).is_some();
                 }
 
                 if matches!(node.kind, BinaryKind::Cast) {
@@ -72,6 +119,10 @@ impl SemanticAnalyzer {
             ExprKind::BitNot(node) => self.evaluate_integer_const_expr(&node.operand).map(|v| !v),
 
             ExprKind::Binary(node) => {
+                if matches!(node.kind, BinaryKind::Access | BinaryKind::ScopeResolution) {
+                    return self.evaluate_imported_module_const_expr(node);
+                }
+
                 if matches!(node.kind, BinaryKind::Cast) {
                     return self.evaluate_integer_const_expr(&node.lhs);
                 }

--- a/compiler/semantic/src/context.rs
+++ b/compiler/semantic/src/context.rs
@@ -263,6 +263,10 @@ impl ModuleContext {
         self.symbol_table_stack.len()
     }
 
+    /// Look up `symbol` and return the binding plus its scope depth.
+    ///
+    /// Depth is the index in `symbol_table_stack` (0 = module root, 1+ = function/closure scopes).
+    /// Private module items also report depth 0.
     pub fn lookup_symbol_with_depth(
         &self,
         symbol: &Symbol,

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -4242,7 +4242,7 @@ impl SemanticAnalyzer {
                     is_const: true,
                     const_value: Some(kaede_symbol_table::ConstValue::Integer(value)),
                     ..
-                }) if depth == 0 => self.module_const_integer_literal(*value, ty, node.span()).ok_or(
+                }) if depth == 0 => self.inline_top_level_const_int(*value, ty, node.span()).ok_or(
                     SemanticError::Undeclared {
                         name: node.symbol(),
                         span: node.span(),

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -4237,6 +4237,10 @@ impl SemanticAnalyzer {
         primary
             .or(fallback)
             .map(|(value, depth)| match &value.borrow().kind {
+                // `depth` is the index in `symbol_table_stack` where the name was found.
+                // 0 = module root (`insert_symbol_to_root_scope`): top-level `const`, `fun`, etc.
+                // 1+ = inner scopes (function params/body, closures): local `const` lowers to `Let`
+                // and must stay `Variable`. Top-level const has no stack slot, so inline it here.
                 SymbolTableValueKind::Variable(VariableInfo {
                     ty,
                     is_const: true,

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -4246,12 +4246,12 @@ impl SemanticAnalyzer {
                     is_const: true,
                     const_value: Some(kaede_symbol_table::ConstValue::Integer(value)),
                     ..
-                }) if depth == 0 => self.inline_top_level_const_int(*value, ty, node.span()).ok_or(
-                    SemanticError::Undeclared {
+                }) if depth == 0 => self
+                    .inline_top_level_const_int(*value, ty, node.span())
+                    .ok_or(SemanticError::Undeclared {
                         name: node.symbol(),
                         span: node.span(),
-                    },
-                ),
+                    }),
                 SymbolTableValueKind::Variable(VariableInfo { ty, .. }) => {
                     self.register_capture(node.symbol(), depth);
                     Ok(ir::expr::Expr {

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -4237,6 +4237,17 @@ impl SemanticAnalyzer {
         primary
             .or(fallback)
             .map(|(value, depth)| match &value.borrow().kind {
+                SymbolTableValueKind::Variable(VariableInfo {
+                    ty,
+                    is_const: true,
+                    const_value: Some(kaede_symbol_table::ConstValue::Integer(value)),
+                    ..
+                }) if depth == 0 => self.module_const_integer_literal(*value, ty, node.span()).ok_or(
+                    SemanticError::Undeclared {
+                        name: node.symbol(),
+                        span: node.span(),
+                    },
+                ),
                 SymbolTableValueKind::Variable(VariableInfo { ty, .. }) => {
                     self.register_capture(node.symbol(), depth);
                     Ok(ir::expr::Expr {

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -166,6 +166,7 @@ impl SemanticAnalyzer {
     ) -> anyhow::Result<()> {
         let current_module_path = self.current_module_path().clone();
         let mut top_levels = Vec::new();
+        let mut top_level_consts = Vec::new();
         let mut top_level_statements = Vec::new();
         let mut explicit_main_span = None;
 
@@ -175,7 +176,11 @@ impl SemanticAnalyzer {
                     if explicit_main_span.is_none() {
                         explicit_main_span = Self::find_explicit_main_span(&top_level);
                     }
-                    top_levels.push(top_level);
+                    if matches!(top_level.kind, ast::top::TopLevelKind::Const(_)) {
+                        top_level_consts.push(top_level);
+                    } else {
+                        top_levels.push(top_level);
+                    }
                 }
                 ast::ModuleItem::Stmt(stmt) => top_level_statements.push(stmt),
             }
@@ -226,6 +231,11 @@ impl SemanticAnalyzer {
             .into_iter()
             .partition(|top| matches!(top.kind, ast::top::TopLevelKind::Use(_)));
 
+        let others: Vec<_> = others
+            .into_iter()
+            .filter(|top| !matches!(top.kind, ast::top::TopLevelKind::Const(_)))
+            .collect();
+
         // Analyze all imports.
         for top_level in imports {
             if let TopLevelAnalysisResult::Imported(imported_irs) =
@@ -264,6 +274,17 @@ impl SemanticAnalyzer {
                 }
                 TopLevelAnalysisResult::GenericTopLevel => {}
                 TopLevelAnalysisResult::Imported(_) => {}
+            }
+        }
+
+        // Register module constants in source order so later consts can refer to earlier ones.
+        for top_level in top_level_consts {
+            if let TopLevelAnalysisResult::Imported(imported_irs) =
+                self.analyze_top_level(top_level)?
+            {
+                assert!(imported_irs.is_empty());
+            } else {
+                unreachable!()
             }
         }
 

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -6,8 +6,8 @@ use std::{
 
 use crate::{context::AnalyzeCommand, rust_import, SemanticAnalyzer, SemanticError};
 use kaede_symbol_table::{
-    GenericEnumInfo, GenericFuncInfo, GenericImplInfo, GenericInfo, GenericKind, GenericStructInfo,
-    ResolvedGenericParam, ResolvedGenericParams, SymbolTable, SymbolTableValue,
+    ConstValue, GenericEnumInfo, GenericFuncInfo, GenericImplInfo, GenericInfo, GenericKind,
+    GenericStructInfo, ResolvedGenericParam, ResolvedGenericParams, SymbolTable, SymbolTableValue,
     SymbolTableValueKind, VariableInfo,
 };
 
@@ -48,6 +48,7 @@ impl SemanticAnalyzer {
             TopLevelKind::Use(node) => self.analyze_use(node),
             TopLevelKind::TypeAlias(node) => self.analyze_type_alias(node),
             TopLevelKind::Interface(node) => self.analyze_interface(node),
+            TopLevelKind::Const(node) => self.analyze_top_const(node),
         }
     }
 
@@ -231,6 +232,7 @@ impl SemanticAnalyzer {
         self.with_module(module_path.clone(), |analyzer| {
             let mut results = vec![];
             let mut top_levels = Vec::new();
+            let mut top_level_consts = Vec::new();
             let mut explicit_main_span = None;
 
             for item in parsed_module.items {
@@ -239,7 +241,11 @@ impl SemanticAnalyzer {
                         if explicit_main_span.is_none() {
                             explicit_main_span = Self::find_explicit_main_span(&top_level);
                         }
-                        top_levels.push(top_level);
+                        if matches!(top_level.kind, ast::top::TopLevelKind::Const(_)) {
+                            top_level_consts.push(top_level);
+                        } else {
+                            top_levels.push(top_level);
+                        }
                     }
                     ast::ModuleItem::Stmt(stmt) => {
                         return Err(SemanticError::TopLevelStatementsOnlyAllowedInEntryUnit {
@@ -280,6 +286,11 @@ impl SemanticAnalyzer {
                 )
             });
 
+            let others: Vec<_> = others
+                .into_iter()
+                .filter(|top| !matches!(top.kind, ast::top::TopLevelKind::Const(_)))
+                .collect();
+
             // Analyze all imports.
             for top_level in imports {
                 results.push(analyzer.analyze_top_level(top_level)?);
@@ -292,6 +303,10 @@ impl SemanticAnalyzer {
 
             // Declare all types.
             for top_level in types {
+                results.push(analyzer.analyze_top_level(top_level)?);
+            }
+
+            for top_level in top_level_consts {
                 results.push(analyzer.analyze_top_level(top_level)?);
             }
 
@@ -1037,6 +1052,37 @@ impl SemanticAnalyzer {
         Ok(TopLevelAnalysisResult::TopLevel(
             ir::top::TopLevel::Interface(ir),
         ))
+    }
+
+    pub fn analyze_top_const(
+        &mut self,
+        node: ast::top::TopConst,
+    ) -> anyhow::Result<TopLevelAnalysisResult> {
+        if !self.is_const_initializer(&node.init) {
+            return Err(SemanticError::ConstInitializerNotConst {
+                span: node.init.span,
+            }
+            .into());
+        }
+
+        let annotated = self.analyze_type(&node.ty)?;
+        let _init = self.analyze_expr_with_expected_type(&node.init, annotated.clone())?;
+        let const_ty = ir::ty::change_mutability_dup(annotated, ir::ty::Mutability::Not);
+        let const_value = self
+            .evaluate_integer_const_expr(&node.init)
+            .map(ConstValue::Integer);
+
+        self.insert_symbol_to_root_scope(
+            node.name.symbol(),
+            SymbolTableValue::new(
+                SymbolTableValueKind::Variable(VariableInfo::new_const(const_ty, const_value)),
+                self.current_module_path().clone(),
+            ),
+            node.vis,
+            node.span,
+        )?;
+
+        Ok(TopLevelAnalysisResult::Imported(vec![]))
     }
 
     pub fn analyze_type_alias(

--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -772,10 +772,7 @@ fn import_exported_top_level_const() -> anyhow::Result<()> {
 fn import_top_level_const_via_use() -> anyhow::Result<()> {
     ImportTestCase {
         name: "top_level_const_via_use",
-        modules: HashMap::from([(
-            "constants",
-            "export const ANSWER: i32 = 42",
-        )]),
+        modules: HashMap::from([("constants", "export const ANSWER: i32 = 42")]),
         main_content: r#"
             import constants
             use constants.ANSWER
@@ -816,10 +813,7 @@ fn import_top_level_const_arithmetic_in_module() -> anyhow::Result<()> {
 fn import_private_top_level_const_fails() -> anyhow::Result<()> {
     ImportTestCase {
         name: "private_top_level_const",
-        modules: HashMap::from([(
-            "secrets",
-            "const HIDDEN: i32 = 99",
-        )]),
+        modules: HashMap::from([("secrets", "const HIDDEN: i32 = 99")]),
         main_content: r#"
             import secrets
             fun main() -> i32 {

--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -810,6 +810,48 @@ fn import_top_level_const_arithmetic_in_module() -> anyhow::Result<()> {
 }
 
 #[test]
+fn import_top_level_const_in_array_repeat_count() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "top_level_const_in_array_repeat_count",
+        modules: HashMap::from([(
+            "layout",
+            r#"
+                export const BASE: u32 = 2
+                export const LEN: u32 = BASE + 2
+            "#,
+        )]),
+        main_content: r#"
+            import layout
+            fun main() -> i32 {
+                let xs = [0; layout.LEN]
+                return xs[3]
+            }
+        "#,
+        expected_min_top_levels: 2,
+        should_fail: false,
+    }
+    .run()
+}
+
+#[test]
+fn import_private_top_level_const_in_array_repeat_fails() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "private_top_level_const_in_array_repeat",
+        modules: HashMap::from([("secrets", "const HIDDEN: u32 = 4")]),
+        main_content: r#"
+            import secrets
+            fun main() -> i32 {
+                let _ = [0; secrets.HIDDEN]
+                return 0
+            }
+        "#,
+        expected_min_top_levels: 0,
+        should_fail: true,
+    }
+    .run()
+}
+
+#[test]
 fn import_private_top_level_const_fails() -> anyhow::Result<()> {
     ImportTestCase {
         name: "private_top_level_const",

--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -741,6 +741,125 @@ fn private_use_is_still_visible_locally() -> anyhow::Result<()> {
 // `analyze_use` (the old code marked every `use` as Public to keep this path
 // working; the new code must rely on same-module private lookup instead).
 #[test]
+fn import_exported_top_level_const() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "exported_top_level_const",
+        modules: HashMap::from([(
+            "constants",
+            r#"
+                export const PAGE_SIZE: u64 = 4096
+                export const LEAF: u16 = 2
+            "#,
+        )]),
+        main_content: r#"
+            import constants
+            fun main() -> i32 {
+                let page: u64 = constants.PAGE_SIZE
+                let kind: u16 = constants.LEAF
+                if page != constants.PAGE_SIZE {
+                    return 0
+                }
+                return kind as i32
+            }
+        "#,
+        expected_min_top_levels: 2,
+        should_fail: false,
+    }
+    .run()
+}
+
+#[test]
+fn import_top_level_const_via_use() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "top_level_const_via_use",
+        modules: HashMap::from([(
+            "constants",
+            "export const ANSWER: i32 = 42",
+        )]),
+        main_content: r#"
+            import constants
+            use constants.ANSWER
+            fun main() -> i32 {
+                return ANSWER
+            }
+        "#,
+        expected_min_top_levels: 2,
+        should_fail: false,
+    }
+    .run()
+}
+
+#[test]
+fn import_top_level_const_arithmetic_in_module() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "top_level_const_arithmetic_in_module",
+        modules: HashMap::from([(
+            "layout",
+            r#"
+                export const BASE: u32 = 2
+                export const LEN: u32 = BASE + 2
+            "#,
+        )]),
+        main_content: r#"
+            import layout
+            fun main() -> i32 {
+                return layout.LEN as i32
+            }
+        "#,
+        expected_min_top_levels: 2,
+        should_fail: false,
+    }
+    .run()
+}
+
+#[test]
+fn import_private_top_level_const_fails() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "private_top_level_const",
+        modules: HashMap::from([(
+            "secrets",
+            "const HIDDEN: i32 = 99",
+        )]),
+        main_content: r#"
+            import secrets
+            fun main() -> i32 {
+                return secrets.HIDDEN
+            }
+        "#,
+        expected_min_top_levels: 0,
+        should_fail: true,
+    }
+    .run()
+}
+
+#[test]
+fn export_use_reexports_top_level_const() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "export_use_top_level_const",
+        modules: HashMap::from([
+            ("provider", "export const FLAG: u16 = 7"),
+            (
+                "middle",
+                r#"
+                import provider
+                export use provider.FLAG
+            "#,
+            ),
+        ]),
+        main_content: r#"
+            import middle
+            fun main() -> i32 {
+                let flag: u16 = middle.FLAG
+                return flag as i32
+            }
+        "#,
+        expected_min_top_levels: 2,
+        should_fail: false,
+    }
+    .run()
+}
+
+#[test]
 fn private_use_is_reachable_from_generic_body() -> anyhow::Result<()> {
     ImportTestCase {
         name: "private_use_is_reachable_from_generic_body",

--- a/compiler/semantic/tests/stmt.rs
+++ b/compiler/semantic/tests/stmt.rs
@@ -112,3 +112,57 @@ fn local_const_rejects_assignment() -> anyhow::Result<()> {
     )?;
     Ok(())
 }
+
+#[test]
+fn top_level_const() -> anyhow::Result<()> {
+    semantic_analyze(
+        "const BNODE_LEAF: u16 = 2
+
+        fun main() -> i32 {
+            let kind: u16 = BNODE_LEAF
+            return kind as i32
+        }
+    ",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn top_level_const_arithmetic() -> anyhow::Result<()> {
+    semantic_analyze(
+        "const BASE: u32 = 2
+        const LEN: u32 = BASE + 2
+
+        fun f() {
+            let _ = [0; LEN]
+        }
+    ",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn top_level_const_rejects_runtime_initializer() -> anyhow::Result<()> {
+    semantic_analyze_expect_error(
+        "fun value() -> i32 {
+            return 1
+        }
+
+        const X: i32 = value()
+    ",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn top_level_const_rejects_assignment() -> anyhow::Result<()> {
+    semantic_analyze_expect_error(
+        "const X: i32 = 1
+
+        fun f() {
+            X = 2
+        }
+    ",
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add module-level `const NAME: Ty = expr` (and `export const`) parsing and semantic registration.
- Analyze top-level constants in source order after type declarations and before function bodies, so later consts can refer to earlier ones.
- Inline module-scope integer constants at use sites instead of emitting runtime globals.

## Motivation

Continues [#321](https://github.com/itto-hiramoto/kaede/issues/321) after local `const` landed in #322. The database/B-tree example can name page sizes, node kinds, and offsets without zero-argument helper functions or magic numbers.

## Test plan

- [x] `cargo test --release -p kaede_semantic top_level_const`
- [x] `cargo test --release -p kaede_codegen top_level_const`
- [x] `cargo clippy -p kaede_semantic -p kaede_parse -p kaede_ast -- -D warnings`

Example usage:

```kd
const BNODE_LEAF: u16 = 2

fun main() -> i32 {
    let kind = BNODE_LEAF
    return kind as i32
}
```

## Deferred

- `const NAME = expr` type inference
- Cross-module `import` of exported consts (visibility wiring exists; dedicated tests not added)
- Non-integer module const inlining (`bool`, strings)