### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "kaede_ast"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "inkwell",
  "kaede_ast_type",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_ast_type"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "inkwell",
  "kaede_span",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_codegen"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -701,11 +701,11 @@ dependencies = [
 
 [[package]]
 name = "kaede_common"
-version = "0.1.1"
+version = "0.2.0"
 
 [[package]]
 name = "kaede_compiler_driver"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_ir"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "inkwell",
  "kaede_ast_type",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_lex"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "kaede_span",
  "unicode-xid",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_lsp"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "kaede_ast",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_monomorphize"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "kaede_common",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_parse"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "kaede_ast",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_semantic"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "kaede_ast",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_span"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "once_cell",
  "slab",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_symbol"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "kaede_span",
  "once_cell",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_symbol_table"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "kaede_ast",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "kaede_type_infer"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "kaede_common",

--- a/compiler/ast/Cargo.toml
+++ b/compiler/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_ast"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/ast_type/Cargo.toml
+++ b/compiler/ast_type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_ast_type"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/codegen/Cargo.toml
+++ b/compiler/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_codegen"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/common/Cargo.toml
+++ b/compiler/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_common"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/driver/Cargo.toml
+++ b/compiler/driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_compiler_driver"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/ir/Cargo.toml
+++ b/compiler/ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_ir"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 license = "MIT OR Apache-2.0"

--- a/compiler/lex/Cargo.toml
+++ b/compiler/lex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_lex"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/lsp/Cargo.toml
+++ b/compiler/lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_lsp"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 license = "MIT OR Apache-2.0"

--- a/compiler/monomorphize/Cargo.toml
+++ b/compiler/monomorphize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_monomorphize"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 license = "MIT OR Apache-2.0"

--- a/compiler/parse/Cargo.toml
+++ b/compiler/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_parse"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/semantic/Cargo.toml
+++ b/compiler/semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_semantic"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 license = "MIT OR Apache-2.0"

--- a/compiler/span/Cargo.toml
+++ b/compiler/span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_span"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/symbol/Cargo.toml
+++ b/compiler/symbol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_symbol"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/compiler/symbol_table/Cargo.toml
+++ b/compiler/symbol_table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_symbol_table"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 
 license = "MIT OR Apache-2.0"

--- a/compiler/type_infer/Cargo.toml
+++ b/compiler/type_infer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaede_type_infer"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- bump all compiler workspace crates from 0.1.1 to 0.2.0
- sync the workspace lockfile
- prepare the release containing the new `select` expression

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `KAEDE_DIR=/tmp/kaede-v0.2.0-prefix cargo test --release --no-fail-fast`
- `/tmp/kaede-v0.2.0-prefix/bin/kaede --version` → `kaede_compiler_driver 0.2.0`