### PR TITLE
feat(lang): add `select` expression for channel multiplexing

### DIFF
--- a/compiler/ast/src/expr.rs
+++ b/compiler/ast/src/expr.rs
@@ -314,6 +314,42 @@ pub struct Match {
 }
 
 #[derive(Debug, Clone)]
+pub enum SelectBinding {
+    /// `case value = ch.recv()` — bind the received value to a name.
+    Named(Ident),
+    /// `case _ = ch.recv()` — discard the received value.
+    Wildcard,
+}
+
+#[derive(Debug, Clone)]
+pub enum SelectOp {
+    /// `case ch.send(value)`
+    Send {
+        channel: Box<Expr>,
+        value: Box<Expr>,
+    },
+    /// `case binding = ch.recv()`
+    Recv {
+        channel: Box<Expr>,
+        binding: SelectBinding,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct SelectArm {
+    pub op: SelectOp,
+    pub body: Rc<Expr>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub struct Select {
+    pub arms: Vec<SelectArm>,
+    pub default: Option<Rc<Expr>>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
 pub struct Expr {
     pub kind: ExprKind,
     pub span: Span,
@@ -403,6 +439,7 @@ pub enum ExprKind {
     While(While),
     Break(Break),
     Match(Match),
+    Select(Select),
     Block(Block),
     Ty(Ty),
 }

--- a/compiler/codegen/src/expr.rs
+++ b/compiler/codegen/src/expr.rs
@@ -18,8 +18,8 @@ use kaede_ir::{
         ArrayLiteral, ArrayRepeat, Binary, BinaryKind, BitNot, BuiltinFnCall, BuiltinFnCallKind,
         ByteLiteral, ByteStringLiteral, Cast, CharLiteral, Closure, Else, EnumUnpack, EnumVariant,
         Expr, ExprKind, FieldAccess, Float, FnCall, FnPointer, FormatPart, ITable, If, Indexing,
-        Int, InterfaceBox, InterfaceMethodCall, LogicalNot, Loop, Slicing, Spawn, StringLiteral,
-        StructLiteral, TupleIndexing, TupleLiteral, Variable,
+        Int, InterfaceBox, InterfaceMethodCall, LogicalNot, Loop, Select, SelectOp, Slicing, Spawn,
+        StringLiteral, StructLiteral, TupleIndexing, TupleLiteral, Variable,
     },
     stmt::Block,
     ty::{
@@ -193,6 +193,7 @@ impl<'ctx> CodeGenerator<'ctx> {
 
             ExprKind::InterfaceBox(node) => self.build_interface_box(node)?,
             ExprKind::InterfaceMethodCall(node) => self.build_interface_method_call(node)?,
+            ExprKind::Select(node) => self.build_select(node)?,
         })
     }
 
@@ -413,6 +414,42 @@ impl<'ctx> CodeGenerator<'ctx> {
         }
 
         self.build_string_literal_internal(dst_buf.into(), total_len)
+    }
+
+    /// Emit a panic with a message fixed at compile time, for failures the
+    /// compiler detects itself rather than ones written as `panic(...)` in
+    /// Kaede source. Same stderr-then-abort shape as `build_panic`, but the
+    /// whole line is one global string since there is no user expression and no
+    /// meaningful source location to report.
+    fn build_static_panic(&mut self, message: &str) -> anyhow::Result<()> {
+        let i32_ty = self.context().i32_type();
+        let i64_ty = self.context().i64_type();
+        let ptr_ty = self.context().ptr_type(inkwell::AddressSpace::default());
+        let write_fn_ty = i32_ty.fn_type(&[i32_ty.into(), ptr_ty.into(), i64_ty.into()], false);
+        let write_fn = self.declare_runtime_fn("write", write_fn_ty);
+
+        let void_ty = self.context().void_type();
+        let abort_fn_ty = void_ty.fn_type(&[], false);
+        let abort_fn = self.declare_runtime_fn("abort", abort_fn_ty);
+
+        let text = format!("panic: {}\n", message);
+        let text_global = self
+            .builder
+            .build_global_string_ptr(&text, "panic.static")?;
+        self.builder.build_call(
+            write_fn,
+            &[
+                i32_ty.const_int(2, false).into(),
+                text_global.as_pointer_value().into(),
+                i64_ty.const_int(text.len() as u64, false).into(),
+            ],
+            "",
+        )?;
+
+        self.builder.build_call(abort_fn, &[], "")?;
+        self.builder.build_unreachable()?;
+
+        Ok(())
     }
 
     fn build_panic(&mut self, node: &BuiltinFnCall) -> anyhow::Result<()> {
@@ -1549,6 +1586,370 @@ impl<'ctx> CodeGenerator<'ctx> {
         }
 
         Ok(wrapper_fn)
+    }
+
+    /// Layout of `struct KaedeSelectCase` in the runtime, matched in LLVM:
+    ///   { i8*, i32, i32_pad, i8*, i32 }
+    /// (8) channel, (12) op, (16) value_slot, (24) status, total 32 bytes.
+    /// The named constants below index this struct.
+    fn select_case_struct_type(&self) -> StructType<'ctx> {
+        let ptr_ty = self.context().ptr_type(AddressSpace::default());
+        let i32_ty = self.context().i32_type();
+        self.context().struct_type(
+            &[
+                ptr_ty.into(),
+                i32_ty.into(),
+                i32_ty.into(), // explicit padding to match C alignment
+                ptr_ty.into(),
+                i32_ty.into(),
+            ],
+            false,
+        )
+    }
+
+    fn build_select(&mut self, node: &Select) -> anyhow::Result<Value<'ctx>> {
+        // Field indices into the KaedeSelectCase struct above. Must stay in
+        // sync with library/runtime/include/kaede/channel.h.
+        const FIELD_CHANNEL: u32 = 0;
+        const FIELD_OP: u32 = 1;
+        // Field 2 is padding, present so these indices line up with the C
+        // struct. It is never read.
+        const FIELD_VALUE_SLOT: u32 = 3;
+        const FIELD_STATUS: u32 = 4;
+        // KaedeSelectStatus values, same header.
+        const STATUS_CLOSED: u64 = 1;
+
+        let parent = self.get_current_fn();
+        let case_struct_ty = self.select_case_struct_type();
+        let n = node.arms.len();
+        let array_ty = case_struct_ty.array_type(n as u32);
+        let cases_alloca = self.create_entry_block_alloca("select.cases", array_ty.into())?;
+        let i32_ty = self.context().i32_type();
+        let ptr_ty = self.context().ptr_type(AddressSpace::default());
+
+        // Allocate value slots per arm and populate the case array in source
+        // order (Go semantics: evaluate every channel/send value once up front).
+        let mut value_slots: Vec<PointerValue<'ctx>> = Vec::with_capacity(n);
+
+        for (i, arm) in node.arms.iter().enumerate() {
+            let elem_llvm_ty = self.conv_to_llvm_type(&arm.elem_ty);
+            let slot =
+                self.create_entry_block_alloca(&format!("select.slot{}", i), elem_llvm_ty)?;
+            value_slots.push(slot);
+
+            // Evaluate the channel expression and extract `Channel<T>.ptr`.
+            let channel_struct_ptr = self.build_expr(&arm.channel)?.unwrap().into_pointer_value();
+            let channel_qsym = Self::channel_struct_qsym(&arm.channel.ty)?;
+            let channel_llvm_struct = self
+                .module
+                .get_struct_type(channel_qsym.mangle().as_str())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Channel<T> LLVM struct type not registered: {}",
+                        channel_qsym.mangle()
+                    )
+                })?;
+            let chan_ptr_gep =
+                self.builder
+                    .build_struct_gep(channel_llvm_struct, channel_struct_ptr, 0, "")?;
+            let chan_raw_ptr = self
+                .builder
+                .build_load(ptr_ty, chan_ptr_gep, "")?
+                .into_pointer_value();
+
+            if let SelectOp::Send = arm.op {
+                let value = self.build_expr(arm.value.as_ref().unwrap())?.unwrap();
+                self.builder.build_store(slot, value)?;
+            }
+
+            let case_ptr = unsafe {
+                self.builder.build_in_bounds_gep(
+                    array_ty,
+                    cases_alloca,
+                    &[i32_ty.const_zero(), i32_ty.const_int(i as u64, false)],
+                    "",
+                )?
+            };
+            let store_field = |ce: &CodeGenerator<'ctx>,
+                               field: u32,
+                               value: BasicValueEnum<'ctx>|
+             -> anyhow::Result<()> {
+                let gep = ce
+                    .builder
+                    .build_struct_gep(case_struct_ty, case_ptr, field, "")?;
+                ce.builder.build_store(gep, value)?;
+                Ok(())
+            };
+
+            let op_const = i32_ty.const_int(
+                match arm.op {
+                    SelectOp::Send => 0,
+                    SelectOp::Recv => 1,
+                },
+                false,
+            );
+            store_field(self, FIELD_CHANNEL, chan_raw_ptr.as_basic_value_enum())?;
+            store_field(self, FIELD_OP, op_const.as_basic_value_enum())?;
+            store_field(self, FIELD_VALUE_SLOT, slot.as_basic_value_enum())?;
+            store_field(
+                self,
+                FIELD_STATUS,
+                i32_ty.const_zero().as_basic_value_enum(),
+            )?;
+        }
+
+        let has_default = node.default.is_some();
+        let i64_ty = self.context().i64_type();
+        let bool_ty = self.context().bool_type();
+        let select_fn = self.declare_runtime_fn(
+            "kaede_select",
+            i32_ty.fn_type(&[ptr_ty.into(), i64_ty.into(), bool_ty.into()], false),
+        );
+
+        let chosen = self
+            .builder
+            .build_call(
+                select_fn,
+                &[
+                    cases_alloca.as_basic_value_enum().into(),
+                    i64_ty.const_int(n as u64, false).into(),
+                    bool_ty
+                        .const_int(if has_default { 1 } else { 0 }, false)
+                        .into(),
+                ],
+                "select.chosen",
+            )?
+            .try_as_basic_value()
+            .left()
+            .unwrap()
+            .into_int_value();
+
+        // Per-arm basic blocks, plus optional default block, plus a join block.
+        let mut arm_blocks: Vec<inkwell::basic_block::BasicBlock<'ctx>> = Vec::with_capacity(n);
+        for i in 0..n {
+            arm_blocks.push(
+                self.context()
+                    .append_basic_block(parent, &format!("select.arm{}", i)),
+            );
+        }
+        let default_block = if has_default {
+            Some(self.context().append_basic_block(parent, "select.default"))
+        } else {
+            None
+        };
+        let cont_block = self.context().append_basic_block(parent, "select.cont");
+
+        // Switch: -1 -> default (if any), else arm[i]. `kaede_select` also
+        // returns -1 without a `default` arm on paths where it cannot pick a
+        // case at all: the runtime is already shutting down, or a waiter
+        // allocation failed. There is no arm body to run then, so fall through
+        // past the select — mirroring how a plain `recv()` degrades to
+        // `Option::None` on shutdown. Routing -1 to `unreachable` instead would
+        // make those paths undefined behaviour.
+        let switch_default = default_block.unwrap_or(cont_block);
+        let cases: Vec<(IntValue<'ctx>, inkwell::basic_block::BasicBlock<'ctx>)> = (0..n)
+            .map(|i| (i32_ty.const_int(i as u64, false), arm_blocks[i]))
+            .collect();
+        self.builder.build_switch(chosen, switch_default, &cases)?;
+
+        // Per-arm bodies.
+        for (i, arm) in node.arms.iter().enumerate() {
+            self.builder.position_at_end(arm_blocks[i]);
+
+            self.tcx.push_symbol_table(SymbolTable::new());
+
+            match arm.op {
+                SelectOp::Send => {
+                    // A send case also fires when the channel turned out to be
+                    // closed, in which case nothing was sent. `Channel::send`
+                    // panics there, so the select arm must not run its body as
+                    // if the value had been handed off.
+                    let case_ptr = unsafe {
+                        self.builder.build_in_bounds_gep(
+                            array_ty,
+                            cases_alloca,
+                            &[i32_ty.const_zero(), i32_ty.const_int(i as u64, false)],
+                            "",
+                        )?
+                    };
+                    let status_gep = self.builder.build_struct_gep(
+                        case_struct_ty,
+                        case_ptr,
+                        FIELD_STATUS,
+                        "",
+                    )?;
+                    let status = self
+                        .builder
+                        .build_load(i32_ty, status_gep, "select.send_status")?
+                        .into_int_value();
+                    let is_closed = self.builder.build_int_compare(
+                        IntPredicate::EQ,
+                        status,
+                        i32_ty.const_int(STATUS_CLOSED, false),
+                        "is_closed",
+                    )?;
+                    let closed_bb = self
+                        .context()
+                        .append_basic_block(parent, "select.send_closed");
+                    let sent_bb = self.context().append_basic_block(parent, "select.sent");
+                    self.builder
+                        .build_conditional_branch(is_closed, closed_bb, sent_bb)?;
+
+                    self.builder.position_at_end(closed_bb);
+                    self.build_static_panic("send on closed channel")?;
+
+                    self.builder.position_at_end(sent_bb);
+                    self.build_expr(&arm.body)?;
+                }
+                SelectOp::Recv => {
+                    if let Some(binding) = arm.binding {
+                        // Materialize Option<T>: read cases[i].status, branch
+                        // VALUE -> Some(load slot), CLOSED -> None.
+                        let option_ty = arm.option_ty.as_ref().unwrap();
+                        let enum_info = arm.option_enum_info.as_ref().ok_or_else(|| {
+                            anyhow::anyhow!("select recv arm missing resolved Option enum info")
+                        })?;
+                        let case_ptr = unsafe {
+                            self.builder.build_in_bounds_gep(
+                                array_ty,
+                                cases_alloca,
+                                &[i32_ty.const_zero(), i32_ty.const_int(i as u64, false)],
+                                "",
+                            )?
+                        };
+                        let status_gep = self.builder.build_struct_gep(
+                            case_struct_ty,
+                            case_ptr,
+                            FIELD_STATUS,
+                            "",
+                        )?;
+                        let option_value =
+                            self.build_recv_option(enum_info, value_slots[i], status_gep)?;
+                        let option_llvm_ty = self.conv_to_llvm_type(option_ty);
+                        self.build_let_internal(binding, option_llvm_ty, Some(option_value))?;
+                    }
+                    self.build_expr(&arm.body)?;
+                }
+            }
+
+            self.tcx.pop_symbol_table();
+
+            if self.no_terminator() {
+                self.builder.build_unconditional_branch(cont_block)?;
+            }
+        }
+
+        // Default body.
+        if let (Some(default_block), Some(default_body)) = (default_block, &node.default) {
+            self.builder.position_at_end(default_block);
+            self.tcx.push_symbol_table(SymbolTable::new());
+            self.build_expr(default_body)?;
+            self.tcx.pop_symbol_table();
+            if self.no_terminator() {
+                self.builder.build_unconditional_branch(cont_block)?;
+            }
+        }
+
+        self.builder.position_at_end(cont_block);
+        Ok(None)
+    }
+
+    fn build_recv_option(
+        &mut self,
+        enum_info: &Rc<kaede_ir::top::Enum>,
+        value_slot: PointerValue<'ctx>,
+        status_gep: PointerValue<'ctx>,
+    ) -> anyhow::Result<BasicValueEnum<'ctx>> {
+        let some_variant = enum_info
+            .variants
+            .iter()
+            .find(|v| v.name.as_str() == "Some")
+            .ok_or_else(|| anyhow::anyhow!("Option enum is missing Some variant"))?;
+        let none_variant = enum_info
+            .variants
+            .iter()
+            .find(|v| v.name.as_str() == "None")
+            .ok_or_else(|| anyhow::anyhow!("Option enum is missing None variant"))?;
+        let enum_llvm_ty = self
+            .module
+            .get_struct_type(enum_info.name.mangle().as_str())
+            .ok_or_else(|| anyhow::anyhow!("Option enum LLVM type not registered"))?;
+        let payload_ty = some_variant
+            .ty
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Option::Some variant has no payload type"))?;
+
+        let i32_ty = self.context().i32_type();
+        let status = self
+            .builder
+            .build_load(i32_ty, status_gep, "select.status")?
+            .into_int_value();
+
+        let parent = self.get_current_fn();
+        let some_bb = self.context().append_basic_block(parent, "recv.some");
+        let none_bb = self.context().append_basic_block(parent, "recv.none");
+        let join_bb = self.context().append_basic_block(parent, "recv.join");
+
+        // KAEDE_SELECT_STATUS_VALUE = 0. status == 0 → Some, else None.
+        let is_value = self.builder.build_int_compare(
+            IntPredicate::EQ,
+            status,
+            i32_ty.const_zero(),
+            "is_value",
+        )?;
+        self.builder
+            .build_conditional_branch(is_value, some_bb, none_bb)?;
+
+        self.builder.position_at_end(some_bb);
+        let payload_llvm_ty = self.conv_to_llvm_type(payload_ty);
+        let loaded_value = self.builder.build_load(payload_llvm_ty, value_slot, "")?;
+        let some_struct = self.create_gc_struct(
+            enum_llvm_ty.as_basic_type_enum(),
+            &[
+                i32_ty.const_int(some_variant.offset as u64, false).into(),
+                loaded_value,
+            ],
+        )?;
+        self.builder.build_unconditional_branch(join_bb)?;
+        let some_bb_end = self.builder.get_insert_block().unwrap();
+
+        self.builder.position_at_end(none_bb);
+        let none_struct = self.create_gc_struct(
+            enum_llvm_ty.as_basic_type_enum(),
+            &[i32_ty.const_int(none_variant.offset as u64, false).into()],
+        )?;
+        self.builder.build_unconditional_branch(join_bb)?;
+        let none_bb_end = self.builder.get_insert_block().unwrap();
+
+        self.builder.position_at_end(join_bb);
+        let phi = self
+            .builder
+            .build_phi(self.context().ptr_type(AddressSpace::default()), "recv.phi")?;
+        phi.add_incoming(&[(&some_struct, some_bb_end), (&none_struct, none_bb_end)]);
+        Ok(phi.as_basic_value())
+    }
+
+    /// For a `Reference<Channel<T>>` (or bare `Channel<T>`) operand type, return
+    /// the qualified symbol naming the LLVM struct type for `Channel<T>`.
+    fn channel_struct_qsym(ty: &Ty) -> anyhow::Result<kaede_ir::qualified_symbol::QualifiedSymbol> {
+        let base = match ty.kind.as_ref() {
+            TyKind::Reference(rty) => rty.get_base_type(),
+            _ => return Self::channel_struct_qsym_from_udt_ty(ty),
+        };
+        Self::channel_struct_qsym_from_udt_ty(&base)
+    }
+
+    fn channel_struct_qsym_from_udt_ty(
+        ty: &Ty,
+    ) -> anyhow::Result<kaede_ir::qualified_symbol::QualifiedSymbol> {
+        let TyKind::UserDefined(udt) = ty.kind.as_ref() else {
+            anyhow::bail!("select channel arm operand is not a user-defined type");
+        };
+        match &udt.kind {
+            kaede_ir::ty::UserDefinedTypeKind::Struct(s) => Ok(s.name.clone()),
+            kaede_ir::ty::UserDefinedTypeKind::Placeholder(qsym) => Ok(qsym.clone()),
+            _ => anyhow::bail!("select channel arm operand is not Channel<T>"),
+        }
     }
 
     fn declare_runtime_fn(

--- a/compiler/codegen/src/expr.rs
+++ b/compiler/codegen/src/expr.rs
@@ -1589,8 +1589,9 @@ impl<'ctx> CodeGenerator<'ctx> {
     }
 
     /// Layout of `struct KaedeSelectCase` in the runtime, matched in LLVM:
-    ///   { i8*, i32, i32_pad, i8*, i32 }
-    /// (8) channel, (12) op, (16) value_slot, (24) status, total 32 bytes.
+    ///   { ptr, i32, i32 (pad), ptr, i32 }
+    /// Offsets 0 channel, 8 op, 12 pad, 16 value_slot, 24 status; size 32 on
+    /// LP64. `channel.h` static-asserts the C side of this.
     /// The named constants below index this struct.
     fn select_case_struct_type(&self) -> StructType<'ctx> {
         let ptr_ty = self.context().ptr_type(AddressSpace::default());

--- a/compiler/codegen/src/expr.rs
+++ b/compiler/codegen/src/expr.rs
@@ -27,6 +27,7 @@ use kaede_ir::{
         TyKind,
     },
 };
