### PR TITLE
chore(ci): add cargo cache fallback, drop magic nix cache

### DIFF
--- a/.github/workflows/ci-nix-linux.yml
+++ b/.github/workflows/ci-nix-linux.yml
@@ -23,8 +23,6 @@ jobs:
             ~/.rustup/
             ./target/
           key: ${{ runner.os }}-nix-cargo-${{ hashFiles('**/Cargo.lock', 'flake.lock') }}
-          # Without a prefix fallback every Cargo.lock change restores nothing,
-          # which is exactly what a dependabot cargo PR does.
           restore-keys: |
             ${{ runner.os }}-nix-cargo-
 

--- a/.github/workflows/ci-nix-linux.yml
+++ b/.github/workflows/ci-nix-linux.yml
@@ -14,11 +14,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
 
-      - name: Set up Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
-        with:
-          use-flakehub: false
-
       - name: Cache rust
         id: cache-rust
         uses: actions/cache@v4
@@ -28,6 +23,10 @@ jobs:
             ~/.rustup/
             ./target/
           key: ${{ runner.os }}-nix-cargo-${{ hashFiles('**/Cargo.lock', 'flake.lock') }}
+          # Without a prefix fallback every Cargo.lock change restores nothing,
+          # which is exactly what a dependabot cargo PR does.
+          restore-keys: |
+            ${{ runner.os }}-nix-cargo-
 
       - name: Install kaede
         run: nix develop --command bash -c "chmod +x install.py && ./install.py --no-setenv"

--- a/.github/workflows/ci-nix-macos.yml
+++ b/.github/workflows/ci-nix-macos.yml
@@ -23,8 +23,6 @@ jobs:
             ~/.rustup/
             ./target/
           key: ${{ runner.os }}-nix-cargo-${{ hashFiles('**/Cargo.lock', 'flake.lock') }}
-          # Without a prefix fallback every Cargo.lock change restores nothing,
-          # which is exactly what a dependabot cargo PR does.
           restore-keys: |
             ${{ runner.os }}-nix-cargo-
 

--- a/.github/workflows/ci-nix-macos.yml
+++ b/.github/workflows/ci-nix-macos.yml
@@ -14,11 +14,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
 
-      - name: Set up Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
-        with:
-          use-flakehub: false
-
       - name: Cache rust
         id: cache-rust
         uses: actions/cache@v4
@@ -28,6 +23,10 @@ jobs:
             ~/.rustup/
             ./target/
           key: ${{ runner.os }}-nix-cargo-${{ hashFiles('**/Cargo.lock', 'flake.lock') }}
+          # Without a prefix fallback every Cargo.lock change restores nothing,
+          # which is exactly what a dependabot cargo PR does.
+          restore-keys: |
+            ${{ runner.os }}-nix-cargo-
 
       - name: Install kaede
         run: nix develop --command bash -c "chmod +x install.py && ./install.py --no-setenv"


### PR DESCRIPTION
Two CI cache fixes. Both workflows, identical changes.

## 1. `restore-keys` for the cargo cache

```yaml
key: ${{ runner.os }}-nix-cargo-${{ hashFiles('**/Cargo.lock', 'flake.lock') }}
restore-keys: |
  ${{ runner.os }}-nix-cargo-
```

The key hashes `Cargo.lock`, but with no prefix fallback a miss restores **zero bytes**. Since changing `Cargo.lock` is what a dependabot cargo PR *is*, those PRs never hit the cache. Measured on the rustdoc-types PR (macOS):

```
Cache rust: 1s        <- nothing restored
Install kaede: 190s   <- 136s on a hit
Run clippy: 34s       <- 9s on a hit
```

GitHub scopes caches per branch, so a feature branch can only read its own entries plus main's — and main's key is also lockfile-derived, so it missed too. Every branch's first build was fully cold. With the fallback, `./target/` is restored from the newest matching entry and cargo rebuilds only the changed crates and their dependents. A fallback hit still saves under the new exact key at the end, so the cache does not go stale.

## 2. Drop Magic Nix Cache

Repo cache usage was at the ceiling:

```
total=10GB count=2094
```

Nearly all 2094 entries are magic-nix-cache narinfo/nar fragments of 0–3MB each. They compete under LRU with the 894MB cargo cache — the thing that actually saves minutes. Meanwhile the dev shell's closure comes from cache.nixos.org, and CI never builds `.#default`, so there is little locally-built output worth caching. On Linux the upload cost 111s of every run:

```
Post Set up Magic Nix Cache: 111s
```

Expected: Linux ~286s → ~175s, and macOS cache-miss builds stop being cold.

## Not included

macOS still runs on every push to every branch (`on: [push]`). Narrowing that to `pull_request` + `push: branches: [main]` is a separate call about merge-gate policy.

https://claude.ai/code/session_01ERupuMPPvcoB39Bc3hEt5M