### PR TITLE
chore(ci): scope docs concurrency to ref, group react bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,17 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
+      # react and react-dom must move together or `npm ci` fails on a peer
+      # dependency conflict; same for the docusaurus packages, which are
+      # released in lockstep. Listed before website-minor-patch because the
+      # first matching group wins.
+      react:
+        patterns:
+          - react
+          - react-dom
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
       website-minor-patch:
         patterns:
           - "*"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,7 +21,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: deploy-docs
+  group: deploy-docs-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Two fixes surfaced by the Dependabot PR wave.

## 1. `deploy-docs` concurrency cancelled unrelated runs

```yaml
concurrency:
  group: deploy-docs          # no ref in the key
  cancel-in-progress: true
```

Every run on every branch shared a single concurrency group, so the newest run cancelled whatever was in flight. Observed on the current PR wave:

```
30547558196  cancelled  pull_request  .../react-dom-19.2.8
30547541454  cancelled  pull_request  .../website-minor-patch-...
30547523602  cancelled  pull_request  .../actions-all-...
30547192295  cancelled  push          main    <- main's own deploy
30547165830  cancelled  push          main
30547055149  cancelled  push          main
```

Three `main` deploys were cancelled by unrelated PR runs. Now keyed by `github.ref`, so a branch only cancels its own superseded runs.

## 2. Split react bumps break `npm ci`

PR #363 (react 18→19) failed at `Install website dependencies` because react-dom 19 was in a separate PR (#362) and the peer dependency could not resolve. `react` + `react-dom` are now one group, as are the `@docusaurus/*` packages, which are released in lockstep and would fail the same way on a major bump.

Group order matters — Dependabot assigns a dependency to the first matching group, so `react` and `docusaurus` are listed before the catch-all `website-minor-patch`.

## Follow-up (not in this PR)

Once this merges, #362 and #363 should be closed with `@dependabot close`; Dependabot will re-open them as one grouped PR on the next run.

https://claude.ai/code/session_01ERupuMPPvcoB39Bc3hEt5M