### PR TITLE
test(driver): bound run_binary with a wall-clock timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,6 +726,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
+ "wait-timeout",
 ]
 
 [[package]]

--- a/compiler/driver/Cargo.toml
+++ b/compiler/driver/Cargo.toml
@@ -28,6 +28,7 @@ kaede_lsp = { path = "../lsp" }
 assert_fs = "1.0.12"
 assert_cmd = "2.0.10"
 predicates = "3.0.1"
+wait-timeout = "0.2"
 
 [[bin]]
 name = "kaede"

--- a/compiler/driver/tests/driver_test_support/mod.rs
+++ b/compiler/driver/tests/driver_test_support/mod.rs
@@ -5,9 +5,12 @@
 
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
-use predicates::prelude::*;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use std::process::{Command, Output};
+use std::time::Duration;
+use wait_timeout::ChildExt;
 
 /// Invoke the kaede compiler. Asserts the compile succeeded and returns
 /// the raw process output so callers can inspect stderr (e.g. for
@@ -52,10 +55,64 @@ pub fn compile_project(
     Ok((exe, output))
 }
 
+/// Wall-clock bound for a compiled test program. The blocking primitives —
+/// channels, `select`, `WaitGroup` — fail by deadlocking rather than by
+/// returning a wrong exit code, so an unbounded wait turns a lost wakeup into a
+/// hung job instead of a failing test.
+const RUN_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Rewind and read back one of the capture files from [`run_binary`].
+fn read_captured(file: &mut File) -> String {
+    let mut buf = Vec::new();
+    match file
+        .seek(SeekFrom::Start(0))
+        .and_then(|_| file.read_to_end(&mut buf))
+    {
+        Ok(_) => String::from_utf8_lossy(&buf).into_owned(),
+        Err(err) => format!("<failed to read captured output: {err}>"),
+    }
+}
+
 /// Run a previously-compiled binary and assert that it exits with the
-/// given code.
+/// given code within [`RUN_TIMEOUT`].
 pub fn run_binary(expect: i32, exe_path: &Path) -> anyhow::Result<()> {
-    Command::new(exe_path).assert().code(predicate::eq(expect));
+    // Capture through temp files rather than pipes: libtest cannot capture a
+    // child's file descriptors, so inherited output would land unattributed in
+    // the runner's output, and an undrained pipe would block a chatty program
+    // and be misreported as a deadlock.
+    let mut stdout_capture = tempfile::tempfile()?;
+    let mut stderr_capture = tempfile::tempfile()?;
+
+    let mut child = Command::new(exe_path)
+        .stdout(stdout_capture.try_clone()?)
+        .stderr(stderr_capture.try_clone()?)
+        .spawn()?;
+
+    let status = match child.wait_timeout(RUN_TIMEOUT)? {
+        Some(status) => status,
+        None => {
+            // Ignore the errors here so the timeout is what gets reported.
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!(
+                "`{}` did not exit within {RUN_TIMEOUT:?} and was killed; \
+                 a blocking primitive most likely deadlocked\nstdout:\n{}\nstderr:\n{}",
+                exe_path.display(),
+                read_captured(&mut stdout_capture),
+                read_captured(&mut stderr_capture)
+            );
+        }
+    };
+
+    assert_eq!(
+        status.code(),
+        Some(expect),
+        "`{}` did not exit with {expect}: {status:?}\nstdout:\n{}\nstderr:\n{}",
+        exe_path.display(),
+        read_captured(&mut stdout_capture),
+        read_captured(&mut stderr_capture)
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
Closes #385

`run_binary` had no time limit. For the blocking primitives — channels, `select`, `WaitGroup` — the natural failure mode is a deadlock rather than a wrong exit code, so a regression that loses a wakeup did not fail the test: it wedged it, and CI hung until the job-level timeout with nothing indicating which test was stuck.

## Changes

- Wait with `wait_timeout` (30s). On expiry, kill the child and panic naming the binary and the bound, so libtest attributes the failure to the right test.
- `wait-timeout` is added as a dev-dependency. It is already a transitive dependency of `assert_cmd`, so no new package enters the lockfile.
- Output is captured through temp files rather than pipes. libtest cannot capture a child process's file descriptors, so inheriting them would drop a failing program's output into the runner's raw output unattributed; and an undrained pipe would block a program that writes more than the pipe buffer, which would then be misreported as a deadlock.

One change in the shared helper, so it applies to every `run_binary`/`run_program` caller.

## Verification

`cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo test --release --no-fail-fast` (645 passed, 0 failed), and a full `./install.py --no-setenv` bootstrap.