+use kaede_span::Span;
 use kaede_symbol::Symbol;
 
 pub type Value<'ctx> = Option<BasicValueEnum<'ctx>>;
@@ -418,10 +419,10 @@ impl<'ctx> CodeGenerator<'ctx> {
 
     /// Emit a panic with a message fixed at compile time, for failures the
     /// compiler detects itself rather than ones written as `panic(...)` in
-    /// Kaede source. Same stderr-then-abort shape as `build_panic`, but the
-    /// whole line is one global string since there is no user expression and no
-    /// meaningful source location to report.
-    fn build_static_panic(&mut self, message: &str) -> anyhow::Result<()> {
+    /// Kaede source. Same stderr-then-abort shape and same " (at file:line)"
+    /// suffix as `build_panic`, but emitted as one global string since there is
+    /// no user expression to format.
+    fn build_static_panic(&mut self, message: &str, span: Span) -> anyhow::Result<()> {
         let i32_ty = self.context().i32_type();
         let i64_ty = self.context().i64_type();
         let ptr_ty = self.context().ptr_type(inkwell::AddressSpace::default());
@@ -432,7 +433,15 @@ impl<'ctx> CodeGenerator<'ctx> {
         let abort_fn_ty = void_ty.fn_type(&[], false);
         let abort_fn = self.declare_runtime_fn("abort", abort_fn_ty);
 
-        let text = format!("panic: {}\n", message);
+        let file_path = span.file.path();
+        let file_name = file_path
+            .file_name()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let text = format!(
+            "panic: {} (at {}:{})\n",
+            message, file_name, span.start.line
+        );
         let text_global = self
             .builder
             .build_global_string_ptr(&text, "panic.static")?;
@@ -1797,7 +1806,7 @@ impl<'ctx> CodeGenerator<'ctx> {
                         .build_conditional_branch(is_closed, closed_bb, sent_bb)?;
 
                     self.builder.position_at_end(closed_bb);
-                    self.build_static_panic("send on closed channel")?;
+                    self.build_static_panic("send on closed channel", arm.span)?;
 
                     self.builder.position_at_end(sent_bb);
                     self.build_expr(&arm.body)?;

--- a/compiler/driver/tests/runtime_select.rs
+++ b/compiler/driver/tests/runtime_select.rs
@@ -1,0 +1,241 @@
+mod driver_test_support;
+
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+use driver_test_support::{compile_project, run_program as test};
+
+#[test]
+fn select_single_recv_arm_behaves_like_plain_recv() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun producer(ch: Channel<i32>) {
+    ch.send(42)
+}
+
+fun main() -> i32 {
+    let ch = Channel<i32>::new()
+    spawn producer(ch)
+
+    select {
+        case value = ch.recv() => {
+            match value {
+                Option::Some(v) => {
+                    if v != 42 { return 2 }
+                    return 0
+                },
+                Option::None => return 1,
+            }
+        }
+    }
+    return 3
+}"#,
+    )
+}
+
+#[test]
+fn select_fan_in_from_two_producers() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun producer1(ch: Channel<i32>) {
+    ch.send(10)
+}
+
+fun producer2(ch: Channel<i32>) {
+    ch.send(32)
+}
+
+fun main() -> i32 {
+    let a = Channel<i32>::new()
+    let b = Channel<i32>::new()
+    spawn producer1(a)
+    spawn producer2(b)
+
+    let mut sum = 0
+    let mut received = 0
+    loop {
+        if received == 2 { break }
+        select {
+            case va = a.recv() => {
+                match va {
+                    Option::Some(v) => { sum = sum + v },
+                    Option::None => {},
+                }
+                received = received + 1
+            },
+            case vb = b.recv() => {
+                match vb {
+                    Option::Some(v) => { sum = sum + v },
+                    Option::None => {},
+                }
+                received = received + 1
+            },
+        }
+    }
+
+    if sum == 42 { return 0 }
+    return 4
+}"#,
+    )
+}
+
+#[test]
+fn select_default_falls_through_when_no_case_ready() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun main() -> i32 {
+    let ch = Channel<i32>::with_capacity(1)
+
+    select {
+        case _ = ch.recv() => return 1,
+        default => return 0,
+    }
+    return 2
+}"#,
+    )
+}
+
+#[test]
+fn select_observes_closed_channel_as_none() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun closer(ch: Channel<i32>) {
+    ch.close()
+}
+
+fun main() -> i32 {
+    let ch = Channel<i32>::new()
+    spawn closer(ch)
+
+    select {
+        case value = ch.recv() => {
+            match value {
+                Option::None => return 0,
+                Option::Some(_) => return 1,
+            }
+        }
+    }
+    return 2
+}"#,
+    )
+}
+
+#[test]
+fn select_send_case_into_buffered_channel() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun main() -> i32 {
+    let ch = Channel<i32>::with_capacity(1)
+
+    select {
+        case ch.send(11) => {},
+    }
+
+    match ch.recv() {
+        Option::Some(v) => {
+            if v == 11 { return 0 }
+            return 2
+        },
+        Option::None => return 1,
+    }
+}"#,
+    )
+}
+
+#[test]
+fn select_send_case_handshakes_with_blocked_receiver() -> anyhow::Result<()> {
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun receiver(ch: Channel<i32>, out: Channel<i32>) {
+    match ch.recv() {
+        Option::Some(v) => out.send(v),
+        Option::None => out.send(-1),
+    }
+}
+
+fun main() -> i32 {
+    let ch = Channel<i32>::new()
+    let out = Channel<i32>::new()
+    spawn receiver(ch, out)
+
+    select {
+        case ch.send(99) => {},
+    }
+
+    match out.recv() {
+        Option::Some(v) => {
+            if v == 99 { return 0 }
+            return 2
+        },
+        Option::None => return 1,
+    }
+}"#,
+    )
+}
+
+#[test]
+fn select_send_case_panics_on_closed_channel() -> anyhow::Result<()> {
+    let tempdir = assert_fs::TempDir::new()?;
+    let main = tempdir.child("main.kd");
+    main.write_str(
+        r#"import std.sync
+
+use std.sync.Channel
+
+fun main() -> i32 {
+    let ch = Channel<i32>::new()
+    ch.close()
+    select {
+        case ch.send(1) => { return 0 }
+        default => { return 1 }
+    }
+    return 2
+}"#,
+    )?;
+
+    let (exe, _) = compile_project(&[main.path()], tempdir.path())?;
+    Command::new(exe.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("panic: send on closed channel"));
+
+    Ok(())
+}

--- a/compiler/driver/tests/runtime_select.rs
+++ b/compiler/driver/tests/runtime_select.rs
@@ -239,3 +239,369 @@ fun main() -> i32 {
 
     Ok(())
 }
