### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "kaede_ast"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "inkwell",
  "kaede_ast_type",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_ast_type"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "inkwell",
  "kaede_span",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_codegen"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -743,11 +743,11 @@ dependencies = [
 
 [[package]]
 name = "kaede_common"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "kaede_compiler_driver"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_ir"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "inkwell",
  "kaede_ast_type",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_lex"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kaede_span",
  "unicode-xid",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_lsp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "kaede_ast",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_monomorphize"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "kaede_common",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_parse"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "kaede_ast",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_semantic"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "kaede_ast",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_span"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "once_cell",
  "slab",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_symbol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kaede_span",
  "once_cell",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_symbol_table"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "kaede_ast",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_type_infer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "kaede_common",

--- a/compiler/ast/Cargo.toml
+++ b/compiler/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_ast"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/ast_type/Cargo.toml
+++ b/compiler/ast_type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_ast_type"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/codegen/Cargo.toml
+++ b/compiler/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_codegen"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/common/Cargo.toml
+++ b/compiler/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_common"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/driver/Cargo.toml
+++ b/compiler/driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_compiler_driver"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/ir/Cargo.toml
+++ b/compiler/ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_ir"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 license = "MIT OR Apache-2.0"

--- a/compiler/lex/Cargo.toml
+++ b/compiler/lex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_lex"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/lsp/Cargo.toml
+++ b/compiler/lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_lsp"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 license = "MIT OR Apache-2.0"

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -166,7 +166,7 @@ impl LanguageServer for Backend {
             },
             server_info: Some(ServerInfo {
                 name: "kaede-lsp".to_string(),
-                version: Some("0.1.0".to_string()),
+                version: Some(env!("CARGO_PKG_VERSION").to_string()),
             }),
         })
     }

--- a/compiler/monomorphize/Cargo.toml
+++ b/compiler/monomorphize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_monomorphize"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 license = "MIT OR Apache-2.0"

--- a/compiler/parse/Cargo.toml
+++ b/compiler/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_parse"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/semantic/Cargo.toml
+++ b/compiler/semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_semantic"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 license = "MIT OR Apache-2.0"

--- a/compiler/span/Cargo.toml
+++ b/compiler/span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_span"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/symbol/Cargo.toml
+++ b/compiler/symbol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_symbol"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/symbol_table/Cargo.toml
+++ b/compiler/symbol_table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_symbol_table"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 license = "MIT OR Apache-2.0"

--- a/compiler/type_infer/Cargo.toml
+++ b/compiler/type_infer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_type_infer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump all compiler crate versions from 0.1.0 to 0.1.1
- Read the LSP server version from `CARGO_PKG_VERSION` instead of hardcoding it

## Test plan
- [x] CI passes
- [x] `cargo run -p kaede_compiler_driver -- --version` reports `0.1.1`
- [x] After merge, tag and push `v0.1.1`, then update the Homebrew formula URL/sha256