### PR TITLE
Add std assert

### DIFF
--- a/compiler/driver/tests/assert.rs
+++ b/compiler/driver/tests/assert.rs
@@ -1,0 +1,45 @@
+mod driver_test_support;
+
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+use driver_test_support::{compile_project, run_program as test};
+
+#[test]
+fn std_assert_accepts_true_conditions() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.assert
+use std.assert.assert
+
+fun main() -> i32 {
+    assert(true)
+    std.assert.assert(1 + 1 == 2, "math broke")
+    return 0
+}"#,
+    )
+}
+
+#[test]
+fn std_assert_panics_with_custom_message() -> anyhow::Result<()> {
+    let tempdir = assert_fs::TempDir::new()?;
+    let main = tempdir.child("main.kd");
+    main.write_str(
+        r#"import std.assert
+use std.assert.assert
+
+fun main() {
+    assert(false, "custom assert message")
+}"#,
+    )?;
+
+    let (exe, _) = compile_project(&[main.path()], tempdir.path())?;
+    Command::new(exe.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("panic: custom assert message"));
+
+    Ok(())
+}

--- a/library/src/std/assert.kd
+++ b/library/src/std/assert.kd
@@ -1,0 +1,10 @@
+// Assertion helpers built on top of the `panic` builtin.
+//
+// The panic location currently points at this helper rather than the caller.
+// Preserving caller locations requires compiler support, but this function is
+// still useful for ordinary runtime checks.
+export fun assert(cond: bool, msg: str = "assertion failed") {
+    if !cond {
+        panic(msg)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `std.assert.assert(cond, msg = "assertion failed")`.
- Cover success and panic cases with driver integration tests.

## Verification

- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c ./install.py --prefix /tmp/kaede-assert-pr-20260529`
- `nix develop -c env KAEDE_DIR=/tmp/kaede-assert-pr-20260529 cargo test --release -p kaede_compiler_driver --test assert`
- `nix develop -c cargo clippy -- -D warnings`