+
+#[test]
+fn select_consumes_from_exactly_one_channel() -> anyhow::Result<()> {
+    // Both channels hold a value, so either case may be picked. Whichever one
+    // fires, the other channel must be left untouched — exactly one value is
+    // still there afterwards.
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun still_held(ch: Channel<i32>) -> i32 {
+    match ch.try_recv() {
+        Option::Some(_) => return 1,
+        Option::None => return 0,
+    }
+}
+
+fun main() -> i32 {
+    let a = Channel<i32>::with_capacity(1)
+    let b = Channel<i32>::with_capacity(1)
+    a.send(1)
+    b.send(2)
+
+    select {
+        case _ = a.recv() => {}
+        case _ = b.recv() => {}
+    }
+
+    if still_held(a) + still_held(b) != 1 { return 1 }
+    return 0
+}"#,
+    )
+}
+
+#[test]
+fn select_picks_both_arms_over_many_rounds() -> anyhow::Result<()> {
+    // Fairness: with both cases permanently ready, a fixed try order would
+    // starve one arm. Over 100 rounds each arm should win at least once; the
+    // odds of a correct shuffle failing this are 2^-99.
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun main() -> i32 {
+    let a = Channel<i32>::with_capacity(1)
+    let b = Channel<i32>::with_capacity(1)
+
+    let mut hit_a = 0
+    let mut hit_b = 0
+    let mut i = 0
+    loop {
+        if i >= 100 { break }
+        a.send(1)
+        b.send(2)
+        select {
+            case _ = a.recv() => { hit_a = hit_a + 1 },
+            case _ = b.recv() => { hit_b = hit_b + 1 },
+        }
+        // Drain whichever one was not taken.
+        a.try_recv()
+        b.try_recv()
+        i = i + 1
+    }
+
+    if hit_a == 0 { return 1 }
+    if hit_b == 0 { return 2 }
+    if hit_a + hit_b != 100 { return 3 }
+    return 0
+}"#,
+    )
+}
+
+#[test]
+fn select_loops_until_the_channel_closes() -> anyhow::Result<()> {
+    // The pattern the docs teach: accumulate on Some, break on None. Also
+    // covers `break` inside an arm leaving the enclosing loop.
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun producer(ch: Channel<i32>) {
+    ch.send(1)
+    ch.send(2)
+    ch.send(3)
+    ch.close()
+}
+
+fun main() -> i32 {
+    let ch = Channel<i32>::new()
+    spawn producer(ch)
+
+    let mut total = 0
+    loop {
+        select {
+            case value = ch.recv() => {
+                match value {
+                    Option::Some(v) => { total = total + v },
+                    Option::None => break,
+                }
+            }
+        }
+    }
+
+    if total != 6 { return 1 }
+    return 0
+}"#,
+    )
+}
+
+#[test]
+fn select_in_a_generic_function_handles_two_instantiations() -> anyhow::Result<()> {
+    // A recv arm resolves Option<T> at analysis time. Instantiating the same
+    // generic at two element types, one scalar and one pointer-shaped, catches
+    // an Option payload type that got stuck on whichever came first.
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun first<T>(ch: Channel<T>) -> Option<T> {
+    select {
+        case v = ch.recv() => { return v }
+    }
+    return Option::None
+}
+
+fun feed_i32(ch: Channel<i32>) { ch.send(7) }
+fun feed_str(ch: Channel<str>) { ch.send("hello") }
+
+fun main() -> i32 {
+    let a = Channel<i32>::new()
+    spawn feed_i32(a)
+    match first<i32>(a) {
+        Option::Some(x) => { if x != 7 { return 1 } },
+        Option::None => return 2,
+    }
+
+    let b = Channel<str>::new()
+    spawn feed_str(b)
+    match first<str>(b) {
+        Option::Some(s) => { if s != "hello" { return 3 } },
+        Option::None => return 4,
+    }
+
+    return 0
+}"#,
+    )
+}
+
+#[test]
+fn select_over_more_cases_than_the_stack_buffer_holds() -> anyhow::Result<()> {
+    // kaede_select keeps 32 cases on the stack and heap-allocates beyond that,
+    // for both the shuffle order and the waiter array. Nothing is ready here,
+    // so it has to reach Phase B and allocate the waiters too.
+    test(
+        32,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun waker(ch: Channel<i32>) {
+    ch.send(1)
+}
+
+fun main() -> i32 {
+    let c0 = Channel<i32>::new()
+    let c1 = Channel<i32>::new()
+    let c2 = Channel<i32>::new()
+    let c3 = Channel<i32>::new()
+    let c4 = Channel<i32>::new()
+    let c5 = Channel<i32>::new()
+    let c6 = Channel<i32>::new()
+    let c7 = Channel<i32>::new()
+    let c8 = Channel<i32>::new()
+    let c9 = Channel<i32>::new()
+    let c10 = Channel<i32>::new()
+    let c11 = Channel<i32>::new()
+    let c12 = Channel<i32>::new()
+    let c13 = Channel<i32>::new()
+    let c14 = Channel<i32>::new()
+    let c15 = Channel<i32>::new()
+    let c16 = Channel<i32>::new()
+    let c17 = Channel<i32>::new()
+    let c18 = Channel<i32>::new()
+    let c19 = Channel<i32>::new()
+    let c20 = Channel<i32>::new()
+    let c21 = Channel<i32>::new()
+    let c22 = Channel<i32>::new()
+    let c23 = Channel<i32>::new()
+    let c24 = Channel<i32>::new()
+    let c25 = Channel<i32>::new()
+    let c26 = Channel<i32>::new()
+    let c27 = Channel<i32>::new()
+    let c28 = Channel<i32>::new()
+    let c29 = Channel<i32>::new()
+    let c30 = Channel<i32>::new()
+    let c31 = Channel<i32>::new()
+    let c32 = Channel<i32>::new()
+
+    spawn waker(c32)
+
+    select {
+            case _ = c0.recv() => { return 0 }
+            case _ = c1.recv() => { return 1 }
+            case _ = c2.recv() => { return 2 }
+            case _ = c3.recv() => { return 3 }
+            case _ = c4.recv() => { return 4 }
+            case _ = c5.recv() => { return 5 }
+            case _ = c6.recv() => { return 6 }
+            case _ = c7.recv() => { return 7 }
+            case _ = c8.recv() => { return 8 }
+            case _ = c9.recv() => { return 9 }
+            case _ = c10.recv() => { return 10 }
+            case _ = c11.recv() => { return 11 }
+            case _ = c12.recv() => { return 12 }
+            case _ = c13.recv() => { return 13 }
+            case _ = c14.recv() => { return 14 }
+            case _ = c15.recv() => { return 15 }
+            case _ = c16.recv() => { return 16 }
+            case _ = c17.recv() => { return 17 }
+            case _ = c18.recv() => { return 18 }
+            case _ = c19.recv() => { return 19 }
+            case _ = c20.recv() => { return 20 }
+            case _ = c21.recv() => { return 21 }
+            case _ = c22.recv() => { return 22 }
+            case _ = c23.recv() => { return 23 }
+            case _ = c24.recv() => { return 24 }
+            case _ = c25.recv() => { return 25 }
+            case _ = c26.recv() => { return 26 }
+            case _ = c27.recv() => { return 27 }
+            case _ = c28.recv() => { return 28 }
+            case _ = c29.recv() => { return 29 }
+            case _ = c30.recv() => { return 30 }
+            case _ = c31.recv() => { return 31 }
+            case _ = c32.recv() => { return 32 }
+    }
+
+    return 99
+}"#,
+    )
+}
+
+#[test]
+fn select_mixes_send_and_recv_arms_at_runtime() -> anyhow::Result<()> {
+    // Send and recv arms take structurally different codegen paths — the send
+    // arm emits a status check and a panic block, the recv arm emits the
+    // Option materialization. Interleaving them in one select is where block
+    // ordering goes wrong.
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun main() -> i32 {
+    let src = Channel<i32>::with_capacity(1)
+    let sink = Channel<i32>::with_capacity(1)
+
+    // Only the send can proceed: src is empty, sink has room.
+    select {
+        case _ = src.recv() => { return 1 }
+        case sink.send(9) => {}
+    }
+
+    match sink.try_recv() {
+        Option::Some(v) => { if v != 9 { return 2 } },
+        Option::None => return 3,
+    }
+
+    // Now only the recv can proceed: sink is full, src has a value.
+    sink.send(0)
+    src.send(5)
+    select {
+        case v = src.recv() => {
+            match v {
+                Option::Some(x) => { if x != 5 { return 4 } },
+                Option::None => return 5,
+            }
+        }
+        case sink.send(9) => { return 6 }
+    }
+
+    return 0
+}"#,
+    )
+}
+
+#[test]
+fn concurrent_selects_split_values_without_losing_any() -> anyhow::Result<()> {
+    // Two tasks parked in select on the same channel. Each value must wake
+    // exactly one of them — this is what the `done` check in
+    // pop_live_waiter_locked exists for. A lost value hangs the test; a
+    // double delivery overshoots the total.
+    test(
+        0,
+        r#"import std.sync
+import std.option
+
+use std.sync.Channel
+use std.option.Option
+
+fun consumer(work: Channel<i32>, results: Channel<i32>) {
+    let mut seen = 0
+    loop {
+        select {
+            case value = work.recv() => {
+                match value {
+                    Option::Some(_) => { seen = seen + 1 },
+                    Option::None => break,
+                }
+            }
+        }
+    }
+    results.send(seen)
+}
+
+fun main() -> i32 {
+    let work = Channel<i32>::new()
+    let results = Channel<i32>::new()
+
+    spawn consumer(work, results)
+    spawn consumer(work, results)
+
+    let mut i = 0
+    loop {
+        if i >= 20 { break }
+        work.send(i)
+        i = i + 1
+    }
+    work.close()
+
+    let mut total = 0
+    let mut got = 0
+    loop {
+        if got >= 2 { break }
+        match results.recv() {
+            Option::Some(n) => { total = total + n },
+            Option::None => return 1,
+        }
+        got = got + 1
+    }
+
+    if total != 20 { return 2 }
+    return 0
+}"#,
+    )
+}

--- a/compiler/ir/src/expr.rs
+++ b/compiler/ir/src/expr.rs
@@ -370,6 +370,43 @@ pub struct InterfaceMethodCall {
 }
 
 #[derive(Debug, Clone)]
