### PR TITLE
Add slice copy_from

### DIFF
--- a/compiler/driver/tests/bytes.rs
+++ b/compiler/driver/tests/bytes.rs
@@ -46,40 +46,6 @@ fun main() -> i32 {
 }
 
 #[test]
-fn std_bytes_copy_fill_cover_lengths() -> anyhow::Result<()> {
-    test(
-        0,
-        r#"import std.bytes
-
-fun main() -> i32 {
-    let mut dst = [0 as u8; 5]
-    std.bytes.fill(dst, 9)
-    if dst[0] != 9 || dst[4] != 9 {
-        return 1
-    }
-
-    let copied = std.bytes.copy(dst[1:4], b"abc")
-    if copied != 3 {
-        return 2
-    }
-    if dst[0] != 9 || dst[1] != 'a' as u8 || dst[2] != 'b' as u8 || dst[3] != 'c' as u8 || dst[4] != 9 {
-        return 3
-    }
-
-    let mut short = [0 as u8; 2]
-    if std.bytes.copy(short, b"wxyz") != 2 {
-        return 4
-    }
-    if short[0] != 'w' as u8 || short[1] != 'x' as u8 {
-        return 5
-    }
-
-    return 0
-}"#,
-    )
-}
-
-#[test]
 fn std_bytes_range_checks_panic() -> anyhow::Result<()> {
     let tempdir = assert_fs::TempDir::new()?;
     let main = tempdir.child("main.kd");

--- a/compiler/driver/tests/slice.rs
+++ b/compiler/driver/tests/slice.rs
@@ -1,0 +1,53 @@
+mod driver_test_support;
+
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+use driver_test_support::{compile_project, run_program as test};
+
+#[test]
+fn slice_copy_from_copies_exact_length() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"fun main() -> i32 {
+    let mut bytes = [0 as u8; 5]
+    bytes[1:4].copy_from(b"abc")
+    if bytes[0] != 0 || bytes[1] != 'a' as u8 || bytes[2] != 'b' as u8 || bytes[3] != 'c' as u8 || bytes[4] != 0 {
+        return 1
+    }
+
+    let mut nums = [0, 0, 0]
+    let src = [4, 5, 6]
+    nums[:].copy_from(src[:])
+    if nums[0] != 4 || nums[1] != 5 || nums[2] != 6 {
+        return 2
+    }
+
+    return 0
+}"#,
+    )
+}
+
+#[test]
+fn slice_copy_from_panics_on_length_mismatch() -> anyhow::Result<()> {
+    let tempdir = assert_fs::TempDir::new()?;
+    let main = tempdir.child("main.kd");
+    main.write_str(
+        r#"fun main() {
+    let mut dst = [0 as u8; 2]
+    dst[:].copy_from(b"abc")
+}"#,
+    )?;
+
+    let (exe, _) = compile_project(&[main.path()], tempdir.path())?;
+    Command::new(exe.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "panic: [T].copy_from: length mismatch",
+        ));
+
+    Ok(())
+}

--- a/library/src/autoload/slice.kd
+++ b/library/src/autoload/slice.kd
@@ -6,4 +6,20 @@ impl<T> [T] {
     export fun len(self) -> u64 {
         return self.1
     }
+
+    // Copies every element from `src` into `self`.
+    //
+    // This is length-exact: callers that want to copy a smaller range should
+    // slice both sides explicitly so the copied range is visible.
+    export fun copy_from(mut self, src: [T]) {
+        if self.len() != src.len() {
+            panic("[T].copy_from: length mismatch")
+        }
+
+        let mut i = 0
+        while i < self.len() {
+            self[i] = src[i]
+            i += 1
+        }
+    }
 }

--- a/library/src/std/bytes.kd
+++ b/library/src/std/bytes.kd
@@ -62,23 +62,3 @@ impl u64 {
         buf[offset + 7] = ((self >> 56) & 0xff) as u8
     }
 }
-
-// Replaces every byte in `buf` with `value`.
-export fun fill(buf: mut [u8], value: u8) {
-    let mut i = 0
-    while i < buf.len() {
-        buf[i] = value
-        i += 1
-    }
-}
-
-// Copies up to `dst.len()` bytes from `src` and returns the number copied.
-export fun copy(dst: mut [u8], src: [u8]) -> u64 {
-    let n = if dst.len() < src.len() { dst.len() } else { src.len() }
-    let mut i = 0
-    while i < n {
-        dst[i] = src[i]
-        i += 1
-    }
-    return n
-}


### PR DESCRIPTION
## Summary

- Add generic `[T].copy_from(mut self, src: [T])` on slices.
- Require exact source/destination lengths and panic on mismatch.
- Remove unused `std.bytes.copy` and `std.bytes.fill`.

## Verification

- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c ./install.py --prefix /tmp/kaede-copy-from-bytes-pr-20260529`
- `nix develop -c env KAEDE_DIR=/tmp/kaede-copy-from-bytes-pr-20260529 cargo test --release -p kaede_compiler_driver --test bytes --test slice`
- `nix develop -c cargo clippy -- -D warnings`
