### PR TITLE
refactor: make semantic lookup mode explicit

### DIFF
--- a/compiler/semantic/src/context.rs
+++ b/compiler/semantic/src/context.rs
@@ -17,12 +17,28 @@ pub enum AnalyzeCommand {
 }
 
 #[derive(Debug, Clone)]
+pub enum LookupMode {
+    // Analyze the session home module. Lookups stay in `current_module_path`.
+    HomeModule,
+    // Visit another module's table without falling back to the session home.
+    ModuleOnly,
+    // Analyze a foreign module access expression (`m.foo(x)`). The member is
+    // resolved in the foreign module; nested expressions may fall back home.
+    ForeignModule,
+    // Analyze a generated body as the module where it was defined.
+    DefiningModule,
+    // Builtin impls are registered in root, while their bodies may reference
+    // helpers from the module that declared the impl.
+    RootModuleWithFallback { fallback: ModulePath },
+}
+
+#[derive(Debug, Clone)]
 pub struct AnalysisContext {
     // std.io.print(s) in test.kd -> [std, io]
     current_module_path: ModulePath,
     // std.io.print(s) in test.kd -> [test]
     module_path: ModulePath,
-    fallback_lookup_module_path: Option<ModulePath>,
+    lookup_mode: LookupMode,
 
     is_inside_loop: bool,
     current_function: Vec<Option<Rc<ir::top::FnDecl>>>,
@@ -35,7 +51,7 @@ impl AnalysisContext {
         Self {
             current_module_path: ModulePath::root(),
             module_path,
-            fallback_lookup_module_path: None,
+            lookup_mode: LookupMode::HomeModule,
             is_inside_loop: false,
             current_function: vec![None],
             no_prelude: false,
@@ -65,6 +81,11 @@ impl AnalysisContext {
 
     pub fn set_current_module_path(&mut self, path: ModulePath) {
         self.current_module_path = path;
+        self.lookup_mode = if self.current_module_path == self.module_path {
+            LookupMode::HomeModule
+        } else {
+            LookupMode::ModuleOnly
+        };
     }
 
     pub fn analyze_command(&self) -> AnalyzeCommand {
@@ -81,8 +102,8 @@ impl SemanticAnalyzer {
         &self.context.module_path
     }
 
-    pub fn fallback_lookup_module_path(&self) -> Option<&ModulePath> {
-        self.context.fallback_lookup_module_path.as_ref()
+    pub fn lookup_mode(&self) -> &LookupMode {
+        &self.context.lookup_mode
     }
 
     // Temporarily changes the current context, executes the provided closure.
@@ -113,6 +134,20 @@ impl SemanticAnalyzer {
     {
         let mut new_context = self.context.clone();
         new_context.current_module_path = path;
+        new_context.lookup_mode = LookupMode::ModuleOnly;
+        self.with_context(new_context, f)
+    }
+
+    // Temporarily analyzes a foreign module member expression. The foreign
+    // module is searched first; unresolved nested identifiers can fall back to
+    // the home module that contains the call site.
+    pub fn with_foreign_module<F, R>(&mut self, path: ModulePath, f: F) -> R
+    where
+        F: FnOnce(&mut Self) -> R,
+    {
+        let mut new_context = self.context.clone();
+        new_context.current_module_path = path;
+        new_context.lookup_mode = LookupMode::ForeignModule;
         self.with_context(new_context, f)
     }
 
@@ -126,6 +161,7 @@ impl SemanticAnalyzer {
         let mut new_context = self.context.clone();
         new_context.current_module_path = path.clone();
         new_context.module_path = path;
+        new_context.lookup_mode = LookupMode::DefiningModule;
 
         self.with_isolated_closure_captures(|analyzer| analyzer.with_context(new_context, f))
     }
@@ -145,16 +181,9 @@ impl SemanticAnalyzer {
     where
         F: FnOnce(&mut Self) -> R,
     {
-        self.with_lookup_fallback_module(fallback, |analyzer| analyzer.with_root_module(f))
-    }
-
-    // Temporarily changes the fallback module path used for symbol lookup.
-    pub fn with_lookup_fallback_module<F, R>(&mut self, path: ModulePath, f: F) -> R
-    where
-        F: FnOnce(&mut Self) -> R,
-    {
         let mut new_context = self.context.clone();
-        new_context.fallback_lookup_module_path = Some(path);
+        new_context.current_module_path = ModulePath::root();
+        new_context.lookup_mode = LookupMode::RootModuleWithFallback { fallback };
         self.with_context(new_context, f)
     }
 

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -2157,7 +2157,7 @@ impl SemanticAnalyzer {
         }
 
         let (symbol_value, depth) = self
-            .lookup_symbol_with_depth_and_fallback(callee.symbol())
+            .lookup_symbol_with_depth_by_mode(callee.symbol())
             .ok_or_else(|| SemanticError::Undeclared {
                 name: callee.symbol(),
                 span: node.span,
@@ -3981,7 +3981,7 @@ impl SemanticAnalyzer {
             }
         }
 
-        self.with_module(module_path, |analyzer| analyzer.analyze_expr(rhs))
+        self.with_foreign_module(module_path, |analyzer| analyzer.analyze_expr(rhs))
     }
 
     fn rhs_symbol(rhs: &ast::expr::Expr) -> Option<(Symbol, Span)> {
@@ -4219,20 +4219,7 @@ impl SemanticAnalyzer {
     }
 
     fn analyze_ident(&mut self, node: &Ident) -> anyhow::Result<ir::expr::Expr> {
-        let primary = self.lookup_symbol_with_depth(node.symbol());
-
-        let fallback = if primary.is_none() && self.current_module_path() != self.module_path() {
-            let mut new_ctx = self.context.clone();
-            new_ctx.set_current_module_path(self.module_path().clone());
-            self.with_context(new_ctx, |analyzer| {
-                analyzer.lookup_symbol_with_depth(node.symbol())
-            })
-        } else {
-            None
-        };
-
-        primary
-            .or(fallback)
+        self.lookup_symbol_with_depth_by_mode(node.symbol())
             .map(|(value, depth)| match &value.borrow().kind {
                 // `depth` is the index in `symbol_table_stack` where the name was found.
                 // 0 = module root (`insert_symbol_to_root_scope`): top-level `const`, `fun`, etc.

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -40,7 +40,7 @@ use kaede_type_infer::InferContext;
 use subst::GenericSubstituter;
 pub use top::TopLevelAnalysisResult;
 
-use crate::context::{AnalyzeCommand, ModuleContext};
+use crate::context::{AnalyzeCommand, LookupMode, ModuleContext};
 
 #[derive(Debug, Clone)]
 struct ClosureCapture {
@@ -504,7 +504,7 @@ impl SemanticAnalyzer {
     }
 
     pub fn lookup_symbol(&self, symbol: Symbol) -> Option<Rc<RefCell<SymbolTableValue>>> {
-        self.lookup_symbol_with_depth_and_fallback(symbol)
+        self.lookup_symbol_with_depth_by_mode(symbol)
             .map(|(value, _)| value)
     }
 
@@ -618,14 +618,21 @@ impl SemanticAnalyzer {
         &self,
         symbol: Symbol,
     ) -> Option<(Rc<RefCell<SymbolTableValue>>, usize)> {
-        let module_path = self.current_module_path();
+        self.lookup_symbol_in_module_with_depth(self.current_module_path(), symbol)
+    }
+
+    fn lookup_symbol_in_module_with_depth(
+        &self,
+        module_path: &ModulePath,
+        symbol: Symbol,
+    ) -> Option<(Rc<RefCell<SymbolTableValue>>, usize)> {
         self.modules
             .get(module_path)
             .expect("Module context must exist")
             .lookup_symbol_with_depth(&symbol)
     }
 
-    fn lookup_symbol_with_depth_and_fallback(
+    fn lookup_symbol_with_depth_by_mode(
         &self,
         symbol: Symbol,
     ) -> Option<(Rc<RefCell<SymbolTableValue>>, usize)> {
@@ -636,27 +643,32 @@ impl SemanticAnalyzer {
             )
         };
 
-        if let Some(value) = self
-            .modules
-            .get(self.current_module_path())
-            .unwrap_or_else(panic)
-            .lookup_symbol_with_depth(&symbol)
+        if let Some(value) =
+            self.lookup_symbol_in_module_with_depth(self.current_module_path(), symbol)
         {
             return Some(value);
         }
 
-        if let Some(fallback_module_path) = self.fallback_lookup_module_path() {
-            if let Some(module) = self.modules.get(fallback_module_path) {
-                if let Some(value) = module.lookup_symbol_with_depth(&symbol) {
-                    return Some(value);
+        match self.lookup_mode() {
+            LookupMode::HomeModule | LookupMode::ModuleOnly | LookupMode::DefiningModule => None,
+            LookupMode::ForeignModule => {
+                if self.current_module_path() == self.module_path() {
+                    None
+                } else {
+                    self.lookup_symbol_in_module_with_depth(self.module_path(), symbol)
+                }
+            }
+            LookupMode::RootModuleWithFallback { fallback } => {
+                if fallback == self.current_module_path() {
+                    None
+                } else {
+                    self.modules
+                        .get(fallback)
+                        .unwrap_or_else(panic)
+                        .lookup_symbol_with_depth(&symbol)
                 }
             }
         }
-
-        self.modules
-            .get(self.module_path())
-            .unwrap_or_else(panic)
-            .lookup_symbol_with_depth(&symbol)
     }
 
     fn push_closure_capture(&mut self, base_depth: usize) {

--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -116,6 +116,55 @@ fn import_basic_function() -> anyhow::Result<()> {
 }
 
 #[test]
+fn imported_function_call_inside_closure_can_use_call_site_local_arg() -> anyhow::Result<()> {
+    let project = ImportTestProject::new()?;
+    project.create_module("utils", "export fun id(x: i32) -> i32 { return x }")?;
+
+    project.analyze(
+        r#"
+            import utils
+
+            fun main() -> i32 {
+                let x = 42
+                let closure = || utils.id(x)
+                return closure()
+            }
+        "#,
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn imported_module_body_does_not_fallback_to_entry_module_private_items() -> anyhow::Result<()> {
+    let project = ImportTestProject::new()?;
+    project.create_module(
+        "utils",
+        r#"
+            export fun call_helper<T>(value: T) -> i32 {
+                return helper()
+            }
+        "#,
+    )?;
+
+    project.analyze_expect_error(
+        r#"
+            import utils
+
+            fun helper() -> i32 {
+                return 42
+            }
+
+            fun main() -> i32 {
+                return utils.call_helper(0)
+            }
+        "#,
+    )?;
+
+    Ok(())
+}
+
+#[test]
 fn import_struct_and_impl() -> anyhow::Result<()> {
     ImportTestCase {
         name: "struct_and_impl",


### PR DESCRIPTION
## Summary
- replace implicit fallback lookup state with explicit semantic lookup modes
- keep plain with_module module-local, and use with_foreign_module for cross-module member expressions that need call-site fallback
- route identifier and callee lookup through the mode-aware helper
- add regressions for cross-module call arguments and defining-module generic body lookup isolation

## Verification
- nix develop -c cargo fmt --all
- nix develop -c cargo test -p kaede_semantic
- nix develop -c cargo clippy -- -D warnings

Refs #337