+pub enum SelectOp {
+    Send,
+    Recv,
+}
+
+#[derive(Debug, Clone)]
+pub struct SelectArm {
+    pub op: SelectOp,
+    /// Resolved Channel<T> expression.
+    pub channel: Box<Expr>,
+    /// Channel element type T.
+    pub elem_ty: Rc<Ty>,
+    /// For send arms: the value expression (already type-checked against T).
+    /// For recv arms: None.
+    pub value: Option<Box<Expr>>,
+    /// For recv arms with a name binding: the bound symbol whose type is
+    /// `Option<T>`. `None` for `_ = ...` (discarded) or for send arms.
+    pub binding: Option<Symbol>,
+    /// `Option<T>` type for recv arms (used by codegen to materialize the
+    /// Some/None value). `None` for send arms.
+    pub option_ty: Option<Rc<Ty>>,
+    /// Pre-resolved `Option` enum metadata for recv arms (variants + name).
+    /// Set during semantic analysis so codegen does not need to chase
+    /// Placeholder lookups.
+    pub option_enum_info: Option<Rc<crate::top::Enum>>,
+    pub body: Box<Expr>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub struct Select {
+    pub arms: Vec<SelectArm>,
+    pub default: Option<Box<Expr>>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
 pub enum ExprKind {
     Int(Int),
     Float(Float),
@@ -406,6 +443,7 @@ pub enum ExprKind {
     BuiltinFnCall(BuiltinFnCall),
     InterfaceBox(InterfaceBox),
     InterfaceMethodCall(InterfaceMethodCall),
+    Select(Select),
 }
 
 #[derive(Debug, Clone)]

--- a/compiler/lex/src/lib.rs
+++ b/compiler/lex/src/lib.rs
@@ -189,6 +189,9 @@ impl Cursor<'_> {
                     "self" => self.create_token(TokenKind::Self_),
                     "use" => self.create_token(TokenKind::Use),
                     "spawn" => self.create_token(TokenKind::Spawn),
+                    "select" => self.create_token(TokenKind::Select),
+                    "default" => self.create_token(TokenKind::Default),
+                    "case" => self.create_token(TokenKind::Case),
                     "type" => self.create_token(TokenKind::Type),
 
                     // Identifier

--- a/compiler/lex/src/token.rs
+++ b/compiler/lex/src/token.rs
@@ -153,6 +153,12 @@ pub enum TokenKind {
     Use,
     /// "spawn"
     Spawn,
+    /// "select"
+    Select,
+    /// "default"
+    Default,
+    /// "case"
+    Case,
 
     /// "type"
     Type,
@@ -252,6 +258,9 @@ impl std::fmt::Display for TokenKind {
                 Self_ => "'self'",
                 Use => "'use'",
                 Spawn => "'spawn'",
+                Select => "'select'",
+                Default => "'default'",
+                Case => "'case'",
                 Type => "'type'",
 
                 True => "'true'",

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -378,6 +378,7 @@ fn semantic_error_span(err: &SemanticError) -> Option<Span> {
         | SemanticError::SpawnReturnTypeNotUnit { span, .. }
         | SemanticError::ChannelSendRequiresChannel { span, .. }
         | SemanticError::ChannelRecvRequiresChannel { span, .. }
+        | SemanticError::SelectCaseRequiresChannel { span, .. }
         | SemanticError::UnsupportedLanguageLinkage { span, .. }
         | SemanticError::TopLevelStatementsWithExplicitMain { span }
         | SemanticError::TopLevelStatementsOnlyAllowedInEntryUnit { span }

--- a/compiler/monomorphize/src/lib.rs
+++ b/compiler/monomorphize/src/lib.rs
@@ -157,6 +157,16 @@ mod tests {
                 contains_generic_call(&call.receiver)
                     || call.args.0.iter().any(contains_generic_call)
             }
+            ExprKind::Select(select) => {
+                select.arms.iter().any(|arm| {
+                    contains_generic_call(&arm.channel)
+                        || arm.value.as_ref().is_some_and(|v| contains_generic_call(v))
+                        || contains_generic_call(&arm.body)
+                }) || select
+                    .default
+                    .as_ref()
+                    .is_some_and(|d| contains_generic_call(d))
+            }
             ExprKind::Int(_)
             | ExprKind::Float(_)
             | ExprKind::StringLiteral(_)
@@ -524,6 +534,18 @@ impl Monomorphizer {
                 self.rewrite_expr(&mut call.receiver)?;
                 for arg in &mut call.args.0 {
                     self.rewrite_expr(arg)?;
+                }
+            }
+            ExprKind::Select(select) => {
+                for arm in &mut select.arms {
+                    self.rewrite_expr(&mut arm.channel)?;
+                    if let Some(value) = &mut arm.value {
+                        self.rewrite_expr(value)?;
+                    }
+                    self.rewrite_expr(&mut arm.body)?;
+                }
+                if let Some(default) = &mut select.default {
+                    self.rewrite_expr(default)?;
                 }
             }
             ExprKind::Int(_)

--- a/compiler/parse/src/expr.rs
+++ b/compiler/parse/src/expr.rs
@@ -4,7 +4,8 @@ use kaede_ast::expr::{
     Arg, Args, ArrayLiteral, ArrayRepeat, Binary, BinaryKind, BitNot, Break, ByteLiteral,
     ByteStringLiteral, ChannelRecv, ChannelSend, CharLiteral, Closure, Else, Expr, ExprKind, Float,
     FloatKind, FnCall, If, Indexing, Int, IntKind, LogicalNot, Loop, Match, MatchArm, Return,
-    Slicing, Spawn, StringLiteral, StructLiteral, Try, TupleLiteral, While,
+    Select, SelectArm, SelectBinding, SelectOp, Slicing, Spawn, StringLiteral, StructLiteral, Try,
+    TupleLiteral, While,
 };
 use kaede_ast_type::{GenericArgs, Ty, TyKind};
 use kaede_lex::token::TokenKind;
@@ -548,6 +549,10 @@ impl Parser {
             return self.match_();
         }
 
+        if self.check(&TokenKind::Select) {
+            return self.select_();
+        }
+
         if self.check(&TokenKind::Return) {
             return self.return_();
         }
@@ -793,6 +798,248 @@ impl Parser {
                 span,
             }),
         })
+    }
+
+    /// `select { (case CASE_OP "=>" BODY (",")?)* (default "=>" BODY)? }`
+    /// Case op is restricted to one of:
+    ///   - `IDENT "=" EXPR "." "recv" "(" ")"`
+    ///   - `"_" "=" EXPR "." "recv" "(" ")"`
+    ///   - `EXPR "." "send" "(" EXPR ")"`
+    fn select_(&mut self) -> ParseResult<Expr> {
+        let start = self.consume(&TokenKind::Select)?.start;
+
+        self.consume(&TokenKind::OpenBrace)?;
+
+        let mut arms: Vec<SelectArm> = Vec::new();
+        let mut default: Option<Rc<Expr>> = None;
+
+        loop {
+            if self.check(&TokenKind::CloseBrace) {
+                break;
+            }
+
+            if self.consume_b(&TokenKind::Default) {
+                self.consume(&TokenKind::Eq)?;
+                self.consume(&TokenKind::Gt)?;
+                let body = self.expr()?;
+                if default.is_some() {
+                    return Err(ParseError::ExpectedError {
+                        expected: "at most one 'default' arm in select".to_string(),
+                        but: "second 'default' arm".to_string(),
+                        span: body.span,
+                    }
+                    .into());
+                }
+                default = Some(Rc::new(body));
+            } else {
+                self.consume(&TokenKind::Case)?;
+                let arm = self.select_arm()?;
+                arms.push(arm);
+            }
+
+            if self.consume_b(&TokenKind::Comma) {
+                continue;
+            }
+            if self.check(&TokenKind::CloseBrace) {
+                break;
+            }
+            if self.check_semi() {
+                self.consume_semi()?;
+                continue;
+            }
+
+            return Err(ParseError::ExpectedError {
+                expected: "',' or '}'".to_string(),
+                but: self.first().kind.to_string(),
+                span: self.first().span,
+            }
+            .into());
+        }
+
+        let finish = self.consume(&TokenKind::CloseBrace)?.finish;
+        let span = self.new_span(start, finish);
+
+        if arms.is_empty() && default.is_none() {
+            return Err(ParseError::ExpectedError {
+                expected: "at least one 'case' or 'default' arm in select".to_string(),
+                but: "empty select".to_string(),
+                span,
+            }
+            .into());
+        }
+
+        Ok(Expr {
+            span,
+            kind: ExprKind::Select(Select {
+                arms,
+                default,
+                span,
+            }),
+        })
+    }
+
+    fn select_arm(&mut self) -> ParseResult<SelectArm> {
+        let arm_start = self.first().span.start;
+
+        // Peek at the first two tokens to decide between recv-binding form
+        // (`IDENT = ...` or `_ = ...`) and send form (`EXPR.send(...)`).
+        let is_recv_binding = {
+            let first = self.first().kind.clone();
+            let second_kind = self
+                .tokens
+                .get(1)
+                .map(|t| t.kind.clone())
+                .unwrap_or(TokenKind::Eoi);
+            matches!(first, TokenKind::Ident(_)) && matches!(second_kind, TokenKind::Eq)
+        };
+
+        if is_recv_binding {
+            let name_tok = self.first().clone();
+            let TokenKind::Ident(name_str) = name_tok.kind.clone() else {
+                unreachable!("checked above");
+            };
+            self.bump();
+            let binding = if name_str.as_str() == "_" {
+                SelectBinding::Wildcard
+            } else {
+                SelectBinding::Named(Ident::new(Symbol::from(name_str), name_tok.span))
+            };
+            self.consume(&TokenKind::Eq)?;
+            // RHS must be a method call: EXPR.recv().
+            let call = self.expr()?;
+            let (channel, _value) = Self::decompose_channel_method_call(call, "recv", 0)?;
+            self.consume(&TokenKind::Eq)?;
+            self.consume(&TokenKind::Gt)?;
+            let body = self.expr()?;
+            let span = self.new_span(arm_start, body.span.finish);
+            return Ok(SelectArm {
+                op: SelectOp::Recv {
+                    channel: Box::new(channel),
+                    binding,
+                },
+                body: Rc::new(body),
+                span,
+            });
+        }
+
+        // Send: EXPR.send(EXPR)
+        let call = self.expr()?;
+        let (channel, value) = Self::decompose_channel_method_call(call, "send", 1)?;
+        let value = value.ok_or_else(|| ParseError::ExpectedError {
+            expected: "send value expression".to_string(),
+            but: "missing argument".to_string(),
+            span: channel.span,
+        })?;
+        self.consume(&TokenKind::Eq)?;
+        self.consume(&TokenKind::Gt)?;
+        let body = self.expr()?;
+        let span = self.new_span(arm_start, body.span.finish);
+        Ok(SelectArm {
+            op: SelectOp::Send {
+                channel: Box::new(channel),
+                value: Box::new(value),
+            },
+            body: Rc::new(body),
+            span,
+        })
+    }
+
+    /// Given a parsed `EXPR.method(...)` call, return (channel, arg) where
+    /// channel is the receiver and arg is the first argument (for send) or
+    /// None (for recv). Errors if the expression is not a method call to
+    /// `expected_method`.
+    /// Channel method calls (`ch.method(args)`) can produce two AST shapes in
+    /// Kaede's parser, depending on whether `method` resolves as a type name in
+    /// `primary()`:
+    ///
+    /// 1. `FnCall { callee: Binary(ch, Access, method), args }` — classic.
+    /// 2. `Binary(ch, Access, FnCall { callee: method, args })` — happens when
+    ///    `primary()` consumed `method(...)` as a fn-call before postfix saw the
+    ///    surrounding `ch.`.
+    ///
+    /// Accept both and return `(channel, first_arg)`. `expected_args` is the
+    /// exact arity the method takes in a select case, so that a miscount is
+    /// rejected instead of silently dropping the extra arguments.
+    fn decompose_channel_method_call(
+        call: Expr,
+        expected_method: &str,
+        expected_args: usize,
+    ) -> ParseResult<(Expr, Option<Expr>)> {
+        let span = call.span;
+        let err = || ParseError::ExpectedError {
+            expected: format!("'channel.{}(...)' method call", expected_method),
+            but: "non-method-call expression".to_string(),
+            span,
+        };
+
+        let (channel, method_name, method_name_span, args_iter): (
+            Expr,
+            Symbol,
+            Span,
+            Box<dyn Iterator<Item = Arg>>,
+        ) = match call.kind {
+            ExprKind::FnCall(fn_call) => {
+                let ExprKind::Binary(callee_bin) = fn_call.callee.kind else {
+                    return Err(err().into());
+                };
+                if !matches!(callee_bin.kind, BinaryKind::Access) {
+                    return Err(err().into());
+                }
+                let ExprKind::Ident(method_ident) = callee_bin.rhs.kind else {
+                    return Err(err().into());
+                };
+                (
+                    *callee_bin.lhs,
+                    method_ident.symbol(),
+                    method_ident.span(),
+                    Box::new(fn_call.args.args.into_iter()),
+                )
+            }
+            ExprKind::Binary(bin) => {
+                if !matches!(bin.kind, BinaryKind::Access) {
+                    return Err(err().into());
+                }
+                let lhs = *bin.lhs;
+                let rhs = *bin.rhs;
+                let ExprKind::FnCall(inner) = rhs.kind else {
+                    return Err(err().into());
+                };
+                let method_name_expr = *inner.callee;
+                let (method_name, method_name_span) = match method_name_expr.kind {
+                    ExprKind::Ident(ident) => (ident.symbol(), ident.span()),
+                    _ => return Err(err().into()),
+                };
+                (
+                    lhs,
+                    method_name,
+                    method_name_span,
+                    Box::new(inner.args.args.into_iter()),
+                )
+            }
+            _ => return Err(err().into()),
+        };
+
+        if method_name.as_str() != expected_method {
+            return Err(ParseError::ExpectedError {
+                expected: format!("'{}'", expected_method),
+                but: format!("'{}'", method_name),
+                span: method_name_span,
+            }
+            .into());
+        }
+
+        let args: Vec<Arg> = args_iter.collect();
+        if args.len() != expected_args {
+            return Err(ParseError::ExpectedError {
+                expected: format!("{} argument(s) to '{}'", expected_args, expected_method),
+                but: format!("{}", args.len()),
+                span: method_name_span,
+            }
+            .into());
+        }
+
+        let first_arg = args.into_iter().next().map(|a| a.value);
+        Ok((channel, first_arg))
     }
 
     fn comma_separated_elements(&mut self, end: &TokenKind) -> ParseResult<Vec<Expr>> {

--- a/compiler/parse/tests/select_syntax.rs
+++ b/compiler/parse/tests/select_syntax.rs
@@ -1,0 +1,119 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use kaede_ast::expr::{ExprKind, SelectBinding, SelectOp};
+use kaede_parse::Parser;
+use kaede_span::file::FilePath;
+
+fn parse(source: &str) -> Result<kaede_ast::expr::Expr> {
+    let mut parser = Parser::new(source, FilePath::from(PathBuf::from("test.kd")));
+    parser.expr()
+}
+
+#[test]
+fn parses_single_recv_binding() -> Result<()> {
+    let expr = parse("select { case value = ch.recv() => 1 }")?;
+    let select = match expr.kind {
+        ExprKind::Select(s) => s,
+        other => panic!("expected select, got {other:?}"),
+    };
+    assert_eq!(select.arms.len(), 1);
+    assert!(select.default.is_none());
+    match &select.arms[0].op {
+        SelectOp::Recv { binding, channel } => {
+            match binding {
+                SelectBinding::Named(ident) => assert_eq!(ident.symbol().as_str(), "value"),
+                other => panic!("expected named binding, got {other:?}"),
+            }
+            assert!(matches!(channel.kind, ExprKind::Ident(_)));
+        }
+        other => panic!("expected recv op, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[test]
+fn parses_wildcard_recv() -> Result<()> {
+    let expr = parse("select { case _ = ch.recv() => 1 }")?;
+    let select = match expr.kind {
+        ExprKind::Select(s) => s,
+        other => panic!("expected select, got {other:?}"),
+    };
+    match &select.arms[0].op {
+        SelectOp::Recv { binding, .. } => {
+            assert!(matches!(binding, SelectBinding::Wildcard));
+        }
+        other => panic!("expected recv op, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[test]
+fn parses_send_arm() -> Result<()> {
+    let expr = parse("select { case ch.send(42) => 1 }")?;
+    let select = match expr.kind {
+        ExprKind::Select(s) => s,
+        other => panic!("expected select, got {other:?}"),
+    };
+    match &select.arms[0].op {
+        SelectOp::Send { channel, value } => {
+            assert!(matches!(channel.kind, ExprKind::Ident(_)));
+            assert!(matches!(value.kind, ExprKind::Int(_)));
+        }
+        other => panic!("expected send op, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[test]
+fn parses_default_arm() -> Result<()> {
+    let expr = parse("select { default => 7 }")?;
+    let select = match expr.kind {
+        ExprKind::Select(s) => s,
+        other => panic!("expected select, got {other:?}"),
+    };
+    assert_eq!(select.arms.len(), 0);
+    assert!(select.default.is_some());
+    Ok(())
+}
+
+#[test]
+fn parses_mixed_arms_with_default() -> Result<()> {
+    let expr = parse("select { case v = ch.recv() => 1, case ch.send(2) => 3, default => 4 }")?;
+    let select = match expr.kind {
+        ExprKind::Select(s) => s,
+        other => panic!("expected select, got {other:?}"),
+    };
+    assert_eq!(select.arms.len(), 2);
+    assert!(select.default.is_some());
+    assert!(matches!(select.arms[0].op, SelectOp::Recv { .. }));
+    assert!(matches!(select.arms[1].op, SelectOp::Send { .. }));
+    Ok(())
+}
+
+#[test]
+fn rejects_empty_select() {
+    let result = parse("select {}");
+    assert!(result.is_err(), "expected empty select to fail to parse");
+}
+
+#[test]
+fn rejects_non_method_case() {
+    let result = parse("select { case 1 + 2 => 0 }");
+    assert!(result.is_err(), "expected non-method case to fail to parse");
+}
+
+#[test]
+fn rejects_send_with_extra_args() {
+    let result = parse("select { case ch.send(1, 2) => 0 }");
+    assert!(
+        result.is_err(),
+        "expected extra send argument to be rejected"
+    );
+}
+
+#[test]
+fn rejects_recv_with_args() {
+    let result = parse("select { case v = ch.recv(1) => 0 }");
+    assert!(result.is_err(), "expected recv argument to be rejected");
+}

--- a/compiler/semantic/src/error.rs
+++ b/compiler/semantic/src/error.rs
@@ -211,6 +211,9 @@ pub enum SemanticError {
     #[error("{}:{}:{} channel receive requires `std.sync.Channel<T>`, got `{}`", span.file, span.start.line, span.start.column, actual)]
     ChannelRecvRequiresChannel { actual: String, span: Span },
 
+    #[error("{}:{}:{} select case requires `std.sync.Channel<T>`, got `{}`", span.file, span.start.line, span.start.column, actual)]
+    SelectCaseRequiresChannel { actual: String, span: Span },
+
     #[error("{}:{}:{} `format` template must be a string literal", span.file, span.start.line, span.start.column)]
     FormatTemplateMustBeStringLiteral { span: Span },
 

--- a/compiler/semantic/src/expr.rs
+++ b/compiler/semantic/src/expr.rs
@@ -209,6 +209,7 @@ impl SemanticAnalyzer {
             ExprKind::Loop(node) => self.analyze_loop(node),
             ExprKind::While(node) => self.analyze_while(node),
             ExprKind::Match(node) => self.analyze_match(node),
+            ExprKind::Select(node) => self.analyze_select(node),
             ExprKind::StructLiteral(node) => self.analyze_struct_literal(node),
             ExprKind::TupleLiteral(node) => self.analyze_tuple_literal(node),
             ExprKind::Closure(node) => self.analyze_closure(node, None),
@@ -356,6 +357,160 @@ impl SemanticAnalyzer {
             &[],
             node.span,
         )
+    }
+
+    /// Channel<T> element type T, extracted from a Channel UDT's generic args.
+    fn channel_elem_ty(udt: &ir_type::UserDefinedType) -> Option<Rc<ir_type::Ty>> {
+        udt.generic_instance
+            .as_ref()
+            .and_then(|gi| gi.args.first().cloned())
+    }
+
+    fn analyze_select(&mut self, node: &ast::expr::Select) -> anyhow::Result<ir::expr::Expr> {
+        let mut ir_arms: Vec<ir::expr::SelectArm> = Vec::with_capacity(node.arms.len());
+
+        for arm in &node.arms {
+            let arm_ir = match &arm.op {
+                ast::expr::SelectOp::Send { channel, value } => {
+                    let chan_ir = self.analyze_expr(channel)?;
+                    let Some(udt) = self.channel_udt_from_ty(&chan_ir.ty) else {
+                        return Err(SemanticError::SelectCaseRequiresChannel {
+                            actual: chan_ir.ty.kind.to_string(),
+                            span: channel.span,
+                        }
+                        .into());
+                    };
+                    let elem_ty = Self::channel_elem_ty(&udt).ok_or_else(|| {
+                        SemanticError::SelectCaseRequiresChannel {
+                            actual: chan_ir.ty.kind.to_string(),
+                            span: channel.span,
+                        }
+                    })?;
+                    let value_ir = self.analyze_expr_with_expected_type(value, elem_ty.clone())?;
+
+                    self.push_scope(SymbolTable::new());
+                    let body = self.analyze_expr(arm.body.as_ref())?;
+                    self.pop_scope();
+
+                    ir::expr::SelectArm {
+                        op: ir::expr::SelectOp::Send,
+                        channel: Box::new(chan_ir),
+                        elem_ty,
+                        value: Some(Box::new(value_ir)),
+                        binding: None,
+                        option_ty: None,
+                        option_enum_info: None,
+                        body: Box::new(body),
+                        span: arm.span,
+                    }
+                }
+                ast::expr::SelectOp::Recv { channel, binding } => {
+                    let chan_ir = self.analyze_expr(channel)?;
+                    let Some(udt) = self.channel_udt_from_ty(&chan_ir.ty) else {
+                        return Err(SemanticError::SelectCaseRequiresChannel {
+                            actual: chan_ir.ty.kind.to_string(),
+                            span: channel.span,
+                        }
+                        .into());
+                    };
+                    let elem_ty = Self::channel_elem_ty(&udt).ok_or_else(|| {
+                        SemanticError::SelectCaseRequiresChannel {
+                            actual: chan_ir.ty.kind.to_string(),
+                            span: channel.span,
+                        }
+                    })?;
+
+                    // Resolve `Option<T>` by asking the channel UDT for its
+                    // `recv` method: its return type is `Option<T>` already.
+                    let dummy_call = self.build_channel_method_call_expr(
+                        chan_ir.clone(),
+                        &udt,
+                        Symbol::from("recv".to_owned()),
+                        &[],
+                        arm.span,
+                    )?;
+                    let option_ty = dummy_call.ty.clone();
+
+                    // Resolve the Option enum (may be a Placeholder UDT at
+                    // this point) so codegen does not have to chase symbol
+                    // tables to find the variants.
+                    let option_enum_info = {
+                        let inner = match option_ty.kind.as_ref() {
+                            ir_type::TyKind::Reference(rty) => rty.refee_ty.clone(),
+                            _ => option_ty.clone(),
+                        };
+                        let opt_udt = match inner.kind.as_ref() {
+                            ir_type::TyKind::UserDefined(u) => Some(u.clone()),
+                            _ => None,
+                        };
+                        opt_udt.and_then(|u| match &u.kind {
+                            ir_type::UserDefinedTypeKind::Enum(e) => Some(e.clone()),
+                            ir_type::UserDefinedTypeKind::Placeholder(qsym) => self
+                                .lookup_qualified_symbol(qsym.clone())
+                                .and_then(|v| match &v.borrow().kind {
+                                    SymbolTableValueKind::Enum(e) => Some(e.clone()),
+                                    _ => None,
+                                }),
+                            _ => None,
+                        })
+                    };
+
+                    self.push_scope(SymbolTable::new());
+                    let bound_symbol = match binding {
+                        ast::expr::SelectBinding::Named(ident) => {
+                            let sym = ident.symbol();
+                            self.insert_symbol_to_current_scope(
+                                sym,
+                                SymbolTableValue::new(
+                                    SymbolTableValueKind::Variable(VariableInfo::new(
+                                        option_ty.clone(),
+                                    )),
+                                    self.current_module_path().clone(),
+                                ),
+                                ident.span(),
+                            )?;
+                            Some(sym)
+                        }
+                        ast::expr::SelectBinding::Wildcard => None,
+                    };
+                    let body = self.analyze_expr(arm.body.as_ref())?;
+                    self.pop_scope();
+
+                    ir::expr::SelectArm {
+                        op: ir::expr::SelectOp::Recv,
+                        channel: Box::new(chan_ir),
+                        elem_ty,
+                        value: None,
+                        binding: bound_symbol,
+                        option_ty: Some(option_ty),
+                        option_enum_info,
+                        body: Box::new(body),
+                        span: arm.span,
+                    }
+                }
+            };
+            ir_arms.push(arm_ir);
+        }
+
+        let default_ir = match &node.default {
+            Some(body) => {
+                self.push_scope(SymbolTable::new());
+                let ir = self.analyze_expr(body.as_ref())?;
+                self.pop_scope();
+                Some(Box::new(ir))
+            }
+            None => None,
+        };
+
+        Ok(ir::expr::Expr {
+            kind: ir::expr::ExprKind::Select(ir::expr::Select {
+                arms: ir_arms,
+                default: default_ir,
+                span: node.span,
+            }),
+            ty: Rc::new(ir_type::Ty::new_unit()),
+            span: node.span,
+        })
     }
 
     fn analyze_spawn(&mut self, node: &ast::expr::Spawn) -> anyhow::Result<ir::expr::Expr> {

--- a/compiler/semantic/src/subst.rs
+++ b/compiler/semantic/src/subst.rs
@@ -264,6 +264,22 @@ impl<'a> GenericSubstituter<'a> {
                 }
                 call.method.return_ty = self.apply_ty(&call.method.return_ty);
             }
+            ir::expr::ExprKind::Select(select) => {
+                for arm in &mut select.arms {
+                    self.apply_expr(&mut arm.channel);
+                    arm.elem_ty = self.apply_ty(&arm.elem_ty);
+                    if let Some(opt_ty) = &mut arm.option_ty {
+                        *opt_ty = self.apply_ty(opt_ty);
+                    }
+                    if let Some(value) = &mut arm.value {
+                        self.apply_expr(value);
+                    }
+                    self.apply_expr(&mut arm.body);
+                }
+                if let Some(default) = &mut select.default {
+                    self.apply_expr(default);
+                }
+            }
             ir::expr::ExprKind::Int(_)
             | ir::expr::ExprKind::Float(_)
             | ir::expr::ExprKind::StringLiteral(_)

--- a/compiler/type_infer/src/lib.rs
+++ b/compiler/type_infer/src/lib.rs
@@ -541,6 +541,28 @@ impl TypeInferrer {
                 }
                 Ok(expr_ty.clone())
             }
+            Select(select) => {
+                for arm in &select.arms {
+                    self.infer_expr(&arm.channel)?;
+                    if let Some(v) = &arm.value {
+                        self.infer_expr(v)?;
+                    }
+                    self.with_new_scope(|this| {
+                        if let (Some(name), Some(opt_ty)) = (arm.binding, arm.option_ty.as_ref()) {
+                            this.register_variable(name, opt_ty.clone());
+                        }
+                        this.infer_expr(&arm.body)?;
+                        Ok(())
+                    })?;
+                }
+                if let Some(d) = &select.default {
+                    self.with_new_scope(|this| {
+                        this.infer_expr(d)?;
+                        Ok(())
+                    })?;
+                }
+                Ok(expr_ty.clone())
+            }
             Closure(closure) => {
                 for cap in &closure.captures {
                     self.infer_expr(cap)?;
@@ -2101,6 +2123,22 @@ impl TypeInferrer {
                 self.apply_expr(&mut call.receiver)?;
                 for arg in &mut call.args.0 {
                     self.apply_expr(arg)?;
+                }
+            }
+            Select(select) => {
+                for arm in &mut select.arms {
+                    self.apply_expr(&mut arm.channel)?;
+                    arm.elem_ty = self.context.apply(&arm.elem_ty);
+                    if let Some(opt_ty) = &mut arm.option_ty {
+                        *opt_ty = self.context.apply(opt_ty);
+                    }
+                    if let Some(value) = &mut arm.value {
+                        self.apply_expr(value)?;
+                    }
+                    self.apply_expr(&mut arm.body)?;
+                }
+                if let Some(default) = &mut select.default {
+                    self.apply_expr(default)?;
                 }
             }
         }

--- a/library/runtime/include/kaede/channel.h
+++ b/library/runtime/include/kaede/channel.h
@@ -16,7 +16,30 @@ enum KaedeChannelRecvResult {
     KAEDE_CHANNEL_RECV_CLOSED = 2,
 };
 
+enum KaedeSelectOp {
+    KAEDE_SELECT_OP_SEND = 0,
+    KAEDE_SELECT_OP_RECV = 1,
+};
+
+enum KaedeSelectStatus {
+    KAEDE_SELECT_STATUS_VALUE = 0,   // recv: value received
+    KAEDE_SELECT_STATUS_CLOSED = 1,  // recv: channel was closed
+    KAEDE_SELECT_STATUS_SENT = 2,    // send: value sent
+};
+
+// Returned by kaede_select when it did not choose any case. See kaede_select.
+#define KAEDE_SELECT_DEFAULT_INDEX (-1)
+
 struct KaedeChannel;
+
+// Layout must match the LLVM struct emitted by codegen for select cases.
+struct KaedeSelectCase {
+    struct KaedeChannel *channel;
+    uint32_t op;        // KaedeSelectOp
+    uint32_t _pad;      // explicit padding to keep ABI deterministic
+    void *value_slot;   // send: pointer to value; recv: pointer to out slot
+    int32_t status;     // out: meaningful for the chosen case only
+};
 
 struct KaedeChannel *kaede_channel_new(size_t elem_size, size_t capacity);
 int32_t kaede_channel_send(struct KaedeChannel *channel, void *value);
@@ -25,5 +48,23 @@ int32_t kaede_channel_recv(struct KaedeChannel *channel, void *out);
 int32_t kaede_channel_try_recv(struct KaedeChannel *channel, void *out);
 void kaede_channel_close(struct KaedeChannel *channel);
 bool kaede_channel_is_closed(struct KaedeChannel *channel);
+
+// Wait until one of `cases` can proceed, and report which one did.
+//
+// On success the return value is an index into `cases`. That case's `status`
+// field says what happened to it — a value arrived, the channel was closed, or
+// the send went through. The other cases are left untouched, and nothing is
+// consumed from their channels.
+//
+// The return value is KAEDE_SELECT_DEFAULT_INDEX when no case was chosen.
+// That covers two situations:
+//
+//   - `has_default` was set and no case was immediately ready, so the caller
+//     should take its `default` arm.
+//   - The runtime could not wait at all: shutdown is already in progress, or a
+//     waiter allocation failed. This happens whether or not `has_default` is
+//     set, so a caller with no `default` arm must still handle it — as "no case
+//     ran", not as an impossible outcome.
+int32_t kaede_select(struct KaedeSelectCase *cases, size_t n, bool has_default);
 
 #endif // KAEDE_CHANNEL_H

--- a/library/runtime/include/kaede/channel.h
+++ b/library/runtime/include/kaede/channel.h
@@ -61,8 +61,8 @@ bool kaede_channel_is_closed(struct KaedeChannel *channel);
 //
 //   - `has_default` was set and no case was immediately ready, so the caller
 //     should take its `default` arm.
-//   - The runtime could not wait at all: shutdown is already in progress, or a
-//     waiter allocation failed. This happens whether or not `has_default` is
+//   - The runtime could not wait at all: shutdown is already in progress, or
+//     there is no current task. This happens whether or not `has_default` is
 //     set, so a caller with no `default` arm must still handle it — as "no case
 //     ran", not as an impossible outcome.
 int32_t kaede_select(struct KaedeSelectCase *cases, size_t n, bool has_default);

--- a/library/runtime/include/kaede/channel.h
+++ b/library/runtime/include/kaede/channel.h
@@ -32,7 +32,10 @@ enum KaedeSelectStatus {
 
 struct KaedeChannel;
 
-// Layout must match the LLVM struct emitted by codegen for select cases.
+// Layout must match the LLVM struct emitted by
+// CodeGenerator::select_case_struct_type in compiler/codegen/src/expr.rs.
+// Codegen addresses these by field index, which is why the padding is an
+// explicit member on both sides rather than left to the C compiler.
 struct KaedeSelectCase {
     struct KaedeChannel *channel;
     uint32_t op;        // KaedeSelectOp
@@ -40,6 +43,14 @@ struct KaedeSelectCase {
     void *value_slot;   // send: pointer to value; recv: pointer to out slot
     int32_t status;     // out: meaningful for the chosen case only
 };
+
+// Codegen hard-codes these offsets; a reorder on either side would otherwise
+// compile clean and corrupt memory at run time.
+_Static_assert(offsetof(struct KaedeSelectCase, channel) == 0, "case layout");
+_Static_assert(offsetof(struct KaedeSelectCase, op) == 8, "case layout");
+_Static_assert(offsetof(struct KaedeSelectCase, value_slot) == 16, "case layout");
+_Static_assert(offsetof(struct KaedeSelectCase, status) == 24, "case layout");
+_Static_assert(sizeof(struct KaedeSelectCase) == 32, "case layout");
 
 struct KaedeChannel *kaede_channel_new(size_t elem_size, size_t capacity);
 int32_t kaede_channel_send(struct KaedeChannel *channel, void *value);

--- a/library/runtime/include/kaede/task.h
+++ b/library/runtime/include/kaede/task.h
@@ -51,20 +51,13 @@ struct TaskIoWaitState {
     uint32_t events;
     bool wake_success;
 };
-enum KaedeTaskWaitKind {
-    KAEDE_TASK_WAIT_NONE = 0,
-    KAEDE_TASK_WAIT_CHANNEL_SEND = 1u << 0,
-    KAEDE_TASK_WAIT_CHANNEL_RECV = 1u << 1,
-};
-
 struct Task;
 
+// Set by the waker (channel runtime) before a parked task is re-enqueued.
+// `true` means the wait completed normally and the waiter (channel-side) has
+// populated its result fields; `false` signals shutdown or a closed channel.
 struct TaskChannelWaitState {
-    void *obj;
-    uint32_t kind;
-    void *value_slot;
     bool wake_success;
-    struct Task *next;
 };
 struct Task {
     struct Context context;

--- a/library/runtime/include/kaede/worker.h
+++ b/library/runtime/include/kaede/worker.h
@@ -39,9 +39,15 @@ bool worker_shutdown_requested_locked(void);
 struct Task *worker_current_task(void);
 // Park the current task until something wakes it. Call with the scheduler lock
 // held. Unlike every other `_locked` function here, this always returns without
-// the lock: on success it is handed to the scheduler across the context switch,
-// and on failure it is released before returning. Returns false when the task
-// could not park at all, which today means shutdown is already in progress.
+// the lock: on a successful park it is handed to the scheduler across the
+// context switch, and otherwise it is released before returning.
+//
+// The return value is the wake outcome, not whether parking happened. It is
+// false both when the task could not park at all (no current task, or shutdown
+// already requested) and when it parked and was then woken with
+// `success = false`, which is what `kaede_channel_close` does to regular
+// waiters. Callers that need to tell those apart must inspect their own
+// waiter.
 bool worker_park_current_on_channel_locked(void);
 bool worker_wake_task_locked(struct Task *task, bool success);
 void worker_yield(void);

--- a/library/runtime/include/kaede/worker.h
+++ b/library/runtime/include/kaede/worker.h
@@ -30,6 +30,9 @@ void *worker_loop(void *arg);
 bool worker_spawn(TaskFn fn, void *arg, size_t arg_size, bool is_main);
 KaedeIoWaitResult worker_park_current_on_io(int fd, uint32_t events);
 void worker_forget_fd(int fd);
+// Print `message` to stderr and abort. For scheduler and channel states that
+// cannot be recovered from, where continuing would corrupt shared structures.
+_Noreturn void worker_fail(const char *message);
 void worker_scheduler_lock(void);
 void worker_scheduler_unlock(void);
 bool worker_shutdown_requested_locked(void);

--- a/library/runtime/include/kaede/worker.h
+++ b/library/runtime/include/kaede/worker.h
@@ -34,8 +34,12 @@ void worker_scheduler_lock(void);
 void worker_scheduler_unlock(void);
 bool worker_shutdown_requested_locked(void);
 struct Task *worker_current_task(void);
-bool worker_park_current_on_channel_locked(void *obj, uint32_t wait_kind,
-                                           void *value_slot);
+// Park the current task until something wakes it. Call with the scheduler lock
+// held. Unlike every other `_locked` function here, this always returns without
+// the lock: on success it is handed to the scheduler across the context switch,
+// and on failure it is released before returning. Returns false when the task
+// could not park at all, which today means shutdown is already in progress.
+bool worker_park_current_on_channel_locked(void);
 bool worker_wake_task_locked(struct Task *task, bool success);
 void worker_yield(void);
 void worker_reset_main_state(void);

--- a/library/runtime/src/channel.c
+++ b/library/runtime/src/channel.c
@@ -76,6 +76,21 @@ static struct ChannelWaiter *wait_queue_pop_head(struct ChannelWaitQueue *q) {
     return w;
 }
 
+static void wait_queue_unlink(struct ChannelWaitQueue *q, struct ChannelWaiter *w) {
+    if (w->prev) {
+        w->prev->next = w->next;
+    } else if (q->head == w) {
+        q->head = w->next;
+    }
+    if (w->next) {
+        w->next->prev = w->prev;
+    } else if (q->tail == w) {
+        q->tail = w->prev;
+    }
+    w->prev = NULL;
+    w->next = NULL;
+    w->channel = NULL;
+}
 
 static uint8_t *buffer_slot(struct KaedeChannel *channel, size_t index) {
     if (!channel->buffer || channel->elem_size == 0) {
@@ -266,6 +281,13 @@ int32_t kaede_channel_send(struct KaedeChannel *channel, void *value) {
     wait_queue_push_tail(&channel->send_waiters, &waiter, channel);
 
     if (!worker_park_current_on_channel_locked()) {
+        // Parking failed, so nothing will ever wake this waiter. Take it back
+        // out of the queue before the stack frame holding it goes away.
+        worker_scheduler_lock();
+        if (waiter.channel) {
+            wait_queue_unlink(&channel->send_waiters, &waiter);
+        }
+        worker_scheduler_unlock();
         return KAEDE_CHANNEL_SEND_CLOSED;
     }
 
@@ -308,6 +330,11 @@ int32_t kaede_channel_recv(struct KaedeChannel *channel, void *out) {
     wait_queue_push_tail(&channel->recv_waiters, &waiter, channel);
 
     if (!worker_park_current_on_channel_locked()) {
+        worker_scheduler_lock();
+        if (waiter.channel) {
+            wait_queue_unlink(&channel->recv_waiters, &waiter);
+        }
+        worker_scheduler_unlock();
         return KAEDE_CHANNEL_RECV_CLOSED;
     }
 

--- a/library/runtime/src/channel.c
+++ b/library/runtime/src/channel.c
@@ -6,26 +6,31 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 // -----------------------------------------------------------------------------
-// Channel waiters
-//
-// A parked send/recv is represented by a waiter that the channel owns, linked
-// into one of the channel's queues. The waiter lives on the parked task's own
-// stack frame, so it stays valid until that task resumes.
-//
-// The list is doubly linked and each waiter keeps a back-pointer to the queue's
-// channel, so a waiter can be removed without walking the list.
+// Generic channel waiter (regular send/recv and select cases share one queue).
 // -----------------------------------------------------------------------------
 
+enum ChannelWaiterKind {
+    CW_REGULAR = 0,
+    CW_SELECT = 1,
+};
+
+struct KaedeSelectState;
 struct KaedeChannel;
 
 struct ChannelWaiter {
+    int kind;                      // ChannelWaiterKind
+    int op;                        // KaedeSelectOp (SEND/RECV)
     struct ChannelWaiter *prev;
     struct ChannelWaiter *next;
-    struct KaedeChannel *channel;  // queue this waiter is on, NULL once removed
-    struct Task *task;             // task to wake
+    struct KaedeChannel *channel;  // queue this waiter is parked on (or NULL once removed)
+    struct Task *task;             // task to wake; for select, == state->task
     void *value_slot;              // send: source; recv: destination
+    int32_t recv_status;           // for regular recv: VALUE/CLOSED
+    struct KaedeSelectState *state;  // NULL for regular waiters
+    uint32_t case_index;             // for select waiters
 };
 
 struct ChannelWaitQueue {
@@ -43,6 +48,17 @@ struct KaedeChannel {
     size_t tail;
     struct ChannelWaitQueue send_waiters;
     struct ChannelWaitQueue recv_waiters;
+};
+
+// Shared by every waiter registered for one `select` evaluation. All fields are
+// guarded by the scheduler lock, which is what lets `done` be a plain bool: the
+// read in pop_live_waiter_locked and the write in complete_waiter_locked cannot
+// interleave.
+struct KaedeSelectState {
+    bool done;
+    int32_t chosen_index;
+    int32_t chosen_status;
+    struct Task *task;
 };
 
 static void wait_queue_push_tail(struct ChannelWaitQueue *q,
@@ -76,7 +92,8 @@ static struct ChannelWaiter *wait_queue_pop_head(struct ChannelWaitQueue *q) {
     return w;
 }
 
-static void wait_queue_unlink(struct ChannelWaitQueue *q, struct ChannelWaiter *w) {
+static void wait_queue_unlink(struct ChannelWaitQueue *q,
+                              struct ChannelWaiter *w) {
     if (w->prev) {
         w->prev->next = w->next;
     } else if (q->head == w) {
@@ -91,6 +108,10 @@ static void wait_queue_unlink(struct ChannelWaitQueue *q, struct ChannelWaiter *
     w->next = NULL;
     w->channel = NULL;
 }
+
+// -----------------------------------------------------------------------------
+// Buffer helpers
+// -----------------------------------------------------------------------------
 
 static uint8_t *buffer_slot(struct KaedeChannel *channel, size_t index) {
     if (!channel->buffer || channel->elem_size == 0) {
@@ -118,9 +139,42 @@ static void buffer_pop(struct KaedeChannel *channel, void *out) {
     channel->len--;
 }
 
-// Wake a waiter that completed successfully. The caller must have already done
-// any value transfer the woken task expects to find in its slot.
-static void wake_waiter_locked(struct ChannelWaiter *waiter) {
+// -----------------------------------------------------------------------------
+// Wake helpers: pop one waiter and complete it. For select waiters that have
+// already been claimed by another case, skip and continue popping.
+// -----------------------------------------------------------------------------
+
+// Pop the next waiter still eligible for waking (regular, or select whose
+// shared state isn't `done`). Returns NULL if the queue is exhausted.
+static struct ChannelWaiter *pop_live_waiter_locked(
+    struct ChannelWaitQueue *queue) {
+    for (;;) {
+        struct ChannelWaiter *w = wait_queue_pop_head(queue);
+        if (!w) {
+            return NULL;
+        }
+        if (w->kind == CW_SELECT && w->state && w->state->done) {
+            // Already fired via another case; drop and continue.
+            continue;
+        }
+        return w;
+    }
+}
+
+// Mark `waiter` as completed with the given status and wake its task. For
+// select waiters this also records the chosen-case bookkeeping; for regular
+// recv waiters it stores the status onto the waiter for the parked recv() to
+// observe after wakeup. Callers are responsible for any value transfer that
+// must happen before the task can read its slot.
+static void complete_waiter_locked(struct ChannelWaiter *waiter,
+                                   int32_t status) {
+    if (waiter->kind == CW_SELECT) {
+        waiter->state->done = true;
+        waiter->state->chosen_index = (int32_t)waiter->case_index;
+        waiter->state->chosen_status = status;
+    } else {
+        waiter->recv_status = status;
+    }
     if (!worker_wake_task_locked(waiter->task, true)) {
         abort();
     }
@@ -128,25 +182,25 @@ static void wake_waiter_locked(struct ChannelWaiter *waiter) {
 
 static bool wake_waiting_receiver_locked(struct KaedeChannel *channel,
                                          const void *value) {
-    struct ChannelWaiter *receiver = wait_queue_pop_head(&channel->recv_waiters);
+    struct ChannelWaiter *receiver =
+        pop_live_waiter_locked(&channel->recv_waiters);
     if (!receiver) {
         return false;
     }
-
     copy_value(receiver->value_slot, value, channel->elem_size);
-    wake_waiter_locked(receiver);
+    complete_waiter_locked(receiver, KAEDE_SELECT_STATUS_VALUE);
     return true;
 }
 
 static bool wake_waiting_sender_direct_locked(struct KaedeChannel *channel,
                                               void *out) {
-    struct ChannelWaiter *sender = wait_queue_pop_head(&channel->send_waiters);
+    struct ChannelWaiter *sender =
+        pop_live_waiter_locked(&channel->send_waiters);
     if (!sender) {
         return false;
     }
-
     copy_value(out, sender->value_slot, channel->elem_size);
-    wake_waiter_locked(sender);
+    complete_waiter_locked(sender, KAEDE_SELECT_STATUS_SENT);
     return true;
 }
 
@@ -154,27 +208,35 @@ static bool buffer_one_waiting_sender_locked(struct KaedeChannel *channel) {
     if (channel->capacity == 0 || channel->len >= channel->capacity) {
         return false;
     }
-
-    struct ChannelWaiter *sender = wait_queue_pop_head(&channel->send_waiters);
+    struct ChannelWaiter *sender =
+        pop_live_waiter_locked(&channel->send_waiters);
     if (!sender) {
         return false;
     }
-
     buffer_push(channel, sender->value_slot);
-    wake_waiter_locked(sender);
+    complete_waiter_locked(sender, KAEDE_SELECT_STATUS_SENT);
     return true;
 }
 
-// Drain `queue`, waking every waiter with `wake_success = false` so the parked
-// send/recv reports the channel as closed.
+// Drain `queue`, completing select waiters with CLOSED and waking regular
+// waiters with `wake_success=false`. Used by kaede_channel_close on both the
+// send and recv queues.
 static void wake_all_as_closed_locked(struct ChannelWaitQueue *queue) {
     struct ChannelWaiter *w;
     while ((w = wait_queue_pop_head(queue)) != NULL) {
-        if (!worker_wake_task_locked(w->task, false)) {
+        if (w->kind == CW_SELECT) {
+            if (w->state && !w->state->done) {
+                complete_waiter_locked(w, KAEDE_SELECT_STATUS_CLOSED);
+            }
+        } else if (!worker_wake_task_locked(w->task, false)) {
             abort();
         }
     }
 }
+
+// -----------------------------------------------------------------------------
+// Non-blocking attempt primitives (used by both regular ops and select Phase A)
+// -----------------------------------------------------------------------------
 
 // Internal sentinel used only by try_send_locked, distinct from the public
 // KaedeChannelSendResult values. Callers translate it to a parking decision.
@@ -216,6 +278,10 @@ static int32_t try_recv_locked(struct KaedeChannel *channel, void *out) {
 
     return KAEDE_CHANNEL_RECV_EMPTY;
 }
+
+// -----------------------------------------------------------------------------
+// Channel allocation and core API
+// -----------------------------------------------------------------------------
 
 struct KaedeChannel *kaede_channel_new(size_t elem_size, size_t capacity) {
     struct KaedeChannel *channel = GC_malloc(sizeof(struct KaedeChannel));
@@ -276,13 +342,14 @@ int32_t kaede_channel_send(struct KaedeChannel *channel, void *value) {
     }
 
     struct ChannelWaiter waiter = {0};
+    waiter.kind = CW_REGULAR;
+    waiter.op = KAEDE_SELECT_OP_SEND;
     waiter.task = task;
     waiter.value_slot = value;
     wait_queue_push_tail(&channel->send_waiters, &waiter, channel);
 
     if (!worker_park_current_on_channel_locked()) {
-        // Parking failed, so nothing will ever wake this waiter. Take it back
-        // out of the queue before the stack frame holding it goes away.
+        // park failed (shutdown): waiter may still be linked
         worker_scheduler_lock();
         if (waiter.channel) {
             wait_queue_unlink(&channel->send_waiters, &waiter);
@@ -325,8 +392,11 @@ int32_t kaede_channel_recv(struct KaedeChannel *channel, void *out) {
     }
 
     struct ChannelWaiter waiter = {0};
+    waiter.kind = CW_REGULAR;
+    waiter.op = KAEDE_SELECT_OP_RECV;
     waiter.task = task;
     waiter.value_slot = out;
+    waiter.recv_status = KAEDE_CHANNEL_RECV_CLOSED;
     wait_queue_push_tail(&channel->recv_waiters, &waiter, channel);
 
     if (!worker_park_current_on_channel_locked()) {
@@ -365,10 +435,8 @@ void kaede_channel_close(struct KaedeChannel *channel) {
     }
 
     channel->closed = true;
-
     wake_all_as_closed_locked(&channel->send_waiters);
     wake_all_as_closed_locked(&channel->recv_waiters);
-
     worker_scheduler_unlock();
 }
 
@@ -382,6 +450,222 @@ bool kaede_channel_is_closed(struct KaedeChannel *channel) {
     worker_scheduler_unlock();
     return closed;
 }
+
+// -----------------------------------------------------------------------------
+// select implementation
+// -----------------------------------------------------------------------------
+
+// Try to satisfy a single case immediately (must hold scheduler lock).
+// Returns true if the case fired; updates the case's `status` field on success.
+static bool try_select_case_locked(struct KaedeSelectCase *cs) {
+    struct KaedeChannel *channel = cs->channel;
+    if (!channel) {
+        return false;
+    }
+
+    if (cs->op == KAEDE_SELECT_OP_SEND) {
+        int32_t r = try_send_locked(channel, cs->value_slot);
+        if (r == KAEDE_CHANNEL_SEND_OK) {
+            cs->status = KAEDE_SELECT_STATUS_SENT;
+            return true;
+        }
+        // Closed sends in select fire with CLOSED status (so the caller can
+        // observe and panic if appropriate, mirroring Go where send on closed
+        // panics even in select).
+        if (r == KAEDE_CHANNEL_SEND_CLOSED) {
+            cs->status = KAEDE_SELECT_STATUS_CLOSED;
+            return true;
+        }
+        return false;
+    }
+
+    if (cs->op == KAEDE_SELECT_OP_RECV) {
+        int32_t r = try_recv_locked(channel, cs->value_slot);
+        if (r == KAEDE_CHANNEL_RECV_VALUE) {
+            cs->status = KAEDE_SELECT_STATUS_VALUE;
+            return true;
+        }
+        if (r == KAEDE_CHANNEL_RECV_CLOSED) {
+            cs->status = KAEDE_SELECT_STATUS_CLOSED;
+            return true;
+        }
+        return false;
+    }
+
+    return false;
+}
+
+// Fisher-Yates shuffle on an index array using a per-thread xorshift PRNG.
+// kaede_select runs concurrently on every worker; using libc rand() would
+// race on its internal state. The seed is lazily initialized from the task
+// pointer and the wall clock so distinct workers diverge quickly.
+static _Thread_local uint64_t select_rng_state = 0;
+
+static uint64_t select_rng_next(void) {
+    if (select_rng_state == 0) {
+        select_rng_state = (uint64_t)(uintptr_t)worker_current_task()
+                           ^ ((uint64_t)time(NULL) * 0x9E3779B97F4A7C15ULL);
+        if (select_rng_state == 0) {
+            select_rng_state = 0x9E3779B97F4A7C15ULL;
+        }
+    }
+    uint64_t x = select_rng_state;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    select_rng_state = x;
+    return x;
+}
+
+// Remove every select waiter still linked into a channel's queue. Used both
+// on park failure (none have fired) and after wakeup (one fired and was
+// already unlinked by the waker; we drop the rest).
+static void scrub_select_waiters(struct ChannelWaiter *waiters, size_t n) {
+    for (size_t i = 0; i < n; ++i) {
+        struct ChannelWaiter *w = &waiters[i];
+        if (!w->channel) {
+            continue;
+        }
+        struct ChannelWaitQueue *q = (w->op == KAEDE_SELECT_OP_SEND)
+                                         ? &w->channel->send_waiters
+                                         : &w->channel->recv_waiters;
+        wait_queue_unlink(q, w);
+    }
+}
+
+static void shuffle_indices(uint32_t *idx, size_t n) {
+    for (size_t i = n; i > 1; --i) {
+        size_t j = (size_t)(select_rng_next() % (uint64_t)i);
+        uint32_t tmp = idx[i - 1];
+        idx[i - 1] = idx[j];
+        idx[j] = tmp;
+    }
+}
+
+int32_t kaede_select(struct KaedeSelectCase *cases, size_t n, bool has_default) {
+    if (n == 0) {
+        // Empty select: no cases. With default, return default; without it,
+        // there is nothing to wait on — this is treated like Go's `select {}`
+        // (blocks forever). Approximate by parking, which the parser should
+        // make unreachable.
+        if (has_default) {
+            return KAEDE_SELECT_DEFAULT_INDEX;
+        }
+        worker_scheduler_lock();
+        (void)worker_park_current_on_channel_locked();
+        return KAEDE_SELECT_DEFAULT_INDEX;
+    }
+
+    // Stack-allocated shuffled index order for fairness.
+    uint32_t order_buf[32];
+    uint32_t *order = order_buf;
+    uint32_t *order_heap = NULL;
+    if (n > sizeof(order_buf) / sizeof(order_buf[0])) {
+        order_heap = malloc(n * sizeof(uint32_t));
+        if (!order_heap) {
+            return KAEDE_SELECT_DEFAULT_INDEX;
+        }
+        order = order_heap;
+    }
+    for (size_t i = 0; i < n; ++i) {
+        order[i] = (uint32_t)i;
+    }
+    shuffle_indices(order, n);
+
+    worker_scheduler_lock();
+
+    // Phase A: try every case once in randomized order.
+    for (size_t i = 0; i < n; ++i) {
+        struct KaedeSelectCase *cs = &cases[order[i]];
+        if (try_select_case_locked(cs)) {
+            int32_t chosen = (int32_t)order[i];
+            worker_scheduler_unlock();
+            free(order_heap);
+            return chosen;
+        }
+    }
+
+    if (has_default) {
+        worker_scheduler_unlock();
+        free(order_heap);
+        return KAEDE_SELECT_DEFAULT_INDEX;
+    }
+
+    // Phase B: nothing was ready and no default — register waiters and park.
+    struct Task *task = worker_current_task();
+    if (!task) {
+        worker_scheduler_unlock();
+        free(order_heap);
+        return KAEDE_SELECT_DEFAULT_INDEX;
+    }
+
+    struct KaedeSelectState state = {0};
+    state.done = false;
+    state.chosen_index = -1;
+    state.chosen_status = 0;
+    state.task = task;
+
+    struct ChannelWaiter waiters_buf[32];
+    struct ChannelWaiter *waiters = waiters_buf;
+    struct ChannelWaiter *waiters_heap = NULL;
+    if (n > sizeof(waiters_buf) / sizeof(waiters_buf[0])) {
+        waiters_heap = calloc(n, sizeof(struct ChannelWaiter));
+        if (!waiters_heap) {
+            worker_scheduler_unlock();
+            free(order_heap);
+            return KAEDE_SELECT_DEFAULT_INDEX;
+        }
+        waiters = waiters_heap;
+    } else {
+        memset(waiters_buf, 0, sizeof(waiters_buf));
+    }
+
+    for (size_t i = 0; i < n; ++i) {
+        struct ChannelWaiter *w = &waiters[i];
+        w->kind = CW_SELECT;
+        w->op = (int)cases[i].op;
+        w->task = task;
+        w->value_slot = cases[i].value_slot;
+        w->state = &state;
+        w->case_index = (uint32_t)i;
+        struct KaedeChannel *ch = cases[i].channel;
+        if (!ch) {
+            continue;
+        }
+        struct ChannelWaitQueue *q = (cases[i].op == KAEDE_SELECT_OP_SEND)
+                                         ? &ch->send_waiters
+                                         : &ch->recv_waiters;
+        wait_queue_push_tail(q, w, ch);
+    }
+
+    if (!worker_park_current_on_channel_locked()) {
+        // Park failed (shutdown). Re-acquire lock to scrub residual waiters.
+        worker_scheduler_lock();
+        scrub_select_waiters(waiters, n);
+        worker_scheduler_unlock();
+        free(waiters_heap);
+        free(order_heap);
+        return KAEDE_SELECT_DEFAULT_INDEX;
+    }
+
+    // We woke; remove any leftover waiters that were not the firing case.
+    worker_scheduler_lock();
+    scrub_select_waiters(waiters, n);
+    worker_scheduler_unlock();
+
+    int32_t chosen = state.chosen_index;
+    if (chosen >= 0 && (size_t)chosen < n) {
+        cases[chosen].status = state.chosen_status;
+    }
+
+    free(waiters_heap);
+    free(order_heap);
+    return chosen;
+}
+
+// -----------------------------------------------------------------------------
+// void* shims for Kaede FFI
+// -----------------------------------------------------------------------------
 
 void *kaede_chan_new(size_t elem_size, size_t capacity) {
     return kaede_channel_new(elem_size, capacity);

--- a/library/runtime/src/channel.c
+++ b/library/runtime/src/channel.c
@@ -556,29 +556,35 @@ int32_t kaede_select(struct KaedeSelectCase *cases, size_t n, bool has_default) 
         return KAEDE_SELECT_DEFAULT_INDEX;
     }
 
-    // Stack-allocated shuffled index order for fairness.
+    // Shuffling the try order is what keeps one case from starving the others.
+    // It needs scratch space: a stack array for the common case, a heap one
+    // beyond 32 cases. If that allocation fails, fall back to source order —
+    // biased, but every case is still tried, which beats abandoning a select
+    // whose cases may well be ready.
     uint32_t order_buf[32];
-    uint32_t *order = order_buf;
     uint32_t *order_heap = NULL;
-    if (n > sizeof(order_buf) / sizeof(order_buf[0])) {
+    uint32_t *order = NULL;
+    if (n <= sizeof(order_buf) / sizeof(order_buf[0])) {
+        order = order_buf;
+    } else {
         order_heap = malloc(n * sizeof(uint32_t));
-        if (!order_heap) {
-            return KAEDE_SELECT_DEFAULT_INDEX;
-        }
         order = order_heap;
     }
-    for (size_t i = 0; i < n; ++i) {
-        order[i] = (uint32_t)i;
+    if (order) {
+        for (size_t i = 0; i < n; ++i) {
+            order[i] = (uint32_t)i;
+        }
+        shuffle_indices(order, n);
     }
-    shuffle_indices(order, n);
 
     worker_scheduler_lock();
 
     // Phase A: try every case once in randomized order.
     for (size_t i = 0; i < n; ++i) {
-        struct KaedeSelectCase *cs = &cases[order[i]];
+        const uint32_t index = order ? order[i] : (uint32_t)i;
+        struct KaedeSelectCase *cs = &cases[index];
         if (try_select_case_locked(cs)) {
-            int32_t chosen = (int32_t)order[i];
+            int32_t chosen = (int32_t)index;
             worker_scheduler_unlock();
             free(order_heap);
             return chosen;

--- a/library/runtime/src/channel.c
+++ b/library/runtime/src/channel.c
@@ -26,9 +26,8 @@ struct ChannelWaiter {
     struct ChannelWaiter *prev;
     struct ChannelWaiter *next;
     struct KaedeChannel *channel;  // queue this waiter is parked on (or NULL once removed)
-    struct Task *task;             // task to wake; for select, == state->task
+    struct Task *task;             // task to wake
     void *value_slot;              // send: source; recv: destination
-    int32_t recv_status;           // for regular recv: VALUE/CLOSED
     struct KaedeSelectState *state;  // NULL for regular waiters
     uint32_t case_index;             // for select waiters
 };
@@ -58,7 +57,6 @@ struct KaedeSelectState {
     bool done;
     int32_t chosen_index;
     int32_t chosen_status;
-    struct Task *task;
 };
 
 static void wait_queue_push_tail(struct ChannelWaitQueue *q,
@@ -161,19 +159,16 @@ static struct ChannelWaiter *pop_live_waiter_locked(
     }
 }
 
-// Mark `waiter` as completed with the given status and wake its task. For
-// select waiters this also records the chosen-case bookkeeping; for regular
-// recv waiters it stores the status onto the waiter for the parked recv() to
-// observe after wakeup. Callers are responsible for any value transfer that
-// must happen before the task can read its slot.
+// Complete `waiter` and wake its task. `status` is recorded only for select
+// waiters, which need to know which case fired and how; a regular send/recv
+// reads its outcome from `wake_success` instead. Callers are responsible for
+// any value transfer that must happen before the task can read its slot.
 static void complete_waiter_locked(struct ChannelWaiter *waiter,
                                    int32_t status) {
     if (waiter->kind == CW_SELECT) {
         waiter->state->done = true;
         waiter->state->chosen_index = (int32_t)waiter->case_index;
         waiter->state->chosen_status = status;
-    } else {
-        waiter->recv_status = status;
     }
     if (!worker_wake_task_locked(waiter->task, true)) {
         worker_fail("channel: could not schedule a woken task");
@@ -396,7 +391,6 @@ int32_t kaede_channel_recv(struct KaedeChannel *channel, void *out) {
     waiter.op = KAEDE_SELECT_OP_RECV;
     waiter.task = task;
     waiter.value_slot = out;
-    waiter.recv_status = KAEDE_CHANNEL_RECV_CLOSED;
     wait_queue_push_tail(&channel->recv_waiters, &waiter, channel);
 
     if (!worker_park_current_on_channel_locked()) {
@@ -608,7 +602,6 @@ int32_t kaede_select(struct KaedeSelectCase *cases, size_t n, bool has_default) 
     state.done = false;
     state.chosen_index = -1;
     state.chosen_status = 0;
-    state.task = task;
 
     struct ChannelWaiter waiters_buf[32];
     struct ChannelWaiter *waiters = waiters_buf;

--- a/library/runtime/src/channel.c
+++ b/library/runtime/src/channel.c
@@ -7,9 +7,30 @@
 #include <stdlib.h>
 #include <string.h>
 
-struct TaskWaitQueue {
-    struct Task *head;
-    struct Task *tail;
+// -----------------------------------------------------------------------------
+// Channel waiters
+//
+// A parked send/recv is represented by a waiter that the channel owns, linked
+// into one of the channel's queues. The waiter lives on the parked task's own
+// stack frame, so it stays valid until that task resumes.
+//
+// The list is doubly linked and each waiter keeps a back-pointer to the queue's
+// channel, so a waiter can be removed without walking the list.
+// -----------------------------------------------------------------------------
+
+struct KaedeChannel;
+
+struct ChannelWaiter {
+    struct ChannelWaiter *prev;
+    struct ChannelWaiter *next;
+    struct KaedeChannel *channel;  // queue this waiter is on, NULL once removed
+    struct Task *task;             // task to wake
+    void *value_slot;              // send: source; recv: destination
+};
+
+struct ChannelWaitQueue {
+    struct ChannelWaiter *head;
+    struct ChannelWaiter *tail;
 };
 
 struct KaedeChannel {
@@ -20,33 +41,41 @@ struct KaedeChannel {
     size_t len;
     size_t head;
     size_t tail;
-    struct TaskWaitQueue send_waiters;
-    struct TaskWaitQueue recv_waiters;
+    struct ChannelWaitQueue send_waiters;
+    struct ChannelWaitQueue recv_waiters;
 };
 
-static void wait_queue_push(struct TaskWaitQueue *queue, struct Task *task) {
-    task->channel_wait.next = NULL;
-    if (queue->tail) {
-        queue->tail->channel_wait.next = task;
+static void wait_queue_push_tail(struct ChannelWaitQueue *q,
+                                 struct ChannelWaiter *w,
+                                 struct KaedeChannel *channel) {
+    w->prev = q->tail;
+    w->next = NULL;
+    w->channel = channel;
+    if (q->tail) {
+        q->tail->next = w;
     } else {
-        queue->head = task;
+        q->head = w;
     }
-    queue->tail = task;
+    q->tail = w;
 }
 
-static struct Task *wait_queue_pop(struct TaskWaitQueue *queue) {
-    struct Task *task = queue->head;
-    if (!task) {
+static struct ChannelWaiter *wait_queue_pop_head(struct ChannelWaitQueue *q) {
+    struct ChannelWaiter *w = q->head;
+    if (!w) {
         return NULL;
     }
-
-    queue->head = task->channel_wait.next;
-    if (!queue->head) {
-        queue->tail = NULL;
+    q->head = w->next;
+    if (q->head) {
+        q->head->prev = NULL;
+    } else {
+        q->tail = NULL;
     }
-    task->channel_wait.next = NULL;
-    return task;
+    w->prev = NULL;
+    w->next = NULL;
+    w->channel = NULL;
+    return w;
 }
+
 
 static uint8_t *buffer_slot(struct KaedeChannel *channel, size_t index) {
     if (!channel->buffer || channel->elem_size == 0) {
@@ -74,31 +103,35 @@ static void buffer_pop(struct KaedeChannel *channel, void *out) {
     channel->len--;
 }
 
+// Wake a waiter that completed successfully. The caller must have already done
+// any value transfer the woken task expects to find in its slot.
+static void wake_waiter_locked(struct ChannelWaiter *waiter) {
+    if (!worker_wake_task_locked(waiter->task, true)) {
+        abort();
+    }
+}
+
 static bool wake_waiting_receiver_locked(struct KaedeChannel *channel,
                                          const void *value) {
-    struct Task *receiver = wait_queue_pop(&channel->recv_waiters);
+    struct ChannelWaiter *receiver = wait_queue_pop_head(&channel->recv_waiters);
     if (!receiver) {
         return false;
     }
 
-    copy_value(receiver->channel_wait.value_slot, value, channel->elem_size);
-    if (!worker_wake_task_locked(receiver, true)) {
-        abort();
-    }
+    copy_value(receiver->value_slot, value, channel->elem_size);
+    wake_waiter_locked(receiver);
     return true;
 }
 
 static bool wake_waiting_sender_direct_locked(struct KaedeChannel *channel,
                                               void *out) {
-    struct Task *sender = wait_queue_pop(&channel->send_waiters);
+    struct ChannelWaiter *sender = wait_queue_pop_head(&channel->send_waiters);
     if (!sender) {
         return false;
     }
 
-    copy_value(out, sender->channel_wait.value_slot, channel->elem_size);
-    if (!worker_wake_task_locked(sender, true)) {
-        abort();
-    }
+    copy_value(out, sender->value_slot, channel->elem_size);
+    wake_waiter_locked(sender);
     return true;
 }
 
@@ -107,17 +140,30 @@ static bool buffer_one_waiting_sender_locked(struct KaedeChannel *channel) {
         return false;
     }
 
-    struct Task *sender = wait_queue_pop(&channel->send_waiters);
+    struct ChannelWaiter *sender = wait_queue_pop_head(&channel->send_waiters);
     if (!sender) {
         return false;
     }
 
-    buffer_push(channel, sender->channel_wait.value_slot);
-    if (!worker_wake_task_locked(sender, true)) {
-        abort();
-    }
+    buffer_push(channel, sender->value_slot);
+    wake_waiter_locked(sender);
     return true;
 }
+
+// Drain `queue`, waking every waiter with `wake_success = false` so the parked
+// send/recv reports the channel as closed.
+static void wake_all_as_closed_locked(struct ChannelWaitQueue *queue) {
+    struct ChannelWaiter *w;
+    while ((w = wait_queue_pop_head(queue)) != NULL) {
+        if (!worker_wake_task_locked(w->task, false)) {
+            abort();
+        }
+    }
+}
+
+// Internal sentinel used only by try_send_locked, distinct from the public
+// KaedeChannelSendResult values. Callers translate it to a parking decision.
+#define TRY_SEND_WOULD_BLOCK 2
 
 static int32_t try_send_locked(struct KaedeChannel *channel, void *value) {
     if (channel->closed || worker_shutdown_requested_locked()) {
@@ -133,7 +179,7 @@ static int32_t try_send_locked(struct KaedeChannel *channel, void *value) {
         return KAEDE_CHANNEL_SEND_OK;
     }
 
-    return KAEDE_CHANNEL_SEND_CLOSED + 1;
+    return TRY_SEND_WOULD_BLOCK;
 }
 
 static int32_t try_recv_locked(struct KaedeChannel *channel, void *out) {
@@ -203,7 +249,7 @@ int32_t kaede_channel_send(struct KaedeChannel *channel, void *value) {
         return result;
     }
 
-    if (result != KAEDE_CHANNEL_SEND_CLOSED + 1) {
+    if (result != TRY_SEND_WOULD_BLOCK) {
         worker_scheduler_unlock();
         return KAEDE_CHANNEL_SEND_CLOSED;
     }
@@ -214,9 +260,12 @@ int32_t kaede_channel_send(struct KaedeChannel *channel, void *value) {
         return KAEDE_CHANNEL_SEND_CLOSED;
     }
 
-    wait_queue_push(&channel->send_waiters, task);
-    if (!worker_park_current_on_channel_locked(
-            channel, KAEDE_TASK_WAIT_CHANNEL_SEND, value)) {
+    struct ChannelWaiter waiter = {0};
+    waiter.task = task;
+    waiter.value_slot = value;
+    wait_queue_push_tail(&channel->send_waiters, &waiter, channel);
+
+    if (!worker_park_current_on_channel_locked()) {
         return KAEDE_CHANNEL_SEND_CLOSED;
     }
 
@@ -253,9 +302,12 @@ int32_t kaede_channel_recv(struct KaedeChannel *channel, void *out) {
         return KAEDE_CHANNEL_RECV_EMPTY;
     }
 
-    wait_queue_push(&channel->recv_waiters, task);
-    if (!worker_park_current_on_channel_locked(
-            channel, KAEDE_TASK_WAIT_CHANNEL_RECV, out)) {
+    struct ChannelWaiter waiter = {0};
+    waiter.task = task;
+    waiter.value_slot = out;
+    wait_queue_push_tail(&channel->recv_waiters, &waiter, channel);
+
+    if (!worker_park_current_on_channel_locked()) {
         return KAEDE_CHANNEL_RECV_CLOSED;
     }
 
@@ -287,17 +339,8 @@ void kaede_channel_close(struct KaedeChannel *channel) {
 
     channel->closed = true;
 
-    struct Task *task = NULL;
-    while ((task = wait_queue_pop(&channel->send_waiters)) != NULL) {
-        if (!worker_wake_task_locked(task, false)) {
-            abort();
-        }
-    }
-    while ((task = wait_queue_pop(&channel->recv_waiters)) != NULL) {
-        if (!worker_wake_task_locked(task, false)) {
-            abort();
-        }
-    }
+    wake_all_as_closed_locked(&channel->send_waiters);
+    wake_all_as_closed_locked(&channel->recv_waiters);
 
     worker_scheduler_unlock();
 }

--- a/library/runtime/src/channel.c
+++ b/library/runtime/src/channel.c
@@ -49,10 +49,13 @@ struct KaedeChannel {
     struct ChannelWaitQueue recv_waiters;
 };
 
-// Shared by every waiter registered for one `select` evaluation. All fields are
-// guarded by the scheduler lock, which is what lets `done` be a plain bool: the
-// read in pop_live_waiter_locked and the write in complete_waiter_locked cannot
-// interleave.
+// Shared by every waiter registered for one `select` evaluation.
+//
+// `done` is read under the scheduler lock in pop_live_waiter_locked and
+// wake_all_as_closed_locked, and written under it in complete_waiter_locked,
+// which is what lets it be a plain bool rather than an atomic. The chosen-case
+// fields are written under the lock too, then read by the owning task after it
+// has unlinked every waiter, at which point no writer remains.
 struct KaedeSelectState {
     bool done;
     int32_t chosen_index;

--- a/library/runtime/src/channel.c
+++ b/library/runtime/src/channel.c
@@ -176,7 +176,7 @@ static void complete_waiter_locked(struct ChannelWaiter *waiter,
         waiter->recv_status = status;
     }
     if (!worker_wake_task_locked(waiter->task, true)) {
-        abort();
+        worker_fail("channel: could not schedule a woken task");
     }
 }
 
@@ -229,7 +229,7 @@ static void wake_all_as_closed_locked(struct ChannelWaitQueue *queue) {
                 complete_waiter_locked(w, KAEDE_SELECT_STATUS_CLOSED);
             }
         } else if (!worker_wake_task_locked(w->task, false)) {
-            abort();
+            worker_fail("channel: could not schedule a task woken by close");
         }
     }
 }
@@ -544,16 +544,15 @@ static void shuffle_indices(uint32_t *idx, size_t n) {
 
 int32_t kaede_select(struct KaedeSelectCase *cases, size_t n, bool has_default) {
     if (n == 0) {
-        // Empty select: no cases. With default, return default; without it,
-        // there is nothing to wait on — this is treated like Go's `select {}`
-        // (blocks forever). Approximate by parking, which the parser should
-        // make unreachable.
+        // `select { default => ... }` is legal and takes the default arm.
         if (has_default) {
             return KAEDE_SELECT_DEFAULT_INDEX;
         }
-        worker_scheduler_lock();
-        (void)worker_park_current_on_channel_locked();
-        return KAEDE_SELECT_DEFAULT_INDEX;
+        // No cases and no default. The parser rejects `select {}`, so reaching
+        // here means a frontend or FFI caller built something it should not
+        // have. Parking would block this task forever with nothing able to
+        // wake it, so say what happened instead of hanging.
+        worker_fail("kaede_select: no cases and no default arm");
     }
 
     // Shuffling the try order is what keeps one case from starving the others.

--- a/library/runtime/src/task.c
+++ b/library/runtime/src/task.c
@@ -224,9 +224,5 @@ void task_cleanup(struct Task *task) {
     task->io_wait.fd = -1;
     task->io_wait.events = KAEDE_IO_EVENT_NONE;
     task->io_wait.wake_success = false;
-    task->channel_wait.obj = NULL;
-    task->channel_wait.kind = KAEDE_TASK_WAIT_NONE;
-    task->channel_wait.value_slot = NULL;
     task->channel_wait.wake_success = false;
-    task->channel_wait.next = NULL;
 }

--- a/library/runtime/src/worker.c
+++ b/library/runtime/src/worker.c
@@ -221,10 +221,6 @@ static bool enqueue_runnable_task_locked(struct Task *task) {
     task->scheduler.state = TASK_RUNNABLE;
     task->io_wait.fd = -1;
     task->io_wait.events = KAEDE_IO_EVENT_NONE;
-    task->channel_wait.obj = NULL;
-    task->channel_wait.kind = KAEDE_TASK_WAIT_NONE;
-    task->channel_wait.value_slot = NULL;
-    task->channel_wait.next = NULL;
     return task_queue_push(&runnable_tasks, task);
 }
 
@@ -623,10 +619,8 @@ struct Task *worker_current_task(void) {
     return kaede_current_task;
 }
 
-bool worker_park_current_on_channel_locked(void *obj, uint32_t wait_kind,
-                                           void *value_slot) {
-    if (!kaede_current_task || wait_kind == KAEDE_TASK_WAIT_NONE ||
-        shutdown_requested) {
+bool worker_park_current_on_channel_locked(void) {
+    if (!kaede_current_task || shutdown_requested) {
         pthread_mutex_unlock(&scheduler_mutex);
         return false;
     }
@@ -637,9 +631,6 @@ bool worker_park_current_on_channel_locked(void *obj, uint32_t wait_kind,
     struct GC_stack_base *gc_stack_base = &worker.gc_stack_base;
 
     task->scheduler.state = TASK_WAITING_CHANNEL;
-    task->channel_wait.obj = obj;
-    task->channel_wait.kind = wait_kind;
-    task->channel_wait.value_slot = value_slot;
     task->channel_wait.wake_success = false;
     worker.yielded_state = TASK_WAITING_CHANNEL;
     worker.returned_with_scheduler_lock = true;
@@ -704,11 +695,7 @@ bool worker_spawn(TaskFn fn, void *arg, size_t arg_size, bool is_main) {
     task->io_wait.fd = -1;
     task->io_wait.events = KAEDE_IO_EVENT_NONE;
     task->io_wait.wake_success = false;
-    task->channel_wait.obj = NULL;
-    task->channel_wait.kind = KAEDE_TASK_WAIT_NONE;
-    task->channel_wait.value_slot = NULL;
     task->channel_wait.wake_success = false;
-    task->channel_wait.next = NULL;
     create_context(&task->context, fn, arg_on_stack, stack_top);
     task_register_stack_roots(task);
 

--- a/library/runtime/src/worker.c
+++ b/library/runtime/src/worker.c
@@ -58,7 +58,7 @@ static struct IoWaitTable io_waits;
 _Thread_local struct Worker worker;
 _Thread_local struct Task *kaede_current_task = NULL;
 
-static void fail_runtime(const char *message) {
+_Noreturn void worker_fail(const char *message) {
     fprintf(stderr, "%s\n", message);
     abort();
 }
@@ -253,7 +253,7 @@ static size_t wake_waiting_tasks_locked(int fd, uint32_t ready_events,
 
     const uint32_t new_events = io_wait_entry_events(entry);
     if (!update_poller_interest_locked(fd, old_events, new_events)) {
-        fail_runtime("Failed to update poller interest while waking task");
+        worker_fail("Failed to update poller interest while waking task");
     }
     if (new_events == KAEDE_IO_EVENT_NONE) {
         io_wait_table_remove_entry(&io_waits, entry);
@@ -262,7 +262,7 @@ static size_t wake_waiting_tasks_locked(int fd, uint32_t ready_events,
     for (size_t i = 0; i < wake_count; ++i) {
         tasks_to_wake[i]->io_wait.wake_success = wake_success;
         if (!enqueue_runnable_task_locked(tasks_to_wake[i])) {
-            fail_runtime("Failed to enqueue runnable task");
+            worker_fail("Failed to enqueue runnable task");
         }
     }
 
@@ -409,7 +409,7 @@ static void worker_loop_impl(int worker_id) {
     if (GC_get_stack_base(&sb) == GC_SUCCESS && !GC_thread_is_registered()) {
         int reg_result = GC_register_my_thread(&sb);
         if (reg_result != GC_SUCCESS && reg_result != GC_DUPLICATE) {
-            fail_runtime("Failed to register GC thread");
+            worker_fail("Failed to register GC thread");
         }
     }
     worker.gc_thread_handle = GC_get_my_stackbottom(&worker.gc_stack_base);
@@ -450,7 +450,7 @@ static void worker_loop_impl(int worker_id) {
 
                 if (ready < 0) {
                     pthread_mutex_unlock(&scheduler_mutex);
-                    fail_runtime("Poller wait failed");
+                    worker_fail("Poller wait failed");
                 }
 
                 for (int i = 0; i < ready; ++i) {
@@ -504,7 +504,7 @@ static void worker_loop_impl(int worker_id) {
             pthread_mutex_lock(&scheduler_mutex);
             if (!task_queue_push(&runnable_tasks, task)) {
                 pthread_mutex_unlock(&scheduler_mutex);
-                fail_runtime("Failed to requeue task");
+                worker_fail("Failed to requeue task");
             }
             pthread_cond_signal(&scheduler_cond);
             pthread_mutex_unlock(&scheduler_mutex);
@@ -517,7 +517,7 @@ static void worker_loop_impl(int worker_id) {
             free(task);
             break;
         default:
-            fail_runtime("Unknown task state");
+            worker_fail("Unknown task state");
         }
     }
 

--- a/website/docs/language/concurrency.md
+++ b/website/docs/language/concurrency.md
@@ -53,6 +53,41 @@ value := match <-ch {
 }
 ```
 
+## Selecting across multiple channels
+
+`select` blocks the current task until one of its channel operations can
+proceed, then runs the matching arm. It mirrors Go's `select`:
+
+```rust
+select {
+    case value = ch1.recv() => {
+        // value: Option<T>; None means ch1 was closed.
+    }
+    case _ = ch3.recv() => {
+        // received value is discarded
+    }
+    case ch2.send(x) => {
+        // successfully sent x on ch2
+    }
+    default => {
+        // taken only if no other case is immediately ready
+    }
+}
+```
+
+Notes:
+
+- Each `case` must be a `ch.recv()` or `ch.send(value)` method call —
+  arbitrary expressions are rejected at parse time.
+- The bound name on a `recv` arm has type `Option<T>`. A closed channel
+  fires the arm immediately with `None`, mirroring `ch.recv()`'s contract.
+- With `default`, `select` is non-blocking. Without it, the task blocks
+  until at least one case can proceed.
+- When multiple cases are simultaneously ready, one is chosen at random to
+  avoid starvation (Go semantics).
+- Channel expressions and `send` value expressions are evaluated in source
+  order on entry, exactly once per `select` evaluation.
+
 ## Synchronization helpers
 
 Use `WaitGroup` when one task needs to wait for other spawned tasks to finish:

--- a/website/docs/language/concurrency.md
+++ b/website/docs/language/concurrency.md
@@ -67,7 +67,7 @@ select {
         // received value is discarded
     }
     case ch2.send(x) => {
-        // successfully sent x on ch2
+        // x was handed off on ch2
     }
     default => {
         // taken only if no other case is immediately ready
@@ -79,8 +79,13 @@ Notes:
 
 - Each `case` must be a `ch.recv()` or `ch.send(value)` method call —
   arbitrary expressions are rejected at parse time.
-- The bound name on a `recv` arm has type `Option<T>`. A closed channel
-  fires the arm immediately with `None`, mirroring `ch.recv()`'s contract.
+- The bound name on a `recv` arm has type `Option<T>`. A closed channel is
+  always ready; once anything still buffered has been drained the arm fires
+  immediately with `None`, mirroring `ch.recv()`'s contract.
+- A `send` arm on a closed channel is also ready, and taking it panics, just
+  as `ch.send(x)` does. `select` does not route around a closed channel — if
+  that matters, check `is_closed()` first or use a separate cancellation
+  channel.
 - With `default`, `select` is non-blocking. Without it, the task blocks
   until at least one case can proceed.
 - When multiple cases are simultaneously ready, one is chosen at random to

--- a/website/docs/language/concurrency.md
+++ b/website/docs/language/concurrency.md
@@ -56,7 +56,7 @@ value := match <-ch {
 ## Selecting across multiple channels
 
 `select` blocks the current task until one of its channel operations can
-proceed, then runs the matching arm. It mirrors Go's `select`:
+proceed, then runs the matching arm. It follows Go's `select`:
 
 ```rust
 select {
@@ -87,6 +87,33 @@ Notes:
   avoid starvation (Go semantics).
 - Channel expressions and `send` value expressions are evaluated in source
   order on entry, exactly once per `select` evaluation.
+
+### Looping over a select
+
+A `select` handles exactly one operation and then completes, so serving a
+channel continuously means putting it in a loop:
+
+```rust
+loop {
+    select {
+        case value = results.recv() => {
+            match value {
+                Option::Some(v) => { total = total + v },
+                Option::None => break,
+            }
+        }
+        case _ = cancel.recv() => break
+    }
+}
+```
+
+Handling `None` is not optional here. A closed channel is always immediately
+ready, so a loop that ignores closure will spin at full CPU forever once the
+channel closes.
+
+`break` inside an arm leaves the enclosing loop, as it does anywhere else.
+Coming from Go this is worth noting: there, `break` leaves the `select` and a
+labelled `break` is needed to exit the surrounding `for`.
 
 ## Synchronization helpers
 


### PR DESCRIPTION
Adds a Go-style `select` expression that blocks until one of its listed channel operations can proceed. Closes #172.

## Syntax

```kaede
select {
    case value = ch1.recv() => { /* value: Option<T> */ }
    case _     = ch3.recv() => { /* discard */ }
    case         ch2.send(x) => { /* sent */ }
    default => { /* only when no case is immediately ready */ }
}
```

- Exactly one case runs. Nothing is consumed from the other channels.
- A receive binds `Option<T>` — `Some(v)` on a value, `None` once the channel is closed.
- Without `default`, the select blocks; with it, it never does.
- When several cases are ready at once, one is chosen at random so no case starves.
- A send case on a closed channel panics, matching `Channel::send` and Go.
- Channel and send-value expressions are evaluated in source order on entry, exactly once.

## Commits

Each commit builds and passes its relevant tests, so `git bisect` works across the series.

| Commit | Scope |
|---|---|
| `refactor(runtime)` | Move channel wait state out of `Task` into channel-owned `ChannelWaiter`s. No behaviour change. |
| `fix(runtime)` | Unlink a waiter when parking fails. Pre-existing bug, independent of `select`. |
| `feat(runtime)` | `kaede_select` ABI and the two-phase wake-driven implementation. |
| `feat(lang)` | Lexer through codegen, plus parser and end-to-end tests. |
| `docs(language)` | `select` section in the concurrency docs. |

The first two are worth reading on their own: they touch every existing channel user and change no behaviour, which the unmodified `runtime_channel` and `leak` tests confirm.

## Runtime design

`kaede_select` runs in two phases:

- **A.** Under the scheduler lock, try every case once in a shuffled order; first success wins. With a `default` arm, stop here rather than blocking.
- **B.** Otherwise register a waiter on every case's queue and park. The first waker claims the shared `KaedeSelectState`; the resumed task unlinks whatever waiters are still queued.

`pop_live_waiter_locked` skips select waiters whose state another case already claimed, so a queue never hands a value to a select that has moved on. `close()` completes pending select receives with `CLOSED` so the language side observes closure as `Option::None`.

Fairness uses a per-thread xorshift PRNG rather than `rand()`, whose internal state would race across workers.

## Verification

| | |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy -- -D warnings` | pass |
| `cargo test --release --no-fail-fast` | 637 passed, 0 failed (55 targets) |
| `leak` (valgrind) | 2/2 |

New tests: 9 parser cases in `select_syntax.rs`, 7 end-to-end cases in `runtime_select.rs` covering single recv, fan-in from two producers, `default` fallthrough, closed-channel recv, buffered send, send handshake with a blocked receiver, and the closed-channel send panic.

## Note

`let x = select { ... }` crashes the compiler, but so do `let x = loop { break }` and `let x = while c { }` — see #378. That is a pre-existing hole for unit-typed expressions in value position, not something this PR introduces.
