### PR TITLE
Fix closure-valued callees not captured

### DIFF
--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -5053,6 +5053,19 @@ fn closure_as_return_value_immediate_call() -> anyhow::Result<()> {
 }
 
 #[test]
+fn closure_captures_local_closure_callee() -> anyhow::Result<()> {
+    let program = r#"
+        fun main() -> i32 {
+            let add = |n| n + 1
+            let use_add = |n| add(n) + 1
+            return use_add(56)
+        }
+    "#;
+    assert_eq!(exec(program)?, 58);
+    Ok(())
+}
+
+#[test]
 fn function_value_assigned_and_called() -> anyhow::Result<()> {
     let program = r#"
         fun add(x: i32, y: i32) -> i32 {

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -2156,12 +2156,12 @@ impl SemanticAnalyzer {
             return result;
         }
 
-        let symbol_value =
-            self.lookup_symbol(callee.symbol())
-                .ok_or_else(|| SemanticError::Undeclared {
-                    name: callee.symbol(),
-                    span: node.span,
-                })?;
+        let (symbol_value, depth) = self
+            .lookup_symbol_with_depth_and_fallback(callee.symbol())
+            .ok_or_else(|| SemanticError::Undeclared {
+                name: callee.symbol(),
+                span: node.span,
+            })?;
 
         let borrowed = symbol_value.borrow();
         match &borrowed.kind {
@@ -2215,6 +2215,7 @@ impl SemanticAnalyzer {
             SymbolTableValueKind::Generic(info) => self.analyze_generic_fn_call(info, node),
 
             SymbolTableValueKind::Variable(VariableInfo { ty, .. }) => {
+                self.register_capture(callee.symbol(), depth);
                 self.analyze_callable_value(node, callee.symbol(), ty.clone(), None)
             }
 

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -516,34 +516,8 @@ impl SemanticAnalyzer {
     }
 
     pub fn lookup_symbol(&self, symbol: Symbol) -> Option<Rc<RefCell<SymbolTableValue>>> {
-        let panic = || {
-            panic!(
-                "Module not found: {:?}",
-                self.current_module_path().get_module_names_from_root()
-            )
-        };
-
-        if let Some(value) = self
-            .modules
-            .get(self.current_module_path())
-            .unwrap_or_else(panic)
-            .lookup_symbol(&symbol)
-        {
-            return Some(value);
-        }
-
-        if let Some(fallback_module_path) = self.fallback_lookup_module_path() {
-            if let Some(module) = self.modules.get(fallback_module_path) {
-                if let Some(value) = module.lookup_symbol(&symbol) {
-                    return Some(value);
-                }
-            }
-        }
-
-        self.modules
-            .get(self.module_path())
-            .unwrap_or_else(panic)
-            .lookup_symbol(&symbol)
+        self.lookup_symbol_with_depth_and_fallback(symbol)
+            .map(|(value, _)| value)
     }
 
     pub fn lookup_qualified_symbol(
@@ -656,6 +630,40 @@ impl SemanticAnalyzer {
         self.modules
             .get(module_path)
             .expect("Module context must exist")
+            .lookup_symbol_with_depth(&symbol)
+    }
+
+    fn lookup_symbol_with_depth_and_fallback(
+        &self,
+        symbol: Symbol,
+    ) -> Option<(Rc<RefCell<SymbolTableValue>>, usize)> {
+        let panic = || {
+            panic!(
+                "Module not found: {:?}",
+                self.current_module_path().get_module_names_from_root()
+            )
+        };
+
+        if let Some(value) = self
+            .modules
+            .get(self.current_module_path())
+            .unwrap_or_else(panic)
+            .lookup_symbol_with_depth(&symbol)
+        {
+            return Some(value);
+        }
+
+        if let Some(fallback_module_path) = self.fallback_lookup_module_path() {
+            if let Some(module) = self.modules.get(fallback_module_path) {
+                if let Some(value) = module.lookup_symbol_with_depth(&symbol) {
+                    return Some(value);
+                }
+            }
+        }
+
+        self.modules
+            .get(self.module_path())
+            .unwrap_or_else(panic)
             .lookup_symbol_with_depth(&symbol)
     }
 

--- a/compiler/semantic/tests/expr.rs
+++ b/compiler/semantic/tests/expr.rs
@@ -757,6 +757,52 @@ fn closure_captures_outer_variables() -> anyhow::Result<()> {
 }
 
 #[test]
+fn closure_captures_local_closure_callee() -> anyhow::Result<()> {
+    let ir = semantic_analyze(
+        "
+        fun f() -> i32 {
+            let add = |n| n + 1
+            let use_add = |n| add(n) + 1
+            return use_add(56)
+        }
+    ",
+    )?;
+
+    let body = find_function_body(ir, "f");
+
+    let closure_expr = match &body.body[1] {
+        Stmt::Let(let_stmt) => let_stmt.init.as_ref().unwrap(),
+        _ => panic!("expected let binding for closure"),
+    };
+
+    let (captures, capture_tys_len) = match &closure_expr.kind {
+        IrExprKind::Closure(closure) => {
+            let captured: HashSet<Symbol> = closure
+                .captures
+                .iter()
+                .map(|c| match &c.kind {
+                    IrExprKind::Variable(v) => v.name,
+                    _ => panic!("unexpected capture kind"),
+                })
+                .collect();
+
+            let captured_tys_len = match closure_expr.ty.kind.as_ref() {
+                IrTyKind::Closure(ty) => ty.captures.len(),
+                _ => panic!("expected closure type"),
+            };
+
+            (captured, captured_tys_len)
+        }
+        kind => panic!("expected closure expr, got {kind:?}"),
+    };
+
+    assert_eq!(captures, HashSet::from([Symbol::from("add".to_string())]));
+    assert_eq!(capture_tys_len, 1);
+
+    Ok(())
+}
+
+#[test]
 fn keyword_arguments_reorder() -> anyhow::Result<()> {
     semantic_analyze(
         "fun add(a: i32, b: i32) -> i32 { return a + b }


### PR DESCRIPTION
## Summary

- Capture local callable variables when a bare identifier call is analyzed.
- Share fallback-aware symbol lookup for callers that also need scope depth.
- Add semantic and codegen regressions for a closure calling another captured closure.

Fixes #332

## Verification

- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo clippy -- -D warnings`
- `nix develop -c cargo test -p kaede_semantic closure_captures_local_closure_callee`
- `nix develop -c cargo test -p kaede_codegen closure_captures_local_closure_callee`
- `nix develop -c cargo test --release --no-fail-fast`
