### PR TITLE
refactor: route slice generic impl through BuiltinSlice symbol (#327)

### DIFF
--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -59,52 +59,7 @@ fn link_test_executable(
     Ok(())
 }
 
-/// Return exit status
-fn exec(program: &str) -> anyhow::Result<i32> {
-    let context = Context::create();
-    let cgcx = CodegenCtx::new(&context, false).unwrap();
-
-    let file = PathBuf::from("test").into();
-
-    let ast = Parser::new(program, file).run().unwrap();
-    let ir = SemanticAnalyzer::new_for_single_file_test().analyze(
-        ast,
-        AnalyzeOptions {
-            no_autoload: false,
-            no_prelude: false,
-            is_entry_unit: true,
-        },
-    )?;
-
-    let module = CodeGenerator::new(&cgcx).unwrap().codegen(ir).unwrap();
-    if let Some(main_fn) = module.get_function("main") {
-        unsafe {
-            main_fn.delete();
-        }
-    }
-
-    let temp_dir = tempdir()?;
-    let bitcode_path = temp_dir.path().join("test.bc");
-    let obj_path = temp_dir.path().join("test.o");
-    let harness_path = temp_dir.path().join("test_main.c");
-    let exe_path = temp_dir.path().join("test_exec");
-
-    module.write_bitcode_to_path(&bitcode_path);
-
-    let status = Command::new("llc")
-        .args([
-            "-filetype=obj",
-            "-relocation-model=pic",
-            "-o",
-            obj_path.to_str().unwrap(),
-            bitcode_path.to_str().unwrap(),
-        ])
-        .status()?;
-    if !status.success() {
-        anyhow::bail!("Failed to emit object file using 'llc'");
-    }
-
-    let harness_src = r#"
+const TEST_RUNTIME_HARNESS: &str = r#"
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -135,9 +90,54 @@ int main(void) {
 }
 "#;
 
-    fs::write(&harness_path, harness_src)?;
+fn compile_and_link_test(
+    program: &str,
+    options: AnalyzeOptions,
+) -> anyhow::Result<(tempfile::TempDir, PathBuf)> {
+    let context = Context::create();
+    let cgcx = CodegenCtx::new(&context, false).unwrap();
 
+    let file = PathBuf::from("test").into();
+    let ast = Parser::new(program, file).run().unwrap();
+    let ir = SemanticAnalyzer::new_for_single_file_test().analyze(ast, options)?;
+
+    let module = CodeGenerator::new(&cgcx).unwrap().codegen(ir).unwrap();
+    if let Some(main_fn) = module.get_function("main") {
+        unsafe {
+            main_fn.delete();
+        }
+    }
+
+    let temp_dir = tempdir()?;
+    let bitcode_path = temp_dir.path().join("test.bc");
+    let obj_path = temp_dir.path().join("test.o");
+    let harness_path = temp_dir.path().join("test_main.c");
+    let exe_path = temp_dir.path().join("test_exec");
+
+    module.write_bitcode_to_path(&bitcode_path);
+
+    let status = Command::new("llc")
+        .args([
+            "-filetype=obj",
+            "-relocation-model=pic",
+            "-o",
+            obj_path.to_str().unwrap(),
+            bitcode_path.to_str().unwrap(),
+        ])
+        .status()?;
+    if !status.success() {
+        anyhow::bail!("Failed to emit object file using 'llc'");
+    }
+
+    fs::write(&harness_path, TEST_RUNTIME_HARNESS)?;
     link_test_executable(&exe_path, &harness_path, &obj_path)?;
+
+    Ok((temp_dir, exe_path))
+}
+
+/// Compile, link, run, and return the exit code written to stderr by the test harness.
+fn exec_with_options(program: &str, options: AnalyzeOptions) -> anyhow::Result<i32> {
+    let (_temp_dir, exe_path) = compile_and_link_test(program, options)?;
 
     let output = Command::new(&exe_path).output()?;
     if !output.status.success() {
@@ -145,97 +145,48 @@ int main(void) {
     }
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let code = stderr
+    stderr
         .trim()
         .parse::<i32>()
-        .map_err(|_| anyhow::anyhow!("Failed to parse test output"))?;
-    Ok(code)
+        .map_err(|_| anyhow::anyhow!("Failed to parse test output"))
 }
 
-/// Execute a program and return stderr, expecting the program to abort
+/// Return exit status.
+fn exec(program: &str) -> anyhow::Result<i32> {
+    exec_with_options(
+        program,
+        AnalyzeOptions {
+            no_autoload: false,
+            no_prelude: false,
+            is_entry_unit: true,
+        },
+    )
+}
+
+/// Like `exec`, but without autoload so tests can supply their own `impl<T> [T]` block.
+fn exec_no_autoload(program: &str) -> anyhow::Result<i32> {
+    exec_with_options(
+        program,
+        AnalyzeOptions {
+            no_autoload: true,
+            no_prelude: false,
+            is_entry_unit: true,
+        },
+    )
+}
+
+/// Execute a program and return stderr, expecting the program to abort.
 fn exec_expect_abort(program: &str) -> anyhow::Result<String> {
-    let context = Context::create();
-    let cgcx = CodegenCtx::new(&context, false).unwrap();
-
-    let file = PathBuf::from("test").into();
-
-    let ast = Parser::new(program, file).run().unwrap();
-    let ir = SemanticAnalyzer::new_for_single_file_test().analyze(
-        ast,
+    let (_temp_dir, exe_path) = compile_and_link_test(
+        program,
         AnalyzeOptions {
             no_autoload: false,
             no_prelude: false,
             is_entry_unit: true,
         },
     )?;
-
-    let module = CodeGenerator::new(&cgcx).unwrap().codegen(ir).unwrap();
-    if let Some(main_fn) = module.get_function("main") {
-        unsafe {
-            main_fn.delete();
-        }
-    }
-
-    let temp_dir = tempdir()?;
-    let bitcode_path = temp_dir.path().join("test.bc");
-    let obj_path = temp_dir.path().join("test.o");
-    let harness_path = temp_dir.path().join("test_main.c");
-    let exe_path = temp_dir.path().join("test_exec");
-
-    module.write_bitcode_to_path(&bitcode_path);
-
-    let status = Command::new("llc")
-        .args([
-            "-filetype=obj",
-            "-relocation-model=pic",
-            "-o",
-            obj_path.to_str().unwrap(),
-            bitcode_path.to_str().unwrap(),
-        ])
-        .status()?;
-    if !status.success() {
-        anyhow::bail!("Failed to emit object file using 'llc'");
-    }
-
-    let harness_src = r#"
-#include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
-
-typedef void (*TaskFn)(void *);
-
-extern int32_t kdmain(void);
-
-void kaede_runtime_init(void);
-void kaede_spawn_main(TaskFn fn, void *arg, size_t arg_size);
-int kaede_runtime_run(void);
-void kaede_runtime_shutdown(void);
-void kaede_runtime_set_exit_code(int code);
-
-static void kaede_test_main(void *arg) {
-    (void)arg;
-    int32_t code = kdmain();
-    kaede_runtime_set_exit_code((int)code);
-}
-
-int main(void) {
-    kaede_runtime_init();
-    kaede_spawn_main(kaede_test_main, NULL, 0);
-    int code = kaede_runtime_run();
-    kaede_runtime_shutdown();
-    fprintf(stderr, "%d\n", code);
-    return 0;
-}
-"#;
-
-    fs::write(&harness_path, harness_src)?;
-
-    link_test_executable(&exe_path, &harness_path, &obj_path)?;
-
     let output = Command::new(&exe_path).output()?;
-    // We expect the program to abort, so don't check status.success()
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    Ok(stderr)
+    Ok(String::from_utf8_lossy(&output.stderr).to_string())
 }
 
 #[test]
@@ -5817,5 +5768,36 @@ fn float_to_string_round_trip() -> anyhow::Result<()> {
         return 0
     }"#;
     assert_eq!(exec(program)?, 1);
+    Ok(())
+}
+
+#[test]
+fn slice_generic_impl_copy_first_distinct_element_sizes() -> anyhow::Result<()> {
+    let program = r#"
+        impl<T> [T] {
+            fun copy_first(mut self, src: [T]) {
+                self[0] = src[0]
+            }
+        }
+
+        fun main() -> i32 {
+            let mut a: [u8] = [1, 2, 3]
+            let mut b: [u8] = [9, 8, 7]
+            a.copy_first(b)
+            if a[0] != 9 {
+                return 1
+            }
+
+            let mut x: [i32] = [10, 20, 30]
+            let mut y: [i32] = [99, 88, 77]
+            x.copy_first(y)
+            if x[0] != 99 {
+                return 2
+            }
+
+            return 0
+        }
+    "#;
+    assert_eq!(exec_no_autoload(program)?, 0);
     Ok(())
 }

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -3646,6 +3646,30 @@ impl SemanticAnalyzer {
         Ok(())
     }
 
+    /// Slice and array method calls monomorphize `impl<T> [T]` at `elem_ty`.
+    fn analyze_slice_elem_method_call(
+        &mut self,
+        elem_ty: &Rc<ir_type::Ty>,
+        lhs: ir::expr::Expr,
+        call_node: &ast::expr::FnCall,
+    ) -> anyhow::Result<ir::expr::Expr> {
+        let span = Span::new(lhs.span.start, call_node.span.finish, lhs.span.file);
+        let callee_symbol = self.callee_symbol(call_node)?;
+        let origin = Self::slice_generic_origin();
+        let generic_args = std::slice::from_ref(elem_ty);
+
+        self.ensure_generic_impl_method_declarations(origin.clone(), generic_args)?;
+
+        self.create_method_call_ir(
+            callee_symbol,
+            ModulePath::root(),
+            self.impl_method_parent_name(&origin, generic_args),
+            call_node,
+            lhs,
+            span,
+        )
+    }
+
     fn analyze_struct_access_or_tuple_indexing(
         &mut self,
         lhs: ir::expr::Expr,
@@ -3672,21 +3696,7 @@ impl SemanticAnalyzer {
 
             ir_type::TyKind::Slice(elem_ty) => match &rhs.kind {
                 ast::expr::ExprKind::FnCall(call_node) => {
-                    let span = Span::new(lhs.span.start, call_node.span.finish, lhs.span.file);
-                    let callee_symbol = self.callee_symbol(call_node)?;
-
-                    // Monomorphization may produce a slice type whose methods were never
-                    // registered at the call site; ensure they exist before dispatching.
-                    self.generate_slice_impl(elem_ty.clone())?;
-
-                    self.create_method_call_ir(
-                        callee_symbol,
-                        ModulePath::root(),
-                        self.slice_method_parent_name(elem_ty),
-                        call_node,
-                        lhs,
-                        span,
-                    )
+                    self.analyze_slice_elem_method_call(elem_ty, lhs, call_node)
                 }
 
                 _ => {
@@ -3710,21 +3720,7 @@ impl SemanticAnalyzer {
 
             ir_type::TyKind::Array((elem_ty, _len)) => match &rhs.kind {
                 ast::expr::ExprKind::FnCall(call_node) => {
-                    let span = Span::new(lhs.span.start, call_node.span.finish, lhs.span.file);
-                    let callee_symbol = self.callee_symbol(call_node)?;
-
-                    // Generate slice impl for this element type
-                    self.generate_slice_impl(elem_ty.clone())?;
-
-                    // Arrays use slice methods (array is coerced to slice at codegen)
-                    self.create_method_call_ir(
-                        callee_symbol,
-                        ModulePath::root(),
-                        self.slice_method_parent_name(elem_ty),
-                        call_node,
-                        lhs,
-                        span,
-                    )
+                    self.analyze_slice_elem_method_call(elem_ty, lhs, call_node)
                 }
 
                 _ => Err(SemanticError::HasNoFields { span }.into()),

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -18,8 +18,7 @@ use kaede_parse::Parser;
 use kaede_span::{file::FilePath, Span};
 use kaede_symbol::{Ident, Symbol};
 use kaede_symbol_table::{
-    GenericImplInfo, QualifiedSymbolTable, SymbolResolver, SymbolTable, SymbolTableValue,
-    SymbolTableValueKind,
+    QualifiedSymbolTable, SymbolResolver, SymbolTable, SymbolTableValue, SymbolTableValueKind,
 };
 
 mod const_eval;
@@ -56,18 +55,6 @@ pub struct AnalyzeOptions {
     pub is_entry_unit: bool,
 }
 
-// `impl<T>[T] { ... }` is declared once (autoload) but applies to every slice type in the
-// compile unit, so it's stored here as an analyzer-level intrinsic instead of a module
-// symbol. Generated methods are registered in the root module; `defining_module` records
-// where the block was written and serves as a lookup fallback during monomorphization so
-// method bodies can reach symbols declared alongside the impl block.
-pub struct SliceIntrinsic {
-    pub impl_info: GenericImplInfo,
-    pub defining_module: ModulePath,
-    /// Synthetic origin for `GenericInstanceInfo` on generated slice method declarations.
-    pub origin: QualifiedSymbol,
-}
-
 pub struct SemanticAnalyzer {
     modules: HashMap<ModulePath, ModuleContext>,
     context: AnalysisContext,
@@ -87,7 +74,6 @@ pub struct SemanticAnalyzer {
     generated_callable_substitutions:
         HashMap<QualifiedSymbol, HashMap<ir_type::VarId, Rc<ir_type::Ty>>>,
     pending_generic_instance: Option<ir_type::GenericInstanceInfo>,
-    slice_intrinsic: Option<SliceIntrinsic>,
 }
 
 impl SemanticAnalyzer {
@@ -362,7 +348,6 @@ impl SemanticAnalyzer {
             temp_symbol_counter: 0,
             generated_callable_substitutions: HashMap::new(),
             pending_generic_instance: None,
-            slice_intrinsic: None,
         }
     }
 
@@ -389,9 +374,12 @@ impl SemanticAnalyzer {
             closure_capture_stack: Vec::new(),
             temp_symbol_counter: 0,
             generated_callable_substitutions: HashMap::new(),
-            slice_intrinsic: None,
             pending_generic_instance: None,
         }
+    }
+
+    pub(crate) fn slice_generic_origin() -> QualifiedSymbol {
+        QualifiedSymbol::new(ModulePath::root(), Symbol::from("slice".to_owned()))
     }
 
     #[cfg(debug_assertions)]
@@ -585,7 +573,23 @@ impl SemanticAnalyzer {
     }
 
     pub fn slice_method_parent_name(&self, elem_ty: &Rc<ir_type::Ty>) -> Symbol {
-        format!("slice<{}>", elem_ty.kind).into()
+        let elem = match elem_ty.kind.as_ref() {
+            ir_type::TyKind::Var(id) => format!("var{id}"),
+            _ => elem_ty.kind.to_string(),
+        };
+        format!("slice<{elem}>").into()
+    }
+
+    pub fn impl_method_parent_name(
+        &self,
+        origin: &QualifiedSymbol,
+        generic_args: &[Rc<ir_type::Ty>],
+    ) -> Symbol {
+        if origin.symbol().as_str() == "slice" && origin.module_path() == &ModulePath::root() {
+            self.slice_method_parent_name(&generic_args[0])
+        } else {
+            self.create_generated_generic_key(origin.symbol(), generic_args)
+        }
     }
 
     pub fn create_method_key(
@@ -761,31 +765,6 @@ impl SemanticAnalyzer {
                     (ir_type::TyKind::Var(_), _) | (_, ir_type::TyKind::Var(_)) => false,
                     _ => a.kind == b.kind,
                 })
-    }
-
-    /// Slice monomorphization treats any two unresolved type variables as the same
-    /// instantiation so we only register `slice<_>` method declarations once.
-    fn slice_generic_args_match(left: &[Rc<ir_type::Ty>], right: &[Rc<ir_type::Ty>]) -> bool {
-        left.len() == right.len()
-            && left
-                .iter()
-                .zip(right)
-                .all(|(a, b)| match (a.kind.as_ref(), b.kind.as_ref()) {
-                    (ir_type::TyKind::Var(_), ir_type::TyKind::Var(_)) => true,
-                    (ir_type::TyKind::Var(_), _) | (_, ir_type::TyKind::Var(_)) => false,
-                    _ => a.kind == b.kind,
-                })
-    }
-
-    fn slice_instantiation_already_registered(
-        instantiations: &[Vec<Rc<ir_type::Ty>>],
-        generic_args: &[Rc<ir_type::Ty>],
-    ) -> bool {
-        Self::instantiation_already_registered(
-            instantiations,
-            generic_args,
-            Self::slice_generic_args_match,
-        )
     }
 
     fn apply_substitutions_to_generated_generics(&mut self) {

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -572,24 +572,12 @@ impl SemanticAnalyzer {
         .into()
     }
 
-    pub fn slice_method_parent_name(&self, elem_ty: &Rc<ir_type::Ty>) -> Symbol {
-        let elem = match elem_ty.kind.as_ref() {
-            ir_type::TyKind::Var(id) => format!("var{id}"),
-            _ => elem_ty.kind.to_string(),
-        };
-        format!("slice<{elem}>").into()
-    }
-
     pub fn impl_method_parent_name(
         &self,
         origin: &QualifiedSymbol,
         generic_args: &[Rc<ir_type::Ty>],
     ) -> Symbol {
-        if origin.symbol().as_str() == "slice" && origin.module_path() == &ModulePath::root() {
-            self.slice_method_parent_name(&generic_args[0])
-        } else {
-            self.create_generated_generic_key(origin.symbol(), generic_args)
-        }
+        self.create_generated_generic_key(origin.symbol(), generic_args)
     }
 
     pub fn create_method_key(

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -6,9 +6,9 @@ use std::{
 
 use crate::{context::AnalyzeCommand, rust_import, SemanticAnalyzer, SemanticError};
 use kaede_symbol_table::{
-    ConstValue, GenericEnumInfo, GenericFuncInfo, GenericImplInfo, GenericInfo, GenericKind,
-    GenericStructInfo, ResolvedGenericParam, ResolvedGenericParams, SymbolTable, SymbolTableValue,
-    SymbolTableValueKind, VariableInfo,
+    ConstValue, GenericBuiltinSliceInfo, GenericEnumInfo, GenericFuncInfo, GenericImplInfo,
+    GenericInfo, GenericKind, GenericStructInfo, ResolvedGenericParam, ResolvedGenericParams,
+    SymbolTable, SymbolTableValue, SymbolTableValueKind, VariableInfo,
 };
 
 use kaede_ast::{self as ast};
@@ -515,14 +515,45 @@ impl SemanticAnalyzer {
 
                 ast_type::TyKind::Slice(_) => {
                     let defining_module = self.current_module_path().clone();
-                    self.slice_intrinsic = Some(crate::SliceIntrinsic {
-                        impl_info: GenericImplInfo::new(node, resolved_generic_params, span),
-                        defining_module: defining_module.clone(),
-                        origin: QualifiedSymbol::new(
-                            defining_module,
-                            Symbol::from("slice".to_owned()),
-                        ),
-                    });
+                    let impl_info = GenericImplInfo::new(node, resolved_generic_params, span);
+                    let slice_symbol = Symbol::from("slice".to_owned());
+                    let root_module = self
+                        .modules
+                        .get_mut(&ModulePath::root())
+                        .expect("root module");
+
+                    if let Some(symbol) = root_module.lookup_symbol(&slice_symbol) {
+                        let mut borrowed = symbol.borrow_mut();
+                        match &mut borrowed.kind {
+                            SymbolTableValueKind::Generic(generic_info) => {
+                                match &mut generic_info.kind {
+                                    GenericKind::BuiltinSlice(info) => {
+                                        info.impl_info = impl_info;
+                                        info.defining_module = defining_module;
+                                    }
+                                    _ => todo!("Error"),
+                                }
+                            }
+                            _ => todo!("Error"),
+                        }
+                    } else {
+                        root_module.insert_symbol_to_root_scope(
+                            slice_symbol,
+                            SymbolTableValue::new(
+                                SymbolTableValueKind::Generic(Box::new(GenericInfo::new(
+                                    GenericKind::BuiltinSlice(GenericBuiltinSliceInfo {
+                                        impl_info,
+                                        defining_module,
+                                    }),
+                                    ModulePath::root(),
+                                ))),
+                                ModulePath::root(),
+                            ),
+                            ast::top::Visibility::Private,
+                            span,
+                        )?;
+                    }
+
                     return Ok(TopLevelAnalysisResult::GenericTopLevel);
                 }
 

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -610,15 +610,25 @@ impl SemanticAnalyzer {
                 let base_ty = ty.get_base_type();
                 match base_ty.kind.as_ref() {
                     ir::ty::TyKind::UserDefined(udt) => (udt.name(), false),
-                    ir::ty::TyKind::Slice(elem_ty) => {
-                        (self.slice_method_parent_name(elem_ty), true)
-                    }
+                    ir::ty::TyKind::Slice(elem_ty) => (
+                        self.impl_method_parent_name(
+                            &Self::slice_generic_origin(),
+                            std::slice::from_ref(elem_ty),
+                        ),
+                        true,
+                    ),
                     _ => (Symbol::from(base_ty.kind.to_string()), true),
                 }
             }
 
             ir::ty::TyKind::Fundamental(fty) => (Symbol::from(fty.kind.to_string()), true),
-            ir::ty::TyKind::Slice(elem_ty) => (self.slice_method_parent_name(elem_ty), true),
+            ir::ty::TyKind::Slice(elem_ty) => (
+                self.impl_method_parent_name(
+                    &Self::slice_generic_origin(),
+                    std::slice::from_ref(elem_ty),
+                ),
+                true,
+            ),
 
             _ => unreachable!(),
         };

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -187,7 +187,10 @@ impl SemanticAnalyzer {
             )),
             ir_type::TyKind::Slice(elem_ty) => Some((
                 kaede_ir::module_path::ModulePath::root(),
-                self.slice_method_parent_name(elem_ty),
+                self.impl_method_parent_name(
+                    &Self::slice_generic_origin(),
+                    std::slice::from_ref(elem_ty),
+                ),
             )),
             _ => None,
         }

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -33,6 +33,7 @@ impl SemanticAnalyzer {
         match kind {
             GenericKind::Struct(info) => info.impl_info.as_ref(),
             GenericKind::Enum(info) => info.impl_info.as_ref(),
+            GenericKind::BuiltinSlice(info) => Some(&info.impl_info),
             GenericKind::Func(_) => None,
         }
     }
@@ -41,7 +42,17 @@ impl SemanticAnalyzer {
         match kind {
             GenericKind::Struct(info) => info.impl_info.as_mut(),
             GenericKind::Enum(info) => info.impl_info.as_mut(),
+            GenericKind::BuiltinSlice(info) => Some(&mut info.impl_info),
             GenericKind::Func(_) => None,
+        }
+    }
+
+    fn builtin_slice_defining_module(
+        kind: &GenericKind,
+    ) -> Option<kaede_ir::module_path::ModulePath> {
+        match kind {
+            GenericKind::BuiltinSlice(info) => Some(info.defining_module.clone()),
+            _ => None,
         }
     }
 
@@ -555,6 +566,86 @@ impl SemanticAnalyzer {
             .collect()
     }
 
+    pub(crate) fn ensure_generic_impl_method_declarations(
+        &mut self,
+        origin: QualifiedSymbol,
+        generic_args: &[Rc<ir_type::Ty>],
+    ) -> anyhow::Result<()> {
+        let symbol =
+            self.lookup_qualified_symbol(origin.clone())
+                .ok_or(SemanticError::Undeclared {
+                    name: origin.symbol(),
+                    span: Span::dummy(),
+                })?;
+
+        let (mut snapshot, defining_module) = {
+            let mut borrowed = symbol.borrow_mut();
+            let generic_info = match &mut borrowed.kind {
+                SymbolTableValueKind::Generic(generic_info) => generic_info,
+                _ => return Ok(()),
+            };
+
+            let defining_module = Self::builtin_slice_defining_module(&generic_info.kind);
+
+            let Some(impl_info) = Self::generic_impl_info_mut(&mut generic_info.kind) else {
+                return Ok(());
+            };
+
+            if Self::generic_instantiation_already_registered(
+                &impl_info.method_decl_instantiations,
+                generic_args,
+            ) {
+                return Ok(());
+            }
+
+            impl_info
+                .method_decl_instantiations
+                .push(generic_args.to_vec());
+
+            (
+                Self::create_generic_impl_snapshot(impl_info),
+                defining_module,
+            )
+        };
+
+        self.verify_generic_argument_length(
+            &snapshot.generic_params,
+            generic_args,
+            snapshot.generic_params.span,
+        )?;
+
+        self.verify_resolved_generic_bounds(
+            snapshot.resolved_generic_params.as_ref(),
+            generic_args,
+            snapshot.generic_params.span,
+        )?;
+
+        snapshot.impl_.generic_params = None;
+        snapshot.impl_.items = Rc::new(Self::link_once_impl_methods(&snapshot.impl_));
+
+        let register_decls = |analyzer: &mut Self| {
+            analyzer.with_generic_arguments(&snapshot.generic_params, generic_args, |analyzer| {
+                analyzer.with_analyze_command(AnalyzeCommand::OnlyFnDeclare, |analyzer| {
+                    analyzer.with_pending_generic_instance(
+                        Some(ir_type::GenericInstanceInfo::new(
+                            origin.clone(),
+                            generic_args.to_vec(),
+                        )),
+                        |analyzer| analyzer.analyze_impl(snapshot.impl_),
+                    )
+                })
+            })
+        };
+
+        if let Some(defining_module) = defining_module {
+            self.with_root_module_and_fallback(defining_module, register_decls)?;
+        } else {
+            self.with_module(origin.module_path().clone(), register_decls)?;
+        }
+
+        Ok(())
+    }
+
     fn create_generic_type_with_args(
         &mut self,
         name: Ident,
@@ -585,66 +676,10 @@ impl SemanticAnalyzer {
         };
 
         self.with_module(module_path.clone(), |analyzer| {
-            // Register method declarations for this generic instantiation. Bodies are emitted
-            // only when a method call actually references one of these declarations.
-            let decl_generation = {
-                let mut borrowed_mut_symbol = symbol.borrow_mut();
-
-                let generic_info = match &mut borrowed_mut_symbol.kind {
-                    SymbolTableValueKind::Generic(generic_info) => generic_info,
-                    _ => unreachable!(),
-                };
-
-                if let Some(impl_info) = Self::generic_impl_info_mut(&mut generic_info.kind) {
-                    if Self::generic_instantiation_already_registered(
-                        &impl_info.method_decl_instantiations,
-                        &generic_args,
-                    ) {
-                        None
-                    } else {
-                        impl_info
-                            .method_decl_instantiations
-                            .push(generic_args.clone());
-                        Some(Self::create_generic_impl_snapshot(impl_info))
-                    }
-                } else {
-                    None
-                }
-            };
-
-            if let Some(mut snapshot) = decl_generation {
-                analyzer.verify_generic_argument_length(
-                    &snapshot.generic_params,
-                    &generic_args,
-                    snapshot.generic_params.span,
-                )?;
-
-                analyzer.verify_resolved_generic_bounds(
-                    snapshot.resolved_generic_params.as_ref(),
-                    &generic_args,
-                    snapshot.generic_params.span,
-                )?;
-
-                snapshot.impl_.generic_params = None;
-                snapshot.impl_.items = Rc::new(Self::link_once_impl_methods(&snapshot.impl_));
-
-                analyzer.with_generic_arguments(
-                    &snapshot.generic_params,
-                    &generic_args,
-                    |analyzer| {
-                        analyzer.with_analyze_command(AnalyzeCommand::OnlyFnDeclare, |analyzer| {
-                            analyzer.with_pending_generic_instance(
-                                Some(ir_type::GenericInstanceInfo::new(
-                                    QualifiedSymbol::new(module_path.clone(), name.symbol()),
-                                    generic_args.clone(),
-                                )),
-                                |analyzer| analyzer.analyze_impl(snapshot.impl_),
-                            )?;
-                            Ok::<(), anyhow::Error>(())
-                        })
-                    },
-                )?;
-            }
+            analyzer.ensure_generic_impl_method_declarations(
+                QualifiedSymbol::new(module_path.clone(), name.symbol()),
+                &generic_args,
+            )?;
 
             let borrowed_symbol = symbol.borrow();
 
@@ -683,14 +718,6 @@ impl SemanticAnalyzer {
             return Ok(());
         };
 
-        if self
-            .slice_intrinsic
-            .as_ref()
-            .is_some_and(|slice| slice.origin == instance.origin)
-        {
-            return self.ensure_slice_impl_method_body(decl, &instance.args);
-        }
-
         let origin = instance.origin.clone();
         let generic_args = instance.args.clone();
 
@@ -698,7 +725,7 @@ impl SemanticAnalyzer {
             return Ok(());
         }
 
-        let mut snapshot = {
+        let (mut snapshot, defining_module) = {
             let symbol =
                 self.lookup_qualified_symbol(origin.clone())
                     .ok_or(SemanticError::Undeclared {
@@ -712,11 +739,16 @@ impl SemanticAnalyzer {
                 _ => return Ok(()),
             };
 
+            let defining_module = Self::builtin_slice_defining_module(&generic_info.kind);
+
             let Some(impl_info) = Self::generic_impl_info(&generic_info.kind) else {
                 return Ok(());
             };
 
-            Self::create_generic_impl_snapshot(impl_info)
+            (
+                Self::create_generic_impl_snapshot(impl_info),
+                defining_module,
+            )
         };
 
         self.generated_impl_method_bodies.insert(decl.name.clone());
@@ -733,7 +765,7 @@ impl SemanticAnalyzer {
             snapshot.generic_params.span,
         )?;
 
-        let parent_name = self.create_generated_generic_key(origin.symbol(), &generic_args);
+        let parent_name = self.impl_method_parent_name(&origin, &generic_args);
         let target_name = decl.name.symbol();
         snapshot.impl_.generic_params = None;
         snapshot.impl_.items = Rc::new(Self::link_once_impl_methods_matching(
@@ -754,7 +786,7 @@ impl SemanticAnalyzer {
             );
         }
 
-        let impl_ir = self.with_module(origin.module_path().clone(), |analyzer| {
+        let emit_body = |analyzer: &mut Self| {
             analyzer.with_generic_arguments(&snapshot.generic_params, &generic_args, |analyzer| {
                 analyzer.with_analyze_command(AnalyzeCommand::WithoutFnDeclare, |analyzer| {
                     analyzer.with_pending_generic_instance(
@@ -766,82 +798,13 @@ impl SemanticAnalyzer {
                     )
                 })
             })
-        })?;
-
-        if let TopLevelAnalysisResult::TopLevel(top_level) = impl_ir {
-            assert!(matches!(top_level, ir::top::TopLevel::Impl(_)));
-            self.generated_generics.push(top_level);
-        }
-
-        Ok(())
-    }
-
-    fn ensure_slice_impl_method_body(
-        &mut self,
-        decl: &ir::top::FnDecl,
-        generic_args: &[Rc<ir_type::Ty>],
-    ) -> anyhow::Result<()> {
-        if self.generated_impl_method_bodies.contains(&decl.name) {
-            return Ok(());
-        }
-
-        let (defining_module, slice_origin, mut snapshot) = {
-            let Some(slice) = self.slice_intrinsic.as_ref() else {
-                return Ok(());
-            };
-            (
-                slice.defining_module.clone(),
-                slice.origin.clone(),
-                Self::create_generic_impl_snapshot(&slice.impl_info),
-            )
         };
 
-        let generic_params = snapshot.generic_params.clone();
-        let resolved_generic_params = snapshot.resolved_generic_params.clone();
-
-        self.generated_impl_method_bodies.insert(decl.name.clone());
-
-        self.verify_generic_argument_length(&generic_params, generic_args, generic_params.span)?;
-        self.verify_resolved_generic_bounds(
-            resolved_generic_params.as_ref(),
-            generic_args,
-            generic_params.span,
-        )?;
-
-        let parent_name = self.slice_method_parent_name(&generic_args[0]);
-        let target_name = decl.name.symbol();
-        snapshot.impl_.generic_params = None;
-        snapshot.impl_.items = Rc::new(Self::link_once_impl_methods_matching(
-            &snapshot.impl_,
-            |fn_| {
-                self.create_method_key(
-                    parent_name,
-                    fn_.decl.name.symbol(),
-                    fn_.decl.self_.is_none(),
-                ) == target_name
-            },
-        ));
-
-        if snapshot.impl_.items.is_empty() {
-            anyhow::bail!(
-                "internal compiler error: could not find generated slice impl method body for `{}`",
-                decl.name.mangle()
-            );
-        }
-
-        let impl_ir = self.with_root_module_and_fallback(defining_module, |analyzer| {
-            analyzer.with_generic_arguments(&generic_params, generic_args, |analyzer| {
-                analyzer.with_analyze_command(AnalyzeCommand::WithoutFnDeclare, |analyzer| {
-                    analyzer.with_pending_generic_instance(
-                        Some(ir_type::GenericInstanceInfo::new(
-                            slice_origin,
-                            generic_args.to_vec(),
-                        )),
-                        |analyzer| analyzer.analyze_impl(snapshot.impl_),
-                    )
-                })
-            })
-        })?;
+        let impl_ir = if let Some(defining_module) = defining_module {
+            self.with_root_module_and_fallback(defining_module, emit_body)?
+        } else {
+            self.with_module(origin.module_path().clone(), emit_body)?
+        };
 
         if let TopLevelAnalysisResult::TopLevel(top_level) = impl_ir {
             assert!(matches!(top_level, ir::top::TopLevel::Impl(_)));
@@ -1017,68 +980,6 @@ impl SemanticAnalyzer {
             kind: ir_type::TyKind::Slice(elem_ty).into(),
             mutability,
         })
-    }
-
-    pub(crate) fn generate_slice_impl(&mut self, elem_ty: Rc<ir_type::Ty>) -> anyhow::Result<()> {
-        // Autoload hasn't been processed yet; nothing to generate.
-        let Some(slice) = self.slice_intrinsic.as_ref() else {
-            return Ok(());
-        };
-
-        let generic_args = vec![elem_ty.clone()];
-
-        if Self::slice_instantiation_already_registered(
-            &slice.impl_info.method_decl_instantiations,
-            &generic_args,
-        ) {
-            return Ok(());
-        }
-
-        let defining_module = slice.defining_module.clone();
-        let slice_origin = slice.origin.clone();
-        let generic_params = slice
-            .impl_info
-            .impl_
-            .generic_params
-            .as_ref()
-            .unwrap()
-            .clone();
-        let resolved_generic_params = slice.impl_info.resolved_generic_params.clone();
-        let mut impl_ast = slice.impl_info.impl_.clone();
-
-        self.verify_generic_argument_length(&generic_params, &generic_args, generic_params.span)?;
-        self.verify_resolved_generic_bounds(
-            resolved_generic_params.as_ref(),
-            &generic_args,
-            generic_params.span,
-        )?;
-
-        self.slice_intrinsic
-            .as_mut()
-            .unwrap()
-            .impl_info
-            .method_decl_instantiations
-            .push(generic_args.clone());
-
-        impl_ast.generic_params = None;
-        impl_ast.items = Rc::new(Self::link_once_impl_methods(&impl_ast));
-
-        // Register method declarations only; bodies are emitted on demand at call sites.
-        self.with_root_module_and_fallback(defining_module, |analyzer| {
-            analyzer.with_generic_arguments(&generic_params, &generic_args, |analyzer| {
-                analyzer.with_analyze_command(AnalyzeCommand::OnlyFnDeclare, |analyzer| {
-                    analyzer.with_pending_generic_instance(
-                        Some(ir_type::GenericInstanceInfo::new(
-                            slice_origin,
-                            generic_args.clone(),
-                        )),
-                        |analyzer| analyzer.analyze_impl(impl_ast),
-                    )
-                })
-            })
-        })?;
-
-        Ok(())
     }
 
     fn analyze_tuple_type(

--- a/compiler/semantic/tests/common/mod.rs
+++ b/compiler/semantic/tests/common/mod.rs
@@ -28,6 +28,18 @@ pub fn semantic_analyze(program: &str) -> anyhow::Result<ir::CompileUnit> {
 }
 
 #[allow(dead_code)]
+pub fn semantic_analyze_no_autoload(program: &str) -> anyhow::Result<ir::CompileUnit> {
+    semantic_analyze_internal(
+        program,
+        AnalyzeOptions {
+            no_autoload: true,
+            no_prelude: false,
+            is_entry_unit: true,
+        },
+    )
+}
+
+#[allow(dead_code)]
 pub fn semantic_analyze_as_non_entry(program: &str) -> anyhow::Result<ir::CompileUnit> {
     semantic_analyze_internal(
         program,

--- a/compiler/semantic/tests/top.rs
+++ b/compiler/semantic/tests/top.rs
@@ -491,7 +491,7 @@ fn generic_impl_method_call_emits_only_referenced_method_body() -> anyhow::Resul
 }
 
 #[test]
-fn slice_methods_on_distinct_type_variables_share_one_instantiation() -> anyhow::Result<()> {
+fn slice_generic_functions_with_distinct_type_variables_analyze() -> anyhow::Result<()> {
     semantic_analyze(
         r#"
         fun takes<T>(xs: [T]) -> u64 {
@@ -507,6 +507,33 @@ fn slice_methods_on_distinct_type_variables_share_one_instantiation() -> anyhow:
         }
         "#,
     )?;
+
+    Ok(())
+}
+
+#[test]
+fn slice_methods_on_distinct_element_types_are_separate_instantiations() -> anyhow::Result<()> {
+    let ir = semantic_analyze(
+        r#"
+        fun main() -> i32 {
+            let xs: [u8] = [1, 2]
+            let ys: [i32] = [3, 4]
+            return (xs.len() + ys.len()) as i32
+        }
+        "#,
+    )?;
+
+    let generated_methods = generated_impl_method_symbols(&ir);
+    assert!(
+        generated_methods.iter().any(|name| name == "slice<u8>.len"),
+        "expected slice<u8>.len body: {generated_methods:?}"
+    );
+    assert!(
+        generated_methods
+            .iter()
+            .any(|name| name == "slice<i32>.len"),
+        "expected slice<i32>.len body: {generated_methods:?}"
+    );
 
     Ok(())
 }

--- a/compiler/semantic/tests/top.rs
+++ b/compiler/semantic/tests/top.rs
@@ -525,14 +525,12 @@ fn slice_methods_on_distinct_element_types_are_separate_instantiations() -> anyh
 
     let generated_methods = generated_impl_method_symbols(&ir);
     assert!(
-        generated_methods.iter().any(|name| name == "slice<u8>.len"),
-        "expected slice<u8>.len body: {generated_methods:?}"
+        generated_methods.iter().any(|name| name == "slice_u8.len"),
+        "expected slice_u8.len body: {generated_methods:?}"
     );
     assert!(
-        generated_methods
-            .iter()
-            .any(|name| name == "slice<i32>.len"),
-        "expected slice<i32>.len body: {generated_methods:?}"
+        generated_methods.iter().any(|name| name == "slice_i32.len"),
+        "expected slice_i32.len body: {generated_methods:?}"
     );
 
     Ok(())
@@ -551,14 +549,14 @@ fn slice_method_call_emits_only_referenced_method_body() -> anyhow::Result<()> {
 
     let generated_methods = generated_impl_method_symbols(&ir);
     assert!(
-        generated_methods.iter().any(|name| name == "slice<u8>.len"),
-        "expected generated slice<u8>.len body: {generated_methods:?}"
+        generated_methods.iter().any(|name| name == "slice_u8.len"),
+        "expected generated slice_u8.len body: {generated_methods:?}"
     );
     assert!(
         !generated_methods
             .iter()
-            .any(|name| name == "slice<u8>.as_ptr"),
-        "unreferenced slice<u8>.as_ptr should not be emitted: {generated_methods:?}"
+            .any(|name| name == "slice_u8.as_ptr"),
+        "unreferenced slice_u8.as_ptr should not be emitted: {generated_methods:?}"
     );
 
     Ok(())

--- a/compiler/symbol_table/src/lib.rs
+++ b/compiler/symbol_table/src/lib.rs
@@ -105,11 +105,19 @@ pub struct GenericFuncInfo {
     pub resolved_generic_params: Option<ResolvedGenericParams>,
 }
 
+/// Synthetic builtin generic for `impl<T> [T] { ... }` registered as root `slice`.
+#[derive(Debug)]
+pub struct GenericBuiltinSliceInfo {
+    pub impl_info: GenericImplInfo,
+    pub defining_module: ModulePath,
+}
+
 #[derive(Debug)]
 pub enum GenericKind {
     Struct(GenericStructInfo),
     Enum(GenericEnumInfo),
     Func(GenericFuncInfo),
+    BuiltinSlice(GenericBuiltinSliceInfo),
 }
 
 #[derive(Debug)]
@@ -128,6 +136,7 @@ impl GenericInfo {
             GenericKind::Struct(info) => info.resolved_generic_params.as_ref(),
             GenericKind::Enum(info) => info.resolved_generic_params.as_ref(),
             GenericKind::Func(info) => info.resolved_generic_params.as_ref(),
+            GenericKind::BuiltinSlice(info) => info.impl_info.resolved_generic_params.as_ref(),
         }
     }
 
@@ -135,7 +144,8 @@ impl GenericInfo {
         match &self.kind {
             GenericKind::Struct(info) => info.ast.generic_params.as_ref().unwrap().len(),
             GenericKind::Enum(info) => info.ast.generic_params.as_ref().unwrap().len(),
-            _ => unreachable!(),
+            GenericKind::BuiltinSlice(_) => 1,
+            GenericKind::Func(_) => unreachable!(),
         }
     }
 }

--- a/compiler/type_infer/src/lib.rs
+++ b/compiler/type_infer/src/lib.rs
@@ -2412,7 +2412,7 @@ mod tests {
             link_once: true,
             name: QualifiedSymbol::new(
                 ModulePath::root(),
-                Symbol::from("slice<var0>.as_ptr".to_owned()),
+                Symbol::from("slice_var0.as_ptr".to_owned()),
             ),
             params: vec![Param {
                 name: Symbol::from("self".to_owned()),
@@ -2452,7 +2452,7 @@ mod tests {
         let bindings = substitutions
             .get(&QualifiedSymbol::new(
                 ModulePath::root(),
-                Symbol::from("slice<var0>.as_ptr".to_owned()),
+                Symbol::from("slice_var0.as_ptr".to_owned()),
             ))
             .unwrap();
         assert!(matches!(

--- a/compiler/type_infer/src/lib.rs
+++ b/compiler/type_infer/src/lib.rs
@@ -2412,7 +2412,7 @@ mod tests {
             link_once: true,
             name: QualifiedSymbol::new(
                 ModulePath::root(),
-                Symbol::from("slice<_>.as_ptr".to_owned()),
+                Symbol::from("slice<var0>.as_ptr".to_owned()),
             ),
             params: vec![Param {
                 name: Symbol::from("self".to_owned()),
@@ -2452,7 +2452,7 @@ mod tests {
         let bindings = substitutions
             .get(&QualifiedSymbol::new(
                 ModulePath::root(),
-                Symbol::from("slice<_>.as_ptr".to_owned()),
+                Symbol::from("slice<var0>.as_ptr".to_owned()),
             ))
             .unwrap();
         assert!(matches!(


### PR DESCRIPTION
## Summary

- Register `impl<T> [T]` as synthetic builtin generic `root::slice` (`GenericKind::BuiltinSlice`) instead of `SemanticAnalyzer.slice_intrinsic`.
- Unify slice with UDT generic impl: `ensure_generic_impl_method_declarations`, `ensure_generated_impl_method_body`, and `generic_args_match_exactly` for instantiation dedup.
- Remove slice-specific helpers (`generate_slice_impl`, `ensure_slice_impl_method_body`, `slice_generic_args_match`).
- Unify method parent naming with UDT (`slice_u8.len` instead of `slice<u8>.len`).
- Extract `analyze_slice_elem_method_call` for shared slice/array method dispatch; DRY codegen test harness (`compile_and_link_test` / `exec_with_options`).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --release -p kaede_semantic`
- [x] `cargo test --release -p kaede_type_infer`
- [x] `cargo test --release -p kaede_codegen` (including `slice_generic_impl_copy_first_distinct_element_sizes` with `no_autoload`)