### PR TITLE
chore(ci): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      cargo-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /website
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      website-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /editors/vscode
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      vscode-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      actions-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Add `.github/dependabot.yml` so dependency updates arrive as PRs instead of piling up as alerts.

| ecosystem | directory | grouping |
|---|---|---|
| cargo | `/` | minor/patch → 1 PR |
| npm | `/website` | minor/patch → 1 PR |
| npm | `/editors/vscode` | minor/patch → 1 PR |
| github-actions | `/` | all → 1 PR |

Schedule is weekly (Monday), `open-pull-requests-limit: 5` per ecosystem. Major bumps are left as individual PRs so breaking changes stay reviewable.

## Context

There were 21 open Dependabot alerts (1 critical / 6 high / 12 medium / 2 low), all npm, with no Dependabot PRs open. Two separate things were off:

- **Dependabot security updates** (auto-PRs for alerts) — now enabled via repo settings, separate from this PR.
- **Dependabot version updates** — this PR.

Note: the Nix flake inputs and the `library/bdwgc` submodule are not covered by Dependabot and stay manual.

https://claude.ai/code/session_01ERupuMPPvcoB39Bc3hEt5M