### PR TITLE
chore(ci): drop explanatory comment from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,10 +25,6 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
-      # react and react-dom must move together or `npm ci` fails on a peer
-      # dependency conflict; same for the docusaurus packages, which are
-      # released in lockstep. Listed before website-minor-patch because the
-      # first matching group wins.
       react:
         patterns:
           - react


### PR DESCRIPTION
Removes the comment above the `react` group in `.github/dependabot.yml`. The rationale for the grouping is in the commit message of #369 and in that PR's description.

No behavior change — the group ordering itself is unchanged.

https://claude.ai/code/session_01ERupuMPPvcoB39Bc3hEt5M