### PR TITLE
docs(runtime): document the KaedeChannel ring buffer and unbuffered sentinel

### DIFF
--- a/library/runtime/src/channel.c
+++ b/library/runtime/src/channel.c
@@ -39,8 +39,16 @@ struct ChannelWaitQueue {
 
 struct KaedeChannel {
     size_t elem_size;
+    // 0 means unbuffered: `buffer` stays NULL and every send has to hand off
+    // directly to a waiting receiver, so try_send_locked can only succeed
+    // through wake_waiting_receiver_locked.
     size_t capacity;
     bool closed;
+    // Ring buffer of `capacity` slots, NULL when unbuffered. `head` is the next
+    // slot to read and `tail` the next slot to write, both wrapping modulo
+    // `capacity`; `len` tells full from empty when the two meet. Note that
+    // `head`/`tail` here are ring positions, unlike the list endpoints of the
+    // same name in ChannelWaitQueue above.
     uint8_t *buffer;
     size_t len;
     size_t head;


### PR DESCRIPTION
Closes #382

Three properties of `struct KaedeChannel` could not be read off the declaration:

- `buffer` is a **ring** — the words "ring", "circular" and "wrap" appeared nowhere in the file; the only evidence was the modulo in `buffer_push`/`buffer_pop`.
- `capacity == 0` means **unbuffered** — `buffer` stays NULL and `try_send_locked` can only succeed via `wake_waiting_receiver_locked`.
- `len` exists to tell **full from empty** when `head == tail`.

Also notes in passing that `head`/`tail` are ring positions here, unlike the list endpoints of the same name in `ChannelWaitQueue` just above.

Comment-only; no behaviour change.

## Verification

`cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo test --release --no-fail-fast` (645 passed, 0 failed), and a full `./install.py --no-setenv` bootstrap.