### PR TITLE
fix(semantic): report a source file outside the project root instead of panicking

### DIFF
--- a/compiler/driver/src/main.rs
+++ b/compiler/driver/src/main.rs
@@ -266,7 +266,7 @@ fn compile<'ctx>(
             file,
             root_dir.to_path_buf(),
             rust_path.map(Path::to_path_buf),
-        );
+        )?;
         let mut ir = analyzer.analyze(
             ast,
             AnalyzeOptions {

--- a/compiler/driver/tests/cli.rs
+++ b/compiler/driver/tests/cli.rs
@@ -216,6 +216,35 @@ fun main() -> i32 {
     Ok(())
 }
 
+// Regression: a source file outside the root directory used to panic in
+// semantic analysis, discarding the error that had already been produced for
+// exactly this case. See issue #379.
+#[test]
+fn direct_compile_rejects_source_outside_root_dir() -> anyhow::Result<()> {
+    let root = assert_fs::TempDir::new()?;
+    let outside = assert_fs::TempDir::new()?;
+    let app = outside.child("app.kd");
+    let exe = outside.child("a.out");
+
+    app.write_str("fun main() -> i32 { return 0 }")?;
+
+    Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+        .current_dir(root.path())
+        .args([
+            app.path().to_str().unwrap(),
+            "-o",
+            exe.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("is not within project root")
+                .and(predicate::str::contains("panicked").not()),
+        );
+
+    Ok(())
+}
+
 // Regression: passing a bare filename (no leading "./" or directory) used to
 // panic in semantic analysis because Path::parent() returns an empty path,
 // which fails to canonicalize. See issue #285.

--- a/compiler/lsp/src/lib.rs
+++ b/compiler/lsp/src/lib.rs
@@ -75,7 +75,10 @@ fn analyze_text(file_path: PathBuf, text: String, root_dir: PathBuf) -> Vec<Diag
 
     // The LSP does not parse Kaede.toml; default to the legacy "rust/" lookup
     // so rust-interop projects still get diagnostics for `import rust::<crate>`.
-    let mut analyzer = SemanticAnalyzer::new(file, root_dir, Some(PathBuf::from("rust")));
+    let mut analyzer = match SemanticAnalyzer::new(file, root_dir, Some(PathBuf::from("rust"))) {
+        Ok(analyzer) => analyzer,
+        Err(err) => return diagnostics_from_semantic_error(err),
+    };
     let is_entry_unit = ast_has_entry_candidate(&ast);
     match analyzer.analyze(
         ast,
@@ -312,7 +315,10 @@ fn diagnostics_from_semantic_error(err: anyhow::Error) -> Vec<Diagnostic> {
                 type_infer_error_span(&type_err),
                 type_err.to_string(),
             )],
-            Err(err) => vec![diagnostic_with_span(None, err.to_string())],
+            // `{:#}` so the `with_context` chain on plain anyhow errors (for
+            // example a source path that cannot be resolved) survives into the
+            // diagnostic instead of being cut down to its outermost message.
+            Err(err) => vec![diagnostic_with_span(None, format!("{err:#}"))],
         },
     }
 }

--- a/compiler/semantic/src/lib.rs
+++ b/compiler/semantic/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
     rc::Rc,
 };
 
-use anyhow::Context as _;
+use anyhow::{bail, Context as _};
 use context::AnalysisContext;
 use kaede_common::{kaede_autoload_dir, kaede_lib_src_dir};
 use kaede_ir::{
@@ -318,20 +318,23 @@ impl SemanticAnalyzer {
         module_context
     }
 
-    pub fn new(file_path: FilePath, root_dir: PathBuf, rust_path: Option<PathBuf>) -> Self {
+    pub fn new(
+        file_path: FilePath,
+        root_dir: PathBuf,
+        rust_path: Option<PathBuf>,
+    ) -> anyhow::Result<Self> {
         if !root_dir.is_dir() {
-            panic!("Root directory is not a directory");
+            bail!("Root directory '{}' is not a directory", root_dir.display());
         }
 
         // Set the current module name in the context.
-        let module_path =
-            Self::create_module_path_from_file_path(root_dir.clone(), file_path).unwrap();
+        let module_path = Self::create_module_path_from_file_path(root_dir.clone(), file_path)?;
         let mut context = AnalysisContext::new(module_path.clone());
         context.set_current_module_path(module_path.clone());
 
         let module_context = ModuleContext::new(file_path);
 
-        Self {
+        Ok(Self {
             modules: HashMap::from([(module_path, module_context)]),
             context,
             generated_generics: Vec::new(),
@@ -348,7 +351,7 @@ impl SemanticAnalyzer {
             temp_symbol_counter: 0,
             generated_callable_substitutions: HashMap::new(),
             pending_generic_instance: None,
-        }
+        })
     }
 
     pub fn new_for_single_file_test() -> Self {
@@ -441,7 +444,12 @@ impl SemanticAnalyzer {
     ) -> anyhow::Result<ModulePath> {
         let mut diff_from_root = {
             // Get the canonical paths
-            let kaede_lib_src_dir = kaede_lib_src_dir().canonicalize()?;
+            let kaede_lib_src_dir = kaede_lib_src_dir().canonicalize().with_context(|| {
+                format!(
+                    "Failed to resolve standard library source directory '{}'",
+                    kaede_lib_src_dir().display()
+                )
+            })?;
             // Canonicalize the file itself first so that `parent()` always
             // returns a non-empty absolute path. Calling `parent()` directly
             // on a bare filename like "foo.kd" would yield an empty path,
@@ -454,8 +462,15 @@ impl SemanticAnalyzer {
             })?;
             let file_parent = canonical_file.parent().unwrap().to_path_buf();
 
+            let canonical_root = root_dir.canonicalize().with_context(|| {
+                format!(
+                    "Failed to resolve project root directory '{}'",
+                    root_dir.display()
+                )
+            })?;
+
             // Try to strip the project root first, if that fails try the standard library root
-            if let Ok(relative_path) = file_parent.strip_prefix(&root_dir.canonicalize()?) {
+            if let Ok(relative_path) = file_parent.strip_prefix(&canonical_root) {
                 relative_path
                     .components()
                     .map(|c| {

--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -40,7 +40,7 @@ impl ImportTestProject {
             kaede_span::file::FilePath::from(main_file),
             self.temp_dir.path().to_path_buf(),
             Some(std::path::PathBuf::from("rust")),
-        );
+        )?;
 
         analyzer.analyze(
             ast,


### PR DESCRIPTION
Closes #379

`SemanticAnalyzer::new` unwrapped `create_module_path_from_file_path`, so pointing direct-compile mode at a file outside the working directory hit an ICE:

```
$ cd /path/to/kaede && kaede /tmp/scratch/hello.kd -o /tmp/scratch/hello
thread 'main' panicked at compiler/semantic/src/lib.rs:328:82:
called `Result::unwrap()` on an `Err` value: File path '/tmp/scratch' is not
within project root '.' or standard library root '/home/user/.kaede/lib/src'
```

The discarded error already said exactly what was wrong.

## Changes

- `SemanticAnalyzer::new` returns `anyhow::Result<Self>`. The driver prints the error as a normal compile error; the LSP turns it into a file-level diagnostic.
- The adjacent `panic!` on a non-directory root becomes a `bail!` — a `Result`-returning constructor should not panic on the argument next to the one it now reports. (Slightly beyond the issue's stated scope, flagging it explicitly.)
- Every error branch of `create_module_path_from_file_path` is now user-facing, so the two bare `canonicalize()` calls get context. Without it, an un-bootstrapped `~/.kaede` or a wrong `KAEDE_DIR` would surface as a lone `No such file or directory (os error 2)`.
- For the same reason the LSP's generic fallback formats with `{:#}`, so the `with_context` chain survives into the diagnostic instead of being cut to its outermost message.

Call sites updated: `compiler/driver/src/main.rs`, `compiler/lsp/src/lib.rs`, `compiler/semantic/tests/import.rs`.

## Tests

New regression test `direct_compile_rejects_source_outside_root_dir` in `compiler/driver/tests/cli.rs`, asserting the error text appears and that nothing panics.

## Verification

`cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo test --release --no-fail-fast` (645 passed, 0 failed), and a full `./install.py --no-setenv` bootstrap.