### PR TITLE
fix: unblock the pending cargo dependency bumps

### DIFF
--- a/compiler/codegen/src/expr.rs
+++ b/compiler/codegen/src/expr.rs
@@ -1808,8 +1808,8 @@ impl<'ctx> CodeGenerator<'ctx> {
         } else {
             anyhow::bail!(
                 "unsupported cast from `{}` to `{}`",
-                value_ty.kind.to_string(),
-                target_ty.kind.to_string()
+                value_ty.kind,
+                target_ty.kind
             );
         }
     }
@@ -1871,8 +1871,8 @@ impl<'ctx> CodeGenerator<'ctx> {
 
         anyhow::bail!(
             "unsupported cast from `{}` to `{}`",
-            value_ty.kind.to_string(),
-            target_ty.kind.to_string()
+            value_ty.kind,
+            target_ty.kind
         );
     }
 

--- a/compiler/semantic/src/rust_import.rs
+++ b/compiler/semantic/src/rust_import.rs
@@ -13,7 +13,7 @@ use kaede_symbol::Symbol;
 use rustdoc_types::{
     Crate, FunctionSignature, Id, Item, ItemEnum, ItemKind, ItemSummary, Type, Visibility,
 };
-use toml::Value as TomlValue;
+use toml::{Table as TomlTable, Value as TomlValue};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TyPosition {
@@ -275,7 +275,7 @@ fn run_command(mut cmd: Command, name: &str) -> anyhow::Result<()> {
 fn read_package_name(manifest_path: &Path) -> anyhow::Result<String> {
     let content = fs::read_to_string(manifest_path)
         .with_context(|| format!("failed to read {}", manifest_path.display()))?;
-    let toml = content.parse::<TomlValue>().with_context(|| {
+    let toml = content.parse::<TomlTable>().with_context(|| {
         format!(
             "failed to parse Cargo.toml at {}",
             manifest_path.to_string_lossy()


### PR DESCRIPTION
`#375`（cargo-minor-patch グループ）と `#367`（toml 1.1）はどちらも CI が落ちており、原因は別々の既存コード側の前提です。dependabot ブランチを個別に直すのではなく、main 側で先に両方潰しておきます。

## 変更

- **fix(semantic): parse Cargo.toml as a TOML document** — `toml` 1.x は `impl FromStr for Value` を「単一の TOML 値」に狭めたため、`content.parse::<Value>()` がマニフェスト全体を `unexpected content, expected nothing` で弾き、Rust interop が `package.name` を読めなくなる。`Table` は 0.8 / 1.x どちらでもドキュメントとしてパースする。→ #367
- **style(codegen): drop redundant to_string in cast bail! args** — anyhow 1.0.10x は `bail!` の展開が変わって clippy がフォーマット引数を見通せるようになり、`clippy::to_string_in_format_args` が CI の `-D warnings` で 4 箇所を error にする。`TyKind` は `Display` 実装済み。→ #375

## 検証

現行 main の依存と、#375 の `Cargo.lock` + `toml = "1.1"` を重ねた依存の**両方**で確認（各回 `./install.py --no-setenv` からブートストラップ）:

| | 現行依存 | バンプ後依存 |
|---|---|---|
| `cargo fmt --all -- --check` | ✅ | ✅ |
| `cargo clippy -- -D warnings` | ✅ | ✅ |
| `cargo test --release --no-fail-fast` | ✅ 621 passed / 0 failed | ✅ 0 failed |
| `example/*` の `kaede build`（6 件） | ✅ | ✅ |

`example/rust_interop` と `example/comment_app` は `[rust]` 経由で `read_package_name()` を通るので、toml 側の修正はこの 2 件で実際に踏んでいます。clippy は `--keep-going` で全クレート走らせ、CI が最初のエラーで止まって隠れていた違反がないことも確認済みです。

マージ後に #375 / #367 を `@dependabot rebase` すれば両方緑になる見込みです。

https://claude.ai/code/session_01Da9aeu4zfDk8dUBuDByjWw