### PR TITLE
refactor: isolate defining-module capture state

### DIFF
--- a/compiler/semantic/src/context.rs
+++ b/compiler/semantic/src/context.rs
@@ -96,6 +96,16 @@ impl SemanticAnalyzer {
         result
     }
 
+    pub(crate) fn with_isolated_closure_captures<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce(&mut Self) -> R,
+    {
+        let saved_closure_captures = std::mem::take(&mut self.closure_capture_stack);
+        let result = f(self);
+        self.closure_capture_stack = saved_closure_captures;
+        result
+    }
+
     // Temporarily changes the current module path, executes the provided closure.
     pub fn with_module<F, R>(&mut self, path: ModulePath, f: F) -> R
     where
@@ -106,9 +116,9 @@ impl SemanticAnalyzer {
         self.with_context(new_context, f)
     }
 
-    // Changes both `current_module_path` and `module_path`, so name-lookup fallbacks
-    // target the defining module rather than the caller (used when monomorphizing a
-    // generic whose body was written against another module's symbols).
+    // Analyze as the defining module for a generated body. This aligns both
+    // module paths so lookups use the module where the source was written, and
+    // isolates closure capture tracking from the caller's active closure frames.
     pub fn with_defining_module<F, R>(&mut self, path: ModulePath, f: F) -> R
     where
         F: FnOnce(&mut Self) -> R,
@@ -116,7 +126,8 @@ impl SemanticAnalyzer {
         let mut new_context = self.context.clone();
         new_context.current_module_path = path.clone();
         new_context.module_path = path;
-        self.with_context(new_context, f)
+
+        self.with_isolated_closure_captures(|analyzer| analyzer.with_context(new_context, f))
     }
 
     pub fn with_root_module<F, R>(&mut self, f: F) -> R

--- a/compiler/semantic/src/ty.rs
+++ b/compiler/semantic/src/ty.rs
@@ -791,7 +791,6 @@ impl SemanticAnalyzer {
             );
         }
 
-        let saved_closure_captures = std::mem::take(&mut self.closure_capture_stack);
         let emit_body = |analyzer: &mut Self| {
             analyzer.with_generic_arguments(&snapshot.generic_params, &generic_args, |analyzer| {
                 analyzer.with_analyze_command(AnalyzeCommand::WithoutFnDeclare, |analyzer| {
@@ -807,11 +806,12 @@ impl SemanticAnalyzer {
         };
 
         let impl_ir = if let Some(slice_defining_module) = defining_module {
-            self.with_root_module_and_fallback(slice_defining_module, emit_body)?
+            self.with_isolated_closure_captures(|analyzer| {
+                analyzer.with_root_module_and_fallback(slice_defining_module, emit_body)
+            })?
         } else {
             self.with_defining_module(origin.module_path().clone(), emit_body)?
         };
-        self.closure_capture_stack = saved_closure_captures;
 
         if let TopLevelAnalysisResult::TopLevel(top_level) = impl_ir {
             assert!(matches!(top_level, ir::top::TopLevel::Impl(_)));

--- a/compiler/semantic/tests/expr.rs
+++ b/compiler/semantic/tests/expr.rs
@@ -2,7 +2,7 @@ mod common;
 
 use std::collections::HashSet;
 
-use common::{semantic_analyze, semantic_analyze_expect_error};
+use common::{semantic_analyze, semantic_analyze_expect_error, semantic_analyze_no_autoload};
 use kaede_ir::{expr::ExprKind as IrExprKind, stmt::Stmt, top::TopLevel, ty::TyKind as IrTyKind};
 use kaede_symbol::Symbol;
 
@@ -844,6 +844,66 @@ fn closure_captures_local_closure_callee() -> anyhow::Result<()> {
 
     assert_eq!(captures, HashSet::from([Symbol::from("add".to_string())]));
     assert_eq!(capture_tys_len, 1);
+
+    Ok(())
+}
+
+#[test]
+fn generated_generic_fn_body_does_not_capture_call_site_locals() -> anyhow::Result<()> {
+    let ir = semantic_analyze(
+        "
+        fun id<T>(value: T) -> T {
+            return value
+        }
+
+        fun f() -> i32 {
+            let value = 58
+            let closure = || id(1)
+            return closure()
+        }
+    ",
+    )?;
+
+    let body = find_function_body(ir, "f");
+
+    let closure_expr = match &body.body[1] {
+        Stmt::Let(let_stmt) => let_stmt.init.as_ref().unwrap(),
+        _ => panic!("expected let binding for closure"),
+    };
+
+    let captures: HashSet<Symbol> = match &closure_expr.kind {
+        IrExprKind::Closure(closure) => closure
+            .captures
+            .iter()
+            .map(|capture| match &capture.kind {
+                IrExprKind::Variable(variable) => variable.name,
+                _ => panic!("unexpected capture kind"),
+            })
+            .collect(),
+        kind => panic!("expected closure expr, got {kind:?}"),
+    };
+
+    assert!(captures.is_empty(), "unexpected captures: {captures:?}");
+
+    Ok(())
+}
+
+#[test]
+fn generated_slice_impl_body_does_not_use_call_site_capture_stack() -> anyhow::Result<()> {
+    semantic_analyze_no_autoload(
+        "
+        impl<T> [T] {
+            fun first(self) -> T {
+                return self[0]
+            }
+        }
+
+        fun f() -> i32 {
+            let closure = || [1, 2].first()
+            return closure()
+        }
+    ",
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- make with_defining_module isolate closure_capture_stack while aligning defining module paths
- reuse capture isolation for builtin slice lazy impl body emission
- add regression tests for generated generic bodies under call-site closures

## Verification
- nix develop -c cargo fmt --all
- nix develop -c cargo clippy -- -D warnings
- nix develop -c cargo test -p kaede_semantic

Refs